### PR TITLE
Improve Kotlin 2.0 support

### DIFF
--- a/Generator/Beyond.NET.CodeGenerator/Generator/Kotlin/KotlinSharedCode.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/Kotlin/KotlinSharedCode.cs
@@ -15,15 +15,13 @@ open class DNObject(handle: Pointer): IDNObject {
         Skip
     }
     
-    override val __handle: Pointer
+    override val __handle: Pointer = handle
     var __destroyMode: DestroyMode = DestroyMode.Normal
     
     init {
         require(handle != null) {
             "Cannot initialize DNObject with a null pointer"
         }
-    
-        this.__handle = handle
     }
     
     protected fun finalize() {


### PR DESCRIPTION
Kotlin 2.0.x rejects the current code:

```
Generated_Kotlin.kt:29:5 Property must be initialized, be final, or be abstract.
```

Initialize the property inline, with the value passed-in to the constructor, to address this.