### PR TITLE
Remove workaround for `Assembly.SetEntryAssembly`

### DIFF
--- a/Generator/Beyond.NET.CodeGenerator/Collectors/MemberCollector.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Collectors/MemberCollector.cs
@@ -16,12 +16,6 @@ public class MemberCollector
             typeof(System.Runtime.InteropServices.Marshal), [
                 "WriteInt16"
             ]
-        },
-        {
-            typeof(System.Reflection.Assembly), [
-                // TODO: There's a bug in .NET 8.0.400 where Assembly.SetEntryAssembly seems to be exposed in the reference assemblies but not in the implementation assemblies. For now, we just exclude that method. 
-                "SetEntryAssembly"
-            ]
         }
     };
 


### PR DESCRIPTION
There was a ref/def mismatch in .NET 8 APIs, where this method was visible for reflection, but not exposed in the public `ref` API surface.

Remove the workaround now that we're targeting .NET 9.

Closes #79 