### PR TITLE
Allow excluding assemblies by name

### DIFF
--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/Configuration.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/Configuration.cs
@@ -23,5 +23,7 @@ public record Configuration(
     string[]? IncludedTypeNames,
     string[]? ExcludedTypeNames,
     
+    string[]? ExcludedAssemblyNames,
+    
     string[]? AssemblySearchPaths
 );

--- a/Generator/Beyond.NET.CodeGenerator/Collectors/TypeCollector.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Collectors/TypeCollector.cs
@@ -75,6 +75,8 @@ public class TypeCollector
 
     private readonly Type[] m_includedTypes;
     private readonly Type[] m_excludedTypes;
+    private readonly HashSet<string> m_excludedFullAssemblyNames;
+    private readonly HashSet<string> m_excludedSimpleAssemblyNames;
     
     public TypeCollector(
         Assembly? assembly,
@@ -89,6 +91,9 @@ public class TypeCollector
 
         m_includedTypes = whitelist.ToArray();
         m_excludedTypes = blacklist.ToArray();
+
+        m_excludedFullAssemblyNames = settings.ExcludedFullAssemblyNames;
+        m_excludedSimpleAssemblyNames = settings.ExcludedSimpleAssemblyNames;
         
         m_assembly = assembly;
         EnableGenericsSupport = settings.EnableGenericsSupport;
@@ -128,6 +133,18 @@ public class TypeCollector
             !m_includedTypes.Contains(type)) {
             unsupportedTypes[type] = "Excluded";
             
+            return;
+        }
+
+        var assemblyName = type.Assembly.GetName();
+        if (m_excludedFullAssemblyNames.Contains(assemblyName.FullName)) {
+            unsupportedTypes[type] = $"Excluded by assembly name '{assemblyName.FullName}'";
+
+            return;
+        }
+        if (m_excludedSimpleAssemblyNames.Contains(assemblyName.Name)) {
+            unsupportedTypes[type] = $"Excluded by assembly name '{assemblyName.Name}'";
+
             return;
         }
         

--- a/Generator/Beyond.NET.CodeGenerator/Collectors/TypeCollectorSettings.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Collectors/TypeCollectorSettings.cs
@@ -3,5 +3,7 @@ namespace Beyond.NET.CodeGenerator.Collectors;
 public record TypeCollectorSettings(
     bool EnableGenericsSupport,
     Type[] IncludedTypes,
-    Type[] ExcludedTypes
+    Type[] ExcludedTypes,
+    HashSet<string> ExcludedFullAssemblyNames,
+    HashSet<string> ExcludedSimpleAssemblyNames
 );

--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ The generator currently uses a configuration file where all of its options are s
       "AnotherExcludedTypeName"
   ],
 
+  "ExcludedAssemblyNames": [
+    "Assembly1, Version=4.2.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed",
+    "Assembly2"
+  ],
+
   "AssemblySearchPaths": [
       "/Path/To/Assemblies",
       "/Another/Path/To/Assemblies"


### PR DESCRIPTION
Allow excluding types by the full or simple name of the assembly they're defined in, e.g.

```json
{
   // other settings
   "ExcludedAssemblyNames": [
     "Assembly1, Version=4.2.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed",
     "Assembly2"
   ]
}
```

#### Motivation

`ProjectX` is AOT-compatible, has accurate nullability annotations, and `beyondnet` works well on it. 

Later, third-party `Dependency1` and `Dependency2` need to be added. They're used internally and are fully-encapsulated -- their types (and exceptions) are not exposed to `ProjectX` consumers.

But since `Dependency1` and `Dependency2` are *almost but not quite* AOT-compatible (or nullable-correct), they can prevent `beyondnet` from  processing the main project.

This feature allows excluding such assemblies' types from scanning, when it is known that they are not publicly-visible. 

If the types *would* be inadvertenly exposed publicly,  processing would fail loudly because they'd be referenced but not defined from generated code.