### PR TITLE
Update XML docs fallback location to .NET 9.0 RC2

### DIFF
--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/CodeGeneratorDriver.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/CodeGeneratorDriver.cs
@@ -216,7 +216,7 @@ internal class CodeGeneratorDriver
                     !Directory.Exists(systemReferenceAssembliesDirectoryPath)) {
                     // Fall back to hard coded path
                     // TODO: update to `net9.0` after RTM
-                    systemReferenceAssembliesDirectoryPath = $"/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/8.0.0/ref/net8.0";
+                    systemReferenceAssembliesDirectoryPath = "/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/9.0.0-rc.2.24473.5/ref/net9.0";
                     
                     Logger.LogWarning($"Failed to gather path to system reference assemblies - falling back to hard coded path \"{systemReferenceAssembliesDirectoryPath}\"");
                 } else {


### PR DESCRIPTION
ref. https://github.com/royalapplications/beyondnet/issues/85

Still to-do: update to plain `net9.0` next month, and then close #85.