### PR TITLE
Upgrade projects to `net9.0`

### DIFF
--- a/Builder/Beyond.NET.Builder.Apple/Beyond.NET.Builder.Apple.csproj
+++ b/Builder/Beyond.NET.Builder.Apple/Beyond.NET.Builder.Apple.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/Builder/Beyond.NET.Builder.DotNET/Beyond.NET.Builder.DotNET.csproj
+++ b/Builder/Beyond.NET.Builder.DotNET/Beyond.NET.Builder.DotNET.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/Builder/Beyond.NET.Builder/Beyond.NET.Builder.csproj
+++ b/Builder/Beyond.NET.Builder/Beyond.NET.Builder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/Core/Beyond.NET.Core/Beyond.NET.Core.csproj
+++ b/Core/Beyond.NET.Core/Beyond.NET.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/Core/Beyond.NET.Core/DotNETUtils.cs
+++ b/Core/Beyond.NET.Core/DotNETUtils.cs
@@ -66,17 +66,17 @@ public class DotNETUtils
         string latestRefDir = Path.Join(refDir, latestVersion.ToString());
 
         if (!Directory.Exists(latestRefDir)) {
-            throw new Exception($"Found latest ref dir but it does not exist: \"{latestRefDir}\"");
+            throw new Exception("Found latest ref dir but it does not exist");
         }
         
         latestRefDir = Path.Join(latestRefDir, refSubdir);
         
         if (!Directory.Exists(latestRefDir)) {
-            throw new Exception($"Found latest ref dir but it does not exist: \"{latestRefDir}\"");
+            throw new Exception("Found latest ref dir but it does not exist");
         }
 
         if (!Directory.EnumerateFiles(latestRefDir, "*.xml").Any()) {
-            throw new Exception($"Found latest ref dir but it has no xml files: \"{latestRefDir}\"");
+            throw new Exception("Found latest ref dir but it has no xml files");
         }
         
         return latestRefDir;

--- a/Core/Beyond.NET.Core/DotNETUtils.cs
+++ b/Core/Beyond.NET.Core/DotNETUtils.cs
@@ -66,17 +66,17 @@ public class DotNETUtils
         string latestRefDir = Path.Join(refDir, latestVersion.ToString());
 
         if (!Directory.Exists(latestRefDir)) {
-            throw new Exception("Found latest ref dir but it does not exist");
+            throw new Exception($"Found latest ref dir but it does not exist: \"{latestRefDir}\"");
         }
         
         latestRefDir = Path.Join(latestRefDir, refSubdir);
         
         if (!Directory.Exists(latestRefDir)) {
-            throw new Exception("Found latest ref dir but it does not exist");
+            throw new Exception($"Found latest ref dir but it does not exist: \"{latestRefDir}\"");
         }
 
         if (!Directory.EnumerateFiles(latestRefDir, "*.xml").Any()) {
-            throw new Exception("Found latest ref dir but it has no xml files");
+            throw new Exception($"Found latest ref dir but it has no xml files: \"{latestRefDir}\"");
         }
         
         return latestRefDir;

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Beyond.NET.CodeGenerator.CLI.csproj
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Beyond.NET.CodeGenerator.CLI.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>beyondnetgen</AssemblyName>
     <AssemblyVersion>0.4</AssemblyVersion>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/CodeGeneratorDriver.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/CodeGeneratorDriver.cs
