### PR TITLE
[Swift] improve `enum` support in .NET delegates

### DIFF
--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftTypeSyntaxWriter_Delegate.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftTypeSyntaxWriter_Delegate.cs
@@ -229,7 +229,7 @@ public partial class SwiftTypeSyntaxWriter
             typeInfo.IsReturning,
             typeInfo.ReturnTypeDescriptor,
             typeInfo.ReturnTypeIsOptional,
-            typeInfo.ReturnTypeIsPrimitive,
+            typeInfo.ReturnTypeIsPrimitive || typeInfo.ReturnType.IsEnum,
             typeInfo.ReturnTypeIsReadOnlySpanOfByte,
             typeDescriptorRegistry,
             out string createCFunctionFuncName
@@ -386,7 +386,7 @@ public partial class SwiftTypeSyntaxWriter
         bool isReturning,
         TypeDescriptor returnTypeDescriptor,
         bool returnTypeIsOptional,
-        bool returnTypeIsPrimitive,
+        bool returnTypeIsPrimitiveOrEnum,
         bool returnValueIsReadOnlySpanOfByte,
         TypeDescriptorRegistry typeDescriptorRegistry,
         out string createCFunctionFuncName
@@ -504,7 +504,7 @@ public partial class SwiftTypeSyntaxWriter
     
                 sb.AppendLine(fullReturnTypeConversion);
                 
-                if (!returnTypeIsPrimitive &&
+                if (!returnTypeIsPrimitiveOrEnum &&
                     !returnValueIsReadOnlySpanOfByte) {
                     string nullabilitySpecifier = returnTypeIsOptional
                         ? "?"

--- a/Samples/Beyond.NET.Sample.Managed/Source/DelegatesTest.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/DelegatesTest.cs
@@ -20,12 +20,20 @@ public struct Point
     }
 }
 
+public enum StepMode
+{
+    Over,
+    In,
+    Out,
+}
+
 // TODO: Delegates with ref parameters
 public static class DelegatesTest
 {
     public delegate int TransformIntDelegate(int i);
     // public delegate int TransformIntWithRefDelegate(ref int iRef);
-    
+    public delegate StepMode DebugEventHandler(object sender, StepMode stepMode);
+
     public static int TransformInt(
         int i,
         TransformIntDelegate intTransformer
@@ -68,4 +76,9 @@ public static class DelegatesTest
     //
     //     return result;
     // }
+
+    public static StepMode TransformStepMode(StepMode mode)
+    {
+        return mode;
+    }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/DelegateTestTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/DelegateTestTests.swift
@@ -24,6 +24,20 @@ final class DelegateTestTests: XCTestCase {
         XCTAssertEqual(result, expectedResult)
     }
     
+    func testTransformStepMode() throws {
+        var original: Beyond.NET.Sample.StepMode = .in
+        var result = try Beyond.NET.Sample.DelegatesTest.transformStepMode(original)
+        XCTAssertEqual(result, original)
+
+        original = .out
+        result = try Beyond.NET.Sample.DelegatesTest.transformStepMode(original)
+        XCTAssertEqual(result, original)
+
+        original = .over
+        result = try Beyond.NET.Sample.DelegatesTest.transformStepMode(original)
+        XCTAssertEqual(result, original)
+    }
+    
     // TODO: Delegates with ref parameters
 //    func testTransformIntWithRef() {
 //        let original: Int32 = 0


### PR DESCRIPTION
Treat delegates returning enum values the same as those returning primitive types. Add test confirming the expected behavior.