@@ -214,8 +214,8 @@ internal class CodeGeneratorDriver
                 if (string.IsNullOrEmpty(systemReferenceAssembliesDirectoryPath) ||
                     !Directory.Exists(systemReferenceAssembliesDirectoryPath)) {
                     // Fall back to hard coded path
-                    // TODO: update to `net9.0` after RTM
-                    systemReferenceAssembliesDirectoryPath = $"/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/8.0.0/ref/net8.0";
+                    // TODO: update for 9.0 RC2 and then RTM
+                    systemReferenceAssembliesDirectoryPath = $"/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/9.0.0-rc.1.24431.7/ref/net9.0";
                     
                     Logger.LogWarning($"Failed to gather path to system reference assemblies - falling back to hard coded path \"{systemReferenceAssembliesDirectoryPath}\"");
                 } else {

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/CodeGeneratorDriver.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/CodeGeneratorDriver.cs
@@ -214,6 +214,7 @@ internal class CodeGeneratorDriver
                 if (string.IsNullOrEmpty(systemReferenceAssembliesDirectoryPath) ||
                     !Directory.Exists(systemReferenceAssembliesDirectoryPath)) {
                     // Fall back to hard coded path
+                    // TODO: update to `net9.0` after RTM
                     systemReferenceAssembliesDirectoryPath = $"/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/8.0.0/ref/net8.0";
                     
                     Logger.LogWarning($"Failed to gather path to system reference assemblies - falling back to hard coded path \"{systemReferenceAssembliesDirectoryPath}\"");

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/CodeGeneratorDriver.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/CodeGeneratorDriver.cs
@@ -172,8 +172,6 @@ internal class CodeGeneratorDriver
             #region Add System Documentation
             if (!doNotGenerateDocumentation) {
                 var systemReferenceAssembliesDirectoryPath = string.Empty;
-
-                string? dotnetInstallLocation = null;
                 
                 try {
                     var dotnetDir = DotNETUtils.GetDotnetGlobalInstallLocation();
@@ -183,10 +181,7 @@ internal class CodeGeneratorDriver
                     }
                     
                     Logger.LogDebug($".NET Core root directory: \"{dotnetDir}\"");
-                    if (Directory.Exists(dotnetDir)) {
-                        dotnetInstallLocation = dotnetDir;
-                    }
-
+                    
                     var tfm = DotNETUtils.GetTargetFrameworkName(assemblyPath);
 
                     if (string.IsNullOrWhiteSpace(tfm)) {
@@ -218,28 +213,11 @@ internal class CodeGeneratorDriver
                 
                 if (string.IsNullOrEmpty(systemReferenceAssembliesDirectoryPath) ||
                     !Directory.Exists(systemReferenceAssembliesDirectoryPath)) {
+                    // Fall back to hard coded path
+                    // TODO: update for 9.0 RC2 and then RTM
+                    systemReferenceAssembliesDirectoryPath = $"/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/9.0.0-rc.1.24431.7/ref/net9.0";
                     
-                    // TODO: update this for 9.0 RC2, then RTM, then remove this comment.
-                    const string fallbackRefPackPath = "packs/Microsoft.NETCore.App.Ref/9.0.0-rc.1.24431.7/ref/net9.0";
-
-                    // Fall back to relative path from where `dotnet` is installed
-                    if (!string.IsNullOrEmpty(dotnetInstallLocation)) {
-                        string candidatePath = Path.Join(dotnetInstallLocation, fallbackRefPackPath);
-
-                        if (Directory.Exists(candidatePath)) {
-                            Logger.LogWarning($"Failed to gather path to system reference assemblies - falling back to \"{candidatePath}\"");
-                            systemReferenceAssembliesDirectoryPath = candidatePath;
-                        }
-                    }
-
-                    // Fall back to hard coded path if all else failed
-                    if (string.IsNullOrEmpty(systemReferenceAssembliesDirectoryPath) ||
-                        !Directory.Exists(systemReferenceAssembliesDirectoryPath)) {
-
-                        systemReferenceAssembliesDirectoryPath = Path.Join("/usr/local/share/dotnet", fallbackRefPackPath);
-
-                        Logger.LogWarning($"Failed to gather path to system reference assemblies - falling back to hard coded path \"{systemReferenceAssembliesDirectoryPath}\"");
-                    }
+                    Logger.LogWarning($"Failed to gather path to system reference assemblies - falling back to hard coded path \"{systemReferenceAssembliesDirectoryPath}\"");
                 } else {
                     Logger.LogInformation($"Found path to system reference assemblies at \"{systemReferenceAssembliesDirectoryPath}\"");
                 }

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/CodeGeneratorDriver.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/CodeGeneratorDriver.cs
@@ -214,8 +214,8 @@ internal class CodeGeneratorDriver
                 if (string.IsNullOrEmpty(systemReferenceAssembliesDirectoryPath) ||
                     !Directory.Exists(systemReferenceAssembliesDirectoryPath)) {
                     // Fall back to hard coded path
-                    // TODO: update for 9.0 RC2 and then RTM
-                    systemReferenceAssembliesDirectoryPath = $"/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/9.0.0-rc.1.24431.7/ref/net9.0";
+                    // TODO: update to `net9.0` after RTM
+                    systemReferenceAssembliesDirectoryPath = $"/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/8.0.0/ref/net8.0";
                     
                     Logger.LogWarning($"Failed to gather path to system reference assemblies - falling back to hard coded path \"{systemReferenceAssembliesDirectoryPath}\"");
                 } else {

--- a/Generator/Beyond.NET.CodeGenerator/Beyond.NET.CodeGenerator.csproj
+++ b/Generator/Beyond.NET.CodeGenerator/Beyond.NET.CodeGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The generated C# code can then be compiled with .NET NativeAOT which allows the 
 
 ### Prerequisites
 
-- Make sure [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) is installed and on your path.
+- Make sure [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0) is installed and on your path.
 - On macOS, make sure [Xcode](https://developer.apple.com/xcode/), the macOS and iOS SDKs and the Command Line Tools (`xcode-select --install`) are installed.
 - On Linux, make sure clang and zlib are installed
 
@@ -90,14 +90,14 @@ public class Hello
 ```
 
 - Compile the .NET class library: `dotnet publish`.
-- Note the published dll's output path (should be something like this `/Path/To/BeyondDemo/bin/Release/net8.0/publish/BeyondDemo.dll`).
+- Note the published dll's output path (should be something like this `/Path/To/BeyondDemo/bin/Release/net9.0/publish/BeyondDemo.dll`).
 - Create a config file for Beyond.NET: `touch Config.json`.
 - Open `Config.json` in a text editor.
 - Replace its contents with this:
 
 ```json
 {
-    "AssemblyPath": "bin/Release/net8.0/publish/BeyondDemo.dll",
+    "AssemblyPath": "bin/Release/net9.0/publish/BeyondDemo.dll",
 
     "Build": {
         "Target": "apple-universal"
@@ -110,8 +110,8 @@ public class Hello
 - Run the generator: `beyondnetgen Config.json`.
 - On a Mac Studio M2 Ultra, this takes a little more than a minute while on an 8-Core Intel Xeon iMac Pro, it takes around 3 minutes. So it might be worth getting some coffee depending on your hardware. (TODO: Outdated info, as now with parallel building support the times are way better)
 - The individual code generation and builds steps are shown in the terminal.
-- The last printed line should include the path where the build output has been written to (ie. `Build Output has been written to "/Path/To/BeyondDemo/bin/Release/net8.0/publish"`).
-- Check the contents of the build output path: `ls bin/Release/net8.0/publish`
+- The last printed line should include the path where the build output has been written to (ie. `Build Output has been written to "/Path/To/BeyondDemo/bin/Release/net9.0/publish"`).
+- Check the contents of the build output path: `ls bin/Release/net9.0/publish`
 - It should include an XCFramework bundle called `BeyondDemoKit.xcframework`.
 - Congratulations, you now have a fully functional native version of your .NET library that can be consumed by macOS and iOS Xcode projects.
 
@@ -131,7 +131,7 @@ Now that we have an XCFramework containing binaries for macOS and iOS, we can in
 - Select the `General` tab.
 - Under `Frameworks, Libraries and Embedded Content`, click the `+` button.
 - Select `Add Other... - Add Files...`.
-- Navigate one level up in the file picker, then go to `bin/Release/net8.0/publish` (depending on your output path).
+- Navigate one level up in the file picker, then go to `bin/Release/net9.0/publish` (depending on your output path).
 - Select `BeyondDemoKit.xcframework`.
 - The XCFramework should now show up and it should already be configured to `Embed & Sign`.
 - Select `ContentView.swift` in the project navigator.

--- a/README_MANUAL_BUILD.md
+++ b/README_MANUAL_BUILD.md
@@ -4,7 +4,7 @@
 - Create a new .NET class lib project (ie. `mkdir MyLibNative && cd MyLibNative && dotnet new classlib`).
 - Either copy the generated .cs file containing the unmanaged C# bindings to the new project's directory or adjust the path in the generator config file to point to your new project's path.
 - Open `MyLibNative.csproj` in a text editor.
-- Make sure `TargetFramework` is set to `net8.0`.
+- Make sure `TargetFramework` is set to `net9.0`.
 - Set `AllowUnsafeBlocks` to `true` as the generated bindings use unsafe code (ie. `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>`).
 - Add a project reference to the original .NET assembly (ie. `<ProjectReference Include="..\MyLib.csproj" />`).
 - Set `PublishAot` to `true` (ie. `<PublishAot>true</PublishAot>`).
@@ -13,7 +13,7 @@
 - Also, the install name of dylibs created by .NET's NativeAOT compiler needs to adjusted from `/usr/lib/MyLibNative.dylib` to `@rpath/MyLibNative.dylib`.
 - There's a sample publish script which does all of this in the repository called `publish_macos_universal`. You can use this as the basis for your build. Just make sure to adjust the `OUTPUT_PRODUCT_NAME` variable to match the assembly name of your .NET library (`MyLib`).
 - Run the publish script (ie. `./publish_macos_universal`).
-- On macOS this will produce a universal `MyNativeLib.dylib` in the bin directory under `bin/Release/net8.0/osx-universal/publish`.
+- On macOS this will produce a universal `MyNativeLib.dylib` in the bin directory under `bin/Release/net9.0/osx-universal/publish`.
 
 
 ### Use generated bindings from Swift
@@ -27,7 +27,7 @@
     - Select "Add other... - Add files..." and select the native dylib (ie. `MyNativeLib.dylib`)
 - Try to build the project. If it fails, you might need to adjust either your header or library search paths in the project settings.
     - If Xcode fails to link the native dylib (the error looks something like this: `Library not found for -lMyNativeLib`) you need to adjust "Build Settings - Library Search Paths" in you project settings to point to the path where the library is located.
-        - For example, if you the native library is located one level below your Xcode project in a folder called "MyLibNative/bin/Release/net8.0/osx-universal/publish" use this: `$(PROJECT_DIR)/../MyLibNative/bin/Release/net8.0/osx-universal/publish`)
+        - For example, if you the native library is located one level below your Xcode project in a folder called "MyLibNative/bin/Release/net9.0/osx-universal/publish" use this: `$(PROJECT_DIR)/../MyLibNative/bin/Release/net9.0/osx-universal/publish`)
     - If Xcode complains about being unable to find the generated C header, adjust "Build Settings - Header Search Paths" to point to the path where the generated header is located.
         - For example, if your header is one level below your Xcode project in a folder called "Generated" use this: `$(PROJECT_DIR)/../Generated`
 - You're now ready to call any of the APIs that bindings were generated for.

--- a/Samples/Beyond.NET.Sample.Android/app/src/main/jniLibs/arm64-v8a/libBeyondDotNETSampleNative.so
+++ b/Samples/Beyond.NET.Sample.Android/app/src/main/jniLibs/arm64-v8a/libBeyondDotNETSampleNative.so
@@ -1,1 +1,1 @@
-../../../../../../Beyond.NET.Sample.Native/bin/Release/net8.0/linux-bionic-arm64/publish/libBeyondDotNETSampleNative.so
+../../../../../../Beyond.NET.Sample.Native/bin/Release/net9.0/linux-bionic-arm64/publish/libBeyondDotNETSampleNative.so

--- a/Samples/Beyond.NET.Sample.Managed/Beyond.NET.Sample.Managed.csproj
+++ b/Samples/Beyond.NET.Sample.Managed/Beyond.NET.Sample.Managed.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/Samples/Beyond.NET.Sample.Native/Beyond.NET.Sample.Native.csproj
+++ b/Samples/Beyond.NET.Sample.Native/Beyond.NET.Sample.Native.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>libBeyondDotNETSampleNative</AssemblyName>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishTrimmed>true</PublishTrimmed>

--- a/Samples/Beyond.NET.Sample_BuildConfig.json
+++ b/Samples/Beyond.NET.Sample_BuildConfig.json
@@ -1,5 +1,5 @@
 {
-	"AssemblyPath": "Beyond.NET.Sample.Managed/bin/Release/net8.0/publish/Beyond.NET.Sample.Managed.dll",
+	"AssemblyPath": "Beyond.NET.Sample.Managed/bin/Release/net9.0/publish/Beyond.NET.Sample.Managed.dll",
 	
 	"Build": {
 		"Target": "apple-universal",

--- a/Samples/Beyond.NET.Sample_Config.json
+++ b/Samples/Beyond.NET.Sample_Config.json
@@ -1,5 +1,5 @@
 {
-	"AssemblyPath": "Beyond.NET.Sample.Managed/bin/Release/net8.0/publish/Beyond.NET.Sample.Managed.dll",
+	"AssemblyPath": "Beyond.NET.Sample.Managed/bin/Release/net9.0/publish/Beyond.NET.Sample.Managed.dll",
 	
 	"CSharpUnmanagedOutputPath": "Generated/Generated_CS.cs",
 	"COutputPath": "Generated/Generated_C.h",


### PR DESCRIPTION
With .NET 9.0 RC1 [now available](https://github.com/dotnet/core/discussions/9496), we can unlock some new features for downstream projects.