### PR TITLE
Clean up formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_size = 4

--- a/Builder/Beyond.NET.Builder.Apple/Clang/App.cs
+++ b/Builder/Beyond.NET.Builder.Apple/Clang/App.cs
@@ -6,20 +6,20 @@ public static class App
 {
     private static string ClangPath => Which.GetAbsoluteCommandPath("clang");
     internal static CLIApp ClangApp => new(ClangPath);
-    
+
     public const string ARGUMENT_TARGET = "-target";
     public const string ARGUMENT_SYSROOT = "-isysroot";
-    
+
     public const string ARGUMENT_OUTPUT = "-o";
     public const string ARGUMENT_COMPILE = "-c";
-    
+
     public const string FLAG_OPTIMIZE3 = "-O3";
-    
+
     public static string Run(
         string workingDirectory,
         string[] arguments
     )
-    {   
+    {
         var result = ClangApp.Launch(
             arguments,
             workingDirectory
@@ -52,12 +52,12 @@ public static class App
         if (optimize3) {
             arguments.Add(FLAG_OPTIMIZE3);
         }
-        
+
         arguments.AddRange(new [] {
             ARGUMENT_COMPILE,
             targetFile
         });
-        
+
         return Run(
             workingDirectory,
             arguments.ToArray()

--- a/Builder/Beyond.NET.Builder.Apple/Clang/ModuleMap.cs
+++ b/Builder/Beyond.NET.Builder.Apple/Clang/ModuleMap.cs
@@ -12,7 +12,7 @@ public class ModuleMap
             Private,
             Umbrella
         }
-        
+
         public Types Type { get; init; }
         public string Name { get; init; }
 
@@ -36,11 +36,11 @@ public class ModuleMap
                     prefix = string.Empty;
                     break;
             }
-            
+
             return $"{prefix}header \"{Name}\"";
         }
     }
-    
+
     public string Name { get; init; }
     public bool IsFramework { get; init; }
     public Header[]? Headers { get; init; }
@@ -56,7 +56,7 @@ public class ModuleMap
         string frameworkPrefix = IsFramework
             ? "framework "
             : string.Empty;
-        
+
         string moduleDecl = $"{frameworkPrefix}module {Name} {{\n";
 
         StringBuilder sb = new(moduleDecl);

--- a/Builder/Beyond.NET.Builder.Apple/Clang/VFSOverlay/HeaderFile.cs
+++ b/Builder/Beyond.NET.Builder.Apple/Clang/VFSOverlay/HeaderFile.cs
@@ -6,13 +6,13 @@ public class HeaderFile
 {
     public const string TYPE_DIRECTORY = "directory";
     public const string TYPE_FILE = "file";
-    
+
     [JsonPropertyName("version")]
     public int Version { get; set; }
-    
+
     [JsonPropertyName("case-sensitive")]
     public bool CaseSensitive { get; set; }
-    
+
     [JsonPropertyName("roots")]
     public HeaderFileRoot[]? Roots { get; set; }
 
@@ -29,10 +29,10 @@ public class HeaderFileRoot
 {
     [JsonPropertyName("name")]
     public string? Name { get; set; }
-    
+
     [JsonPropertyName("type")]
     public string? Type { get; set; }
-    
+
     [JsonPropertyName("contents")]
     public HeaderFileContent[]? Contents { get; set; }
 }
@@ -41,10 +41,10 @@ public class HeaderFileContent
 {
     [JsonPropertyName("name")]
     public string? Name { get; set; }
-    
+
     [JsonPropertyName("type")]
     public string? Type { get; set; }
-    
+
     [JsonPropertyName("external-contents")]
     public string? ExternalContents { get; set; }
 }

--- a/Builder/Beyond.NET.Builder.Apple/Clang/VFSOverlay/HeaderFileSerializer.cs
+++ b/Builder/Beyond.NET.Builder.Apple/Clang/VFSOverlay/HeaderFileSerializer.cs
@@ -15,7 +15,7 @@ public class HeaderFileSerializer
 
         return json;
     }
-    
+
     public HeaderFile DeserializeFromJson(string jsonString)
     {
         HeaderFile? headerFile = JsonSerializer.Deserialize(jsonString, ConfigurationMetadataOnlyContext.Default.HeaderFile);
@@ -26,7 +26,7 @@ public class HeaderFileSerializer
 
         return headerFile;
     }
-    
+
     public HeaderFile DeserializeFromJsonFilePath(string jsonFilePath)
     {
         string jsonString = File.ReadAllText(jsonFilePath);

--- a/Builder/Beyond.NET.Builder.Apple/Framework/FrameworkBuilder.cs
+++ b/Builder/Beyond.NET.Builder.Apple/Framework/FrameworkBuilder.cs
@@ -9,25 +9,25 @@ public record FrameworkBuilder
     string FrameworkBundleIdentifier,
     string LibraryFilePath,
     string OutputDirectoryPath,
-    
+
     bool BuildForMacOS,
-    
+
     string? ModuleMapFilePath,
     string? SwiftModuleDirectoryPath
 )
 {
 	public record Result(string FrameworkOutputDirectoryPath);
-	
+
     private static ILogger Logger => Services.Shared.LoggerService;
-    
+
     public Result Build()
     {
-	    string bundleName = $"{FrameworkName}.framework"; 
+	    string bundleName = $"{FrameworkName}.framework";
         string outputBundlePath = Path.Combine(OutputDirectoryPath, bundleName);
         string libraryName = FrameworkName;
 
 	    Logger.LogDebug($"Creating framework \"{FrameworkName}\" at \"{outputBundlePath}\"");
-	    
+
         const string versionsDirName = "Versions";
         const string versionsADirName = "A";
         const string versionsCurrentDirName = "Current";
@@ -38,16 +38,16 @@ public record FrameworkBuilder
         const string infoPlistFileName = "Info.plist";
         const string moduleMapFileName = "module.modulemap";
         string swiftModuleDirName = $"{FrameworkName}.{FileExtensions.SwiftModule}";
-        
+
         // Only relevant for macOS
         string versionsDirectoryPath = Path.Combine(outputBundlePath, versionsDirName);
-        
+
         // Only relevant for macOS
         string versionsADirectoryPath = Path.Combine(versionsDirectoryPath, versionsADirName);
-        
+
         // Only relevant for macOS
         string versionsCurrentDirectoryPath = Path.Combine(versionsDirectoryPath, versionsCurrentDirName);
-        
+
         string modulesDirectoryPath;
 
         if (BuildForMacOS) {
@@ -55,7 +55,7 @@ public record FrameworkBuilder
         } else {
 	        modulesDirectoryPath = Path.Combine(outputBundlePath, modulesDirName);
         }
-        
+
         // Only relevant for macOS
         string resourcesDirectoryPath = Path.Combine(versionsADirectoryPath, resourcesDirName);
 
@@ -69,7 +69,7 @@ public record FrameworkBuilder
 
         // Only relevant for macOS
         string modulesLinkDirectoryPath = Path.Combine(outputBundlePath, modulesDirName);
-        
+
         // Only relevant for macOS
         string resourcesLinkDirectoryPath = Path.Combine(outputBundlePath, resourcesDirName);
 
@@ -80,7 +80,7 @@ public record FrameworkBuilder
         } else {
 	        frameworkLibraryFilePath = Path.Combine(outputBundlePath, libraryName);
         }
-        
+
         // Only relevant for macOS
         string frameworkLibraryFileLinkPath = Path.Combine(outputBundlePath, libraryName);
 
@@ -96,9 +96,9 @@ public record FrameworkBuilder
         }
 
         Logger.LogDebug("Creating Framework Directory Structure");
-        
+
         Directory.CreateDirectory(outputBundlePath);
-        
+
         if (BuildForMacOS) {
 	        Directory.CreateDirectory(versionsDirectoryPath);
 	        Directory.CreateDirectory(versionsADirectoryPath);
@@ -107,7 +107,7 @@ public record FrameworkBuilder
 
 	        Directory.CreateSymbolicLink(versionsCurrentDirectoryPath, versionsADirName);
 	        Directory.CreateSymbolicLink(modulesLinkDirectoryPath, $"{versionsDirName}/{versionsCurrentDirName}/{modulesDirName}");
-	        Directory.CreateSymbolicLink(resourcesLinkDirectoryPath, $"{versionsDirName}/{versionsCurrentDirName}/{resourcesDirName}");   
+	        Directory.CreateSymbolicLink(resourcesLinkDirectoryPath, $"{versionsDirName}/{versionsCurrentDirName}/{resourcesDirName}");
         } else { // iOS-like
 	        Directory.CreateDirectory(modulesDirectoryPath);
         }
@@ -129,16 +129,16 @@ public record FrameworkBuilder
 		        true
 		    );
         }
-        
+
         Logger.LogDebug("Copying Framework library");
         File.Copy(LibraryFilePath, frameworkLibraryFilePath);
 
         if (BuildForMacOS) {
 			File.CreateSymbolicLink(frameworkLibraryFileLinkPath, $"{versionsDirName}/{versionsCurrentDirName}/{libraryName}");
         }
-        
+
         Logger.LogDebug($"Changing Framework library ID to \"{newFrameworkLibraryID}\"");
-        
+
         InstallNameTool.App.ChangeId(
 	        frameworkLibraryFilePath,
 	        newFrameworkLibraryID

--- a/Builder/Beyond.NET.Builder.Apple/InstallNameTool/App.cs
+++ b/Builder/Beyond.NET.Builder.Apple/InstallNameTool/App.cs
@@ -6,7 +6,7 @@ public class App
 {
     private static string InstallNameToolPath => Which.GetAbsoluteCommandPath("install_name_tool");
     private static CLIApp InstallNameToolApp => new(InstallNameToolPath);
-    
+
     private const string ARGUMENT_ID = "-id";
 
     public static void ChangeId(
@@ -21,7 +21,7 @@ public class App
         };
 
         var result = InstallNameToolApp.Launch(args);
-        
+
         Exception? failure = result.FailureAsException;
 
         if (failure is not null) {

--- a/Builder/Beyond.NET.Builder.Apple/Lipo/App.cs
+++ b/Builder/Beyond.NET.Builder.Apple/Lipo/App.cs
@@ -6,10 +6,10 @@ public class App
 {
     private static string LipoPath => Which.GetAbsoluteCommandPath("lipo");
     private static CLIApp LipoApp => new(LipoPath);
-    
+
     private const string ARGUMENT_CREATE = "-create";
     private const string ARGUMENT_OUTPUT = "-output";
-    
+
     public static void Create(
         string[] libraryPaths,
         string outputPath
@@ -18,16 +18,16 @@ public class App
         List<string> args = new(new [] {
             ARGUMENT_CREATE
         });
-        
+
         args.AddRange(libraryPaths);
-        
+
         args.AddRange(new [] {
             ARGUMENT_OUTPUT,
             outputPath
         });
 
         var result = LipoApp.Launch(args.ToArray());
-        
+
         Exception? failure = result.FailureAsException;
 
         if (failure is not null) {

--- a/Builder/Beyond.NET.Builder.Apple/Nm/App.cs
+++ b/Builder/Beyond.NET.Builder.Apple/Nm/App.cs
@@ -6,10 +6,10 @@ public class App
 {
     private static string NmPath => Which.GetAbsoluteCommandPath("nm");
     private static CLIApp NmApp => new(NmPath);
-    
+
     private const string FLAG_ONLY_EXTERNAL_SYMBOLS = "-g";
     private const string FLAG_EXCLUDE_UNDEFINED_SYMBOLS = "-U";
-    
+
     private static string GetSymbolsList(
         string targetPath,
         bool onlyExternalSymbols,
@@ -21,15 +21,15 @@ public class App
         if (onlyExternalSymbols) {
             args.Add(FLAG_ONLY_EXTERNAL_SYMBOLS);
         }
-        
+
         if (excludeUndefinedSymbols) {
             args.Add(FLAG_EXCLUDE_UNDEFINED_SYMBOLS);
         }
-        
+
         args.Add(targetPath);
-        
+
         var result = NmApp.Launch(args.ToArray());
-        
+
         Exception? failure = result.FailureAsException;
 
         if (failure is not null) {

--- a/Builder/Beyond.NET.Builder.Apple/Nm/Parser.cs
+++ b/Builder/Beyond.NET.Builder.Apple/Nm/Parser.cs
@@ -5,7 +5,7 @@ internal class Parser
     internal static string[] GetAllRelevantSymbols(string output)
     {
         var lines = output.Split(
-            new[] { "\r\n", "\n", "\r" }, 
+            new[] { "\r\n", "\n", "\r" },
             StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
         );
 
@@ -13,7 +13,7 @@ internal class Parser
 
         foreach (var line in lines) {
             var splitLine = line.Split(
-                ' ', 
+                ' ',
                 StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
             );
 
@@ -29,7 +29,7 @@ internal class Parser
                 // Swift internal symbol, not relevant
                 continue;
             }
-            
+
             symbols.Add(symbol);
         }
 

--- a/Builder/Beyond.NET.Builder.Apple/XCRun/Libtool.cs
+++ b/Builder/Beyond.NET.Builder.Apple/XCRun/Libtool.cs
@@ -22,7 +22,7 @@ public static class Libtool
         if (noWarningForNoSymbols) {
             arguments.Add("-no_warning_for_no_symbols");
         }
-        
+
         var result = App.XCRunApp.Launch(
             arguments.ToArray(),
             workingDirectory

--- a/Builder/Beyond.NET.Builder.Apple/XCRun/SDK.cs
+++ b/Builder/Beyond.NET.Builder.Apple/XCRun/SDK.cs
@@ -3,10 +3,10 @@ namespace Beyond.NET.Builder.Apple.XCRun;
 public static class SDK
 {
     public const string macOSName = "macosx";
-    
+
     public const string iOSName = "iphoneos";
     public const string iOSSimulatorName = "iphonesimulator";
-    
+
     public const string XROSName = "xros";
     public const string XRSimulatorName = "xrsimulator";
 

--- a/Builder/Beyond.NET.Builder.Apple/XCRun/SwiftC/App.cs
+++ b/Builder/Beyond.NET.Builder.Apple/XCRun/SwiftC/App.cs
@@ -3,7 +3,7 @@ namespace Beyond.NET.Builder.Apple.XCRun.SwiftC;
 public class App
 {
     private const string COMMAND_SWIFTC = "swiftc";
-    
+
     public const string ARGUMENT_SDK = "-sdk";
     public const string ARGUMENT_TARGET = "-target";
     public const string ARGUMENT_WORKING_DIRECTORY = "-working-directory";
@@ -34,7 +34,7 @@ public class App
     public const string FLAG_EXPERIMENTAL_EMIT_MODULE_SEPARATELY = "-experimental-emit-module-separately";
     public const string FLAG_DISABLE_CROSS_MODULE_OPTIMIZATION = "-disable-cmo";
     public const string ARGUMENT_COMPILE = "-c";
-    
+
     public static string Run(
         string workingDirectory,
         string[] arguments
@@ -43,9 +43,9 @@ public class App
         List<string> finalArguments = new(new[] {
             COMMAND_SWIFTC
         });
-        
+
         finalArguments.AddRange(arguments);
-        
+
         var result = XCRun.App.XCRunApp.Launch(
             finalArguments.ToArray(),
             workingDirectory

--- a/Builder/Beyond.NET.Builder.Apple/XCRun/SwiftC/PlatformIdentifier.cs
+++ b/Builder/Beyond.NET.Builder.Apple/XCRun/SwiftC/PlatformIdentifier.cs
@@ -5,6 +5,6 @@ public static class PlatformIdentifier
     public const string macOS = "apple-macos";
     public const string iOS = "apple-ios";
     public const string XROS = "apple-xros";
-    
+
     public const string SimulatorSuffix = "-simulator";
 }

--- a/Builder/Beyond.NET.Builder.Apple/XCRun/SwiftC/TargetDouble.cs
+++ b/Builder/Beyond.NET.Builder.Apple/XCRun/SwiftC/TargetDouble.cs
@@ -3,13 +3,13 @@ namespace Beyond.NET.Builder.Apple.XCRun.SwiftC;
 public static class TargetDouble
 {
     public static string Make(
-        string targetIdentifier, 
+        string targetIdentifier,
         string platformIdentifier,
         string platformSuffix
     )
     {
         string targetDouble = $"{targetIdentifier}-{platformIdentifier}{platformSuffix}";
-        
+
         return targetDouble;
     }
 }

--- a/Builder/Beyond.NET.Builder.Apple/XCRun/SwiftC/TargetTriple.cs
+++ b/Builder/Beyond.NET.Builder.Apple/XCRun/SwiftC/TargetTriple.cs
@@ -14,7 +14,7 @@ public static class TargetTriple
             platformIdentifier,
             string.Empty
         );
-        
+
         string targetTriple = $"{targetDouble}{deploymentTarget}{platformSuffix}";
 
         return targetTriple;

--- a/Builder/Beyond.NET.Builder.Apple/Xcodebuild/CreateXCFramework.cs
+++ b/Builder/Beyond.NET.Builder.Apple/Xcodebuild/CreateXCFramework.cs
@@ -5,11 +5,11 @@ namespace Beyond.NET.Builder.Apple.Xcodebuild;
 public class CreateXCFramework
 {
     private const string ARGUMENT_CREATE_XCFRAMEWORK = "-create-xcframework";
-    
+
     private const string ARGUMENT_FRAMEWORK = "-framework";
     private const string ARGUMENT_LIBRARY = "-library";
     private const string ARGUMENT_OUTPUT = "-output";
-    
+
     public static void Run(
         string[]? frameworks,
         string[]? libraries,
@@ -25,34 +25,34 @@ public class CreateXCFramework
                 if (string.IsNullOrEmpty(framework)) {
                     continue;
                 }
-            
+
                 arguments.AddRange(new [] {
                     ARGUMENT_FRAMEWORK,
                     Temp_XcodeBuild_15_ResolveVarSymlink(framework)
                 });
-            }   
+            }
         }
-        
+
         if (libraries is not null) {
             foreach (var library in libraries) {
                 if (string.IsNullOrEmpty(library)) {
                     continue;
                 }
-            
+
                 arguments.AddRange(new [] {
                     ARGUMENT_LIBRARY,
                     Temp_XcodeBuild_15_ResolveVarSymlink(library)
                 });
-            }   
+            }
         }
 
         arguments.AddRange(new [] {
             ARGUMENT_OUTPUT,
             Temp_XcodeBuild_15_ResolveVarSymlink(outputPath)
         });
-        
+
         var result = App.XcodeBuildApp.Launch(arguments.ToArray());
-        
+
         Exception? failure = result.FailureAsException;
 
         if (failure is not null) {
@@ -69,7 +69,7 @@ public class CreateXCFramework
     //   -framework /var/folders/<elided>/ios-arm64/publish/SampleKit.framework\
     //   -output /var/folders/<elided>/apple-universal/publish/SampleKit.xcframework
     // ```
-    // 
+    //
     // It returns exit code 70 and prints an error message similar to:
     //
     // ```
@@ -77,24 +77,24 @@ public class CreateXCFramework
     //  'Path(str: "/private/var/folders/<elided>/osx-universal/publish/SampleKit.framework/Versions/A/SampleKit")'
     // relative to that of '/var/folders/<elided>/osx-universal/publish/SampleKit.framework'
     // ```
-    // 
+    //
     // Note the mismatch between `/private/var` and `/var` -- on OSX,
     // `/var` is a symlink to `/private/var`.
     //
-    // `xcodebuild` v15 seems to resolve symlinks for some arguments but not 
+    // `xcodebuild` v15 seems to resolve symlinks for some arguments but not
     // others and ends up confused. Unfortunately, .NET APIs do not resolve
-    // symlinks at the *start* of a path, only for the *last* component. 
+    // symlinks at the *start* of a path, only for the *last* component.
     //
     // Hence, this helper resolves the symlink in the initial `/var`
     // path segment explicitly, as a workaround until `xcodebuild` is
     // updated to work correctly with symlinked paths again.
-   
+
     private static string Temp_XcodeBuild_15_ResolveVarSymlink(string path)
     {
         if (string.IsNullOrEmpty(path)) {
             return path;
         }
-        
+
         // Console.WriteLine($"ORIGINAL PATH: {path}");
 
         var resolvedPath = path.ResolveSymlinksAndGetCanonicalPath_AppleOnly();
@@ -102,34 +102,34 @@ public class CreateXCFramework
         if (string.IsNullOrEmpty(resolvedPath)) {
             return path;
         }
-        
+
         // Console.WriteLine($"RESOLVED PATH: {resolvedPath}");
 
         return resolvedPath;
     }
-    
+
     // private static string Temp_XcodeBuild_15_ResolveVarSymlink(string path)
     // {
     //     if (string.IsNullOrEmpty(path)) {
     //         return path;
     //     }
-    //     
+    //
     //     Console.WriteLine($"ORIGINAL PATH: {path}");
-    //     
+    //
     //     if (!path.StartsWith("/var/", StringComparison.Ordinal)) {
     //         return path;
     //     }
-    //     
+    //
     //     FileSystemInfo? linkTarget = Directory.ResolveLinkTarget("/var", returnFinalTarget: true);
-    //     
+    //
     //     if (linkTarget is not null) {
     //         var resolvedPath = linkTarget.FullName + path.Substring("/var".Length);
-    //          
+    //
     //         Console.WriteLine($"RESOLVED PATH: {resolvedPath}");
-    //         
+    //
     //         return resolvedPath;
     //     }
-    //     
+    //
     //     return path;
     // }
 }

--- a/Builder/Beyond.NET.Builder.DotNET/Clean.cs
+++ b/Builder/Beyond.NET.Builder.DotNET/Clean.cs
@@ -3,7 +3,7 @@ namespace Beyond.NET.Builder.DotNET;
 public class Clean
 {
     private const string FLAG_CLEAN = "clean";
-    
+
     public static string Run(
         string workingDirectory,
         string? configuration
@@ -15,7 +15,7 @@ public class Clean
 
         if (!string.IsNullOrEmpty(configuration)) {
             string configArg = $"/p:Configuration={configuration}";
-            
+
             args.Add(configArg);
         }
 
@@ -23,7 +23,7 @@ public class Clean
             args.ToArray(),
             workingDirectory
         );
-        
+
         Exception? failure = result.FailureAsException;
 
         if (failure is not null) {

--- a/Builder/Beyond.NET.Builder.DotNET/NativeCsProj.cs
+++ b/Builder/Beyond.NET.Builder.DotNET/NativeCsProj.cs
@@ -10,23 +10,23 @@ public class NativeCsProj
     (
         string iOSSDKPath,
         string iOSSimulatorSDKPath,
-        
+
         string MinMacOSVersion,
         string MiniOSVersion,
 
         string? SwiftLibraryFilePathFormat,
         string? SymbolsFilePathFormat,
-        
+
         string? ModuleMapFilePath
     );
-    
+
     public string TargetFramework { get; }
     public string ProductName { get; }
     public string TargetAssemblyFilePath { get; }
     public string[] AssemblyReferences { get; }
     public AppleSpecificSettings? AppleSettings { get; }
     public bool StripSymbols { get; }
-    
+
     private string OutputProductName => ProductName;
 
     public NativeCsProj(
@@ -50,24 +50,24 @@ public class NativeCsProj
     {
         // TODO: Disabled for now to get faster build times
         const string nullable = "disable";
-        
+
         string iOSSDKPath = AppleSettings?.iOSSDKPath ?? string.Empty;
         string iOSSimulatorSDKPath = AppleSettings?.iOSSimulatorSDKPath ?? string.Empty;
 
         string swiftLibraryFilePathFormat = AppleSettings?.SwiftLibraryFilePathFormat ?? string.Empty;
         string symbolsFilePathFormat = AppleSettings?.SymbolsFilePathFormat ?? string.Empty;
         string moduleMapFilePath = AppleSettings?.ModuleMapFilePath ?? string.Empty;
-        
+
         string minMacOSVersion = AppleSettings?.MinMacOSVersion ?? "1.0";
         string miniOSVersion = AppleSettings?.MiniOSVersion ?? "1.0";
-        
+
         bool mixInSwift = !string.IsNullOrEmpty(swiftLibraryFilePathFormat) &&
                           !string.IsNullOrEmpty(moduleMapFilePath) &&
                           !string.IsNullOrEmpty(symbolsFilePathFormat);
 
         string swiftLibraryFilePath;
         string symbolsFilePath;
-        
+
         if (mixInSwift) {
             swiftLibraryFilePath = string.Format(swiftLibraryFilePathFormat, "$(RuntimeIdentifier)");
             symbolsFilePath = string.Format(symbolsFilePathFormat, "$(RuntimeIdentifier)");
@@ -77,7 +77,7 @@ public class NativeCsProj
         }
 
         StringBuilder assemblyReferencesXmlSb = new();
-        
+
         foreach (var assemblyReference in AssemblyReferences) {
             assemblyReferencesXmlSb.AppendLine($"<Reference Include=\"{assemblyReference}\" />");
         }
@@ -107,21 +107,21 @@ public class NativeCsProj
     }
 
     private const string TOKEN = "$__BEYOND_TOKEN__$";
-    
+
     private const string TOKEN_ASSEMBLY_NAME = $"{TOKEN}AssemblyName{TOKEN}";
     private const string TOKEN_TARGET_FRAMEWORK = $"{TOKEN}TargetFramework{TOKEN}";
     private const string TOKEN_NULLABLE = $"{TOKEN}Nullable{TOKEN}";
     private const string TOKEN_TARGET_ASSEMBLY_FILE_PATH = $"{TOKEN}TargetAssemblyFilePath{TOKEN}";
     private const string TOKEN_ASSEMBLY_REFERENCES = $"{TOKEN}AssemblyReferences{TOKEN}";
     private const string TOKEN_STRIP_SYMBOLS = $"{TOKEN}StripSymbols{TOKEN}";
-    
+
     private const string TOKEN_MIX_IN_SWIFT = $"{TOKEN}MixInSwift{TOKEN}";
     private const string TOKEN_MIN_MACOS_VERSION = $"{TOKEN}MinMacOSVersion{TOKEN}";
     private const string TOKEN_MIN_IOS_VERSION = $"{TOKEN}MiniOSVersion{TOKEN}";
     private const string TOKEN_SWIFT_LIBRARY_FILE_PATH = $"{TOKEN}SwiftLibraryFilePath{TOKEN}";
     private const string TOKEN_SYMBOLS_FILE_PATH = $"{TOKEN}SymbolsFilePath{TOKEN}";
     private const string TOKEN_MODULE_MAP_FILE_PATH = $"{TOKEN}ModuleMapFilePath{TOKEN}";
-    
+
     private const string TOKEN_IOS_SDK_PATH = $"{TOKEN}iOSSDKFilePath{TOKEN}";
     private const string TOKEN_IOS_SIMULATOR_SDK_PATH = $"{TOKEN}iOSSimulatorSDKFilePath{TOKEN}";
 
@@ -138,12 +138,12 @@ public class NativeCsProj
     <PublishAot>true</PublishAot>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    
+
     <StripSymbols>{TOKEN_STRIP_SYMBOLS}</StripSymbols>
 
     <!-- TODO: Disabled for now to get faster build times -->
     <Nullable>{TOKEN_NULLABLE}</Nullable>
-    
+
     <!-- Seems to not be required as long as we're providing the RuntimeIdentifier when calling dotnet publish/build -->
     <!-- <RuntimeIdentifiers>osx-x64;osx-arm64;linux-x64;ios-arm64;iossimulator-arm64;iossimulator-x64</RuntimeIdentifiers> -->
 
@@ -154,11 +154,11 @@ public class NativeCsProj
     <MacOSMinVersion>{TOKEN_MIN_MACOS_VERSION}</MacOSMinVersion>
     <iOSMinVersion>{TOKEN_MIN_IOS_VERSION}</iOSMinVersion>
   </PropertyGroup>
-  
+
   <!-- Compiler Customization -->
 
   <!-- Merge exported Symbols List -->
-  <Target Name="MergeExportedSymbolsList" 
+  <Target Name="MergeExportedSymbolsList"
           BeforeTargets="LinkNative"
           Condition="$(MixInSwift) And ($(RuntimeIdentifier.Contains('osx')) Or $(RuntimeIdentifier.Contains('ios')))">
     <Exec Command="echo '\n' >> '$(ExportsFile)'; cat '{TOKEN_SYMBOLS_FILE_PATH}' >> '$(ExportsFile)'" />
@@ -226,7 +226,7 @@ public class NativeCsProj
       </ItemGroup>
     </When>
   </Choose>
-  
+
   <!-- Item Excludes -->
   <PropertyGroup>
     <DefaultItemExcludes>$(DefaultItemExcludes);.gitignore;*.sln.DotSettings;</DefaultItemExcludes>

--- a/Builder/Beyond.NET.Builder.DotNET/Publish.cs
+++ b/Builder/Beyond.NET.Builder.DotNET/Publish.cs
@@ -7,14 +7,14 @@ public class Publish
     private const string ARGUMENT_VERBOSITY_LEVEL = "-v";
 
     public const string VERBOSITY_LEVEL_NORMAL = "normal";
-    
+
     public const string RUNTIME_IDENTIFIER_MACOS_X64 = "osx-x64";
     public const string RUNTIME_IDENTIFIER_MACOS_ARM64 = "osx-arm64";
 
     public const string RUNTIME_IDENTIFIER_IOS_ARM64 = "ios-arm64";
     public const string RUNTIME_IDENTIFIER_IOS_SIMULATOR_ARM64 = "iossimulator-arm64";
     public const string RUNTIME_IDENTIFIER_IOS_SIMULATOR_X64 = "iossimulator-x64";
-    
+
     public static string Run(
         string workingDirectory,
         string runtimeIdentifier,
@@ -25,7 +25,7 @@ public class Publish
         List<string> args = new(new [] {
             FLAG_PUBLISH
         });
-        
+
         args.AddRange(new [] {
             ARGUMENT_RUNTIME_IDENTIFIER,
             runtimeIdentifier
@@ -47,7 +47,7 @@ public class Publish
             args.ToArray(),
             workingDirectory
         );
-        
+
         Exception? failure = result.FailureAsException;
 
         if (failure is not null) {

--- a/Builder/Beyond.NET.Builder.DotNET/Runtime.cs
+++ b/Builder/Beyond.NET.Builder.DotNET/Runtime.cs
@@ -3,7 +3,7 @@ namespace Beyond.NET.Builder.DotNET;
 public class Runtime
 {
     public const string RUNTIME_NAME_MICROSOFT_NETCORE_APP = "Microsoft.NETCore.App";
-    
+
     public string Name { get; }
     public string Version { get; }
     public string Path { get; }
@@ -18,7 +18,7 @@ public class Runtime
         Version = version ?? throw new ArgumentNullException(nameof(version));
         Path = path ?? throw new ArgumentNullException(nameof(path));
     }
-    
+
     public static Runtime[] GetRuntimes()
     {
         var result = App.DotNETApp.Launch(new[] {
@@ -41,14 +41,14 @@ public class Runtime
         var split = stdOut.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         List<Runtime> runtimes = new();
-        
+
         foreach (var runtimeLine in split) {
             var runtime = WithRuntimeLine(runtimeLine);
 
             if (runtime is null) {
                 continue;
             }
-            
+
             runtimes.Add(runtime);
         }
 
@@ -80,7 +80,7 @@ public class Runtime
             version,
             path
         );
-        
+
         return runtime;
     }
 }

--- a/Builder/Beyond.NET.Builder.DotNET/RuntimeIdentifier.cs
+++ b/Builder/Beyond.NET.Builder.DotNET/RuntimeIdentifier.cs
@@ -4,26 +4,26 @@ public static class RuntimeIdentifier
 {
     public const string MacOS_ARM64 = $"{PlatformIdentifier.macOS}-{TargetIdentifier.ARM64}";
     public const string MacOS_X64 = $"{PlatformIdentifier.macOS}-{TargetIdentifier.x64}";
-    
+
     /// <summary>
     /// Made up, not part of .NET!
     /// </summary>
     public const string MacOS_UNIVERSAL = $"{PlatformIdentifier.macOS}-{TargetIdentifier.UNIVERSAL}";
-    
+
     public const string iOS_ARM64 = $"{PlatformIdentifier.iOS}-{TargetIdentifier.ARM64}";
     public const string iOS_SIMULATOR_ARM64 = $"{PlatformIdentifier.iOSSimulator}-{TargetIdentifier.ARM64}";
     public const string iOS_SIMULATOR_X64 = $"{PlatformIdentifier.iOSSimulator}-{TargetIdentifier.x64}";
-    
+
     /// <summary>
     /// Made up, not part of .NET!
     /// </summary>
     public const string iOS_SIMULATOR_UNIVERSAL = $"{PlatformIdentifier.iOSSimulator}-{TargetIdentifier.UNIVERSAL}";
-    
+
     /// <summary>
     /// Made up, not part of .NET!
     /// </summary>
     public const string iOS_UNIVERSAL = $"{PlatformIdentifier.iOS}-{TargetIdentifier.UNIVERSAL}";
-    
+
     /// <summary>
     /// Made up, not part of .NET!
     /// </summary>

--- a/Builder/Beyond.NET.Builder.DotNET/TargetIdentifier.cs
+++ b/Builder/Beyond.NET.Builder.DotNET/TargetIdentifier.cs
@@ -4,7 +4,7 @@ public static class TargetIdentifier
 {
     public const string ARM64 = "arm64";
     public const string x64 = "x64";
-    
+
     /// <summary>
     /// Made up, not part of .NET!
     /// </summary>

--- a/Builder/Beyond.NET.Builder.DotNET/Version.cs
+++ b/Builder/Beyond.NET.Builder.DotNET/Version.cs
@@ -32,7 +32,7 @@ public class Version
         }
 
         var versionSplit = version.Split(
-            '.', 
+            '.',
             StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
         );
 

--- a/Builder/Beyond.NET.Builder/BuildTargets.cs
+++ b/Builder/Beyond.NET.Builder/BuildTargets.cs
@@ -4,17 +4,17 @@ namespace Beyond.NET.Builder;
 public enum BuildTargets
 {
     None =                  0,
-        
+
     MacOSARM64 =            1 << 0,
     MacOSX64 =              1 << 1,
     iOSARM64 =              1 << 2,
     iOSSimulatorARM64 =     1 << 3,
     iOSSimulatorX64 =       1 << 4,
-        
+
     MacOSUniversal = MacOSARM64 | MacOSX64,
     iOSSimulatorUniversal = iOSSimulatorARM64 | iOSSimulatorX64,
     iOSUniversal = iOSARM64 | iOSSimulatorUniversal,
-        
+
     AppleUniversal = MacOSUniversal | iOSUniversal
 }
 
@@ -26,13 +26,13 @@ internal static class BuildTargets_Extensions
                buildTargets.HasFlag(BuildTargets.iOSSimulatorARM64) ||
                buildTargets.HasFlag(BuildTargets.iOSSimulatorX64);
     }
-    
+
     public static bool ContainsAnyiOSSimulatorTarget(this BuildTargets buildTargets)
     {
         return buildTargets.HasFlag(BuildTargets.iOSSimulatorARM64) ||
                buildTargets.HasFlag(BuildTargets.iOSSimulatorX64);
     }
-    
+
     public static bool ContainsAnyMacOSTarget(this BuildTargets buildTargets)
     {
         return buildTargets.HasFlag(BuildTargets.MacOSARM64) ||

--- a/Core/Beyond.NET.Core/Apple/LibSystem.cs
+++ b/Core/Beyond.NET.Core/Apple/LibSystem.cs
@@ -14,11 +14,11 @@ internal class LibSystem
         RTLD_NODELETE 	= 0x80,
         RTLD_FIRST 		= 0x100
     }
-    
+
     internal static class DL
     {
         internal const string LIBRARY_SYSTEM = "/usr/lib/libSystem.dylib";
-        
+
         [DllImport(LIBRARY_SYSTEM)]
         internal static extern int dlclose(IntPtr handle);
 

--- a/Core/Beyond.NET.Core/Apple/NSObject.cs
+++ b/Core/Beyond.NET.Core/Apple/NSObject.cs
@@ -3,20 +3,20 @@ namespace Beyond.NET.Core;
 public class NSObject: IDisposable
 {
     internal nint m_instance;
-    
+
     private static nint CLASS => ObjCInterop.objc_getClass("NSObject");
-    
+
     internal static nint SELECTOR_ALLOC => ObjCInterop.sel_registerName("alloc");
     internal static nint SELECTOR_INIT => ObjCInterop.sel_registerName("init");
     internal static nint SELECTOR_RETAIN => ObjCInterop.sel_registerName("retain");
     internal static nint SELECTOR_RELEASE => ObjCInterop.sel_registerName("release");
-    
+
     internal NSObject(nint instance)
     {
         if (instance == nint.Zero) {
             throw new Exception($"Passed in {nameof(NSObject)} reference is null");
         }
-        
+
         m_instance = instance;
     }
 
@@ -36,7 +36,7 @@ public class NSObject: IDisposable
     {
         return Alloc(CLASS);
     }
-    
+
     protected static nint Alloc(nint klass)
     {
         var allocedObj = ObjCInterop.objc_msgSend_RetPtr(
@@ -50,7 +50,7 @@ public class NSObject: IDisposable
 
         return allocedObj;
     }
-    
+
     protected static nint Init(nint obj)
     {
         var initedObj = ObjCInterop.objc_msgSend_RetPtr(
@@ -70,7 +70,7 @@ public class NSObject: IDisposable
         if (m_instance == nint.Zero) {
             return;
         }
-        
+
         ObjCInterop.objc_msgSend_RetPtr(
             m_instance,
             SELECTOR_RETAIN
@@ -81,11 +81,11 @@ public class NSObject: IDisposable
     {
         var instance = m_instance;
         m_instance = nint.Zero;
-        
+
         if (instance == nint.Zero) {
             return;
         }
-        
+
         ObjCInterop.objc_msgSend_RetNone(
             instance,
             SELECTOR_RELEASE

--- a/Core/Beyond.NET.Core/Apple/NSString.cs
+++ b/Core/Beyond.NET.Core/Apple/NSString.cs
@@ -5,7 +5,7 @@ namespace Beyond.NET.Core;
 public class NSString: NSObject
 {
     private static nint CLASS => ObjCInterop.objc_getClass("NSString");
-    
+
     private static nint SELECTOR_INITWITHUTF8STRING => ObjCInterop.sel_registerName("initWithUTF8String:");
     private static nint SELECTOR_UTF8STRING => ObjCInterop.sel_registerName("UTF8String");
     private static nint SELECTOR_STRINGBYRESOLVINGSYMLINKSINPATH = ObjCInterop.sel_registerName("stringByResolvingSymlinksInPath");
@@ -13,20 +13,20 @@ public class NSString: NSObject
     internal NSString(nint instance) : base(instance)
     {
     }
-    
+
     public NSString(string str)
     {
         var allocedNSString = Alloc(CLASS);
 
         var cString = nint.Zero;
-        
+
         try {
             cString = Marshal.StringToHGlobalAuto(str);
 
             if (cString == nint.Zero) {
                 throw new Exception("Failed to convert System.String to C String");
             }
-            
+
             var initedNSString = ObjCInterop.objc_msgSend_RetPtr_1ArgPtr(
                 allocedNSString,
                 SELECTOR_INITWITHUTF8STRING,
@@ -47,7 +47,7 @@ public class NSString: NSObject
             m_instance = initedNSString;
         } finally {
             if (cString != nint.Zero) {
-                Marshal.FreeHGlobal(cString); 
+                Marshal.FreeHGlobal(cString);
                 cString = nint.Zero;
             }
         }
@@ -73,7 +73,7 @@ public class NSString: NSObject
                 resolvedNSStringInstance,
                 SELECTOR_RETAIN
             );
-            
+
             if (retainedResolvedNSString == nint.Zero) {
                 return null;
             }

--- a/Core/Beyond.NET.Core/Apple/NSURL.cs
+++ b/Core/Beyond.NET.Core/Apple/NSURL.cs
@@ -5,7 +5,7 @@ namespace Beyond.NET.Core;
 public class NSURL: NSObject
 {
     private static nint CLASS => ObjCInterop.objc_getClass("NSURL");
-    
+
     private static nint SELECTOR_FILEURLWITHPATH = ObjCInterop.sel_registerName("fileURLWithPath:");
     private static nint SELECTOR_PATH = ObjCInterop.sel_registerName("path");
     private static nint SELECTOR_GETRESOURCEVALUEFORKEYERROR = ObjCInterop.sel_registerName("getResourceValue:forKey:error:");
@@ -14,7 +14,7 @@ public class NSURL: NSObject
     {
         get {
             nint foundationFrameworkHandle = nint.Zero;
-            
+
             try {
                 foundationFrameworkHandle = ObjCInterop.LoadFramework("/System/Library/Frameworks/Foundation.framework/Foundation");
 
@@ -26,7 +26,7 @@ public class NSURL: NSObject
 
                         if (inst != nint.Zero) {
                             var key = new NSString(inst);
-    
+
                             return key;
                         }
                     }
@@ -40,7 +40,7 @@ public class NSURL: NSObject
             throw new Exception($"Failed to get {nameof(NSURLCanonicalPathKey)}");
         }
     }
-    
+
     internal NSURL(nint instance) : base(instance)
     {
     }
@@ -56,9 +56,9 @@ public class NSURL: NSObject
         if (urlInst == nint.Zero) {
             throw new Exception($"Failed to initialize {nameof(NSURL)} with {nameof(NSString)}");
         }
-        
+
         m_instance = urlInst;
-        
+
         Retain();
     }
 
@@ -68,7 +68,7 @@ public class NSURL: NSObject
             if (m_instance == nint.Zero) {
                 throw new Exception($"{nameof(NSURL)} is null");
             }
-            
+
             var pathInst = ObjCInterop.objc_msgSend_RetPtr(
                 m_instance,
                 SELECTOR_PATH
@@ -87,7 +87,7 @@ public class NSURL: NSObject
     public NSString? GetResourceValue(NSString urlResourceKey)
     {
         var valuePtr = Marshal.AllocHGlobal(nint.Size);
-        
+
         try {
             var success = ObjCInterop.objc_msgSend_RetBool_3ArgPtr(
                 m_instance,

--- a/Core/Beyond.NET.Core/Apple/ObjCInterop.cs
+++ b/Core/Beyond.NET.Core/Apple/ObjCInterop.cs
@@ -9,17 +9,17 @@ internal class ObjCInterop
 
 	[DllImport(PATH_LIBOBJC)]
 	internal static extern IntPtr sel_registerName(string str);
-	
+
 	[DllImport(PATH_LIBOBJC)]
 	internal static extern IntPtr objc_getClass(string name);
-	
+
 	[DllImport(PATH_LIBOBJC, EntryPoint = ENTRYPOINT_OBJC_MSGSEND)]
 	internal static extern IntPtr objc_msgSend_RetPtr_1ArgPtr(
 		IntPtr target,
 		IntPtr selector,
 		IntPtr arg1
 	);
-	
+
 	[DllImport(PATH_LIBOBJC, EntryPoint = ENTRYPOINT_OBJC_MSGSEND)]
 	internal static extern byte objc_msgSend_RetBool_3ArgPtr(
 		IntPtr target,
@@ -28,13 +28,13 @@ internal class ObjCInterop
 		IntPtr arg2,
 		IntPtr arg3
 	);
-	
+
 	[DllImport(PATH_LIBOBJC, EntryPoint = ENTRYPOINT_OBJC_MSGSEND)]
 	internal static extern void objc_msgSend_RetNone(
 		IntPtr target,
 		IntPtr selector
 	);
-	
+
 	[DllImport(PATH_LIBOBJC, EntryPoint = ENTRYPOINT_OBJC_MSGSEND)]
 	internal static extern IntPtr objc_msgSend_RetPtr(
 		IntPtr target,
@@ -47,7 +47,7 @@ internal class ObjCInterop
 
 		if (handle == nint.Zero) {
 			var error = LibSystem.DL.Error;
-			
+
 			throw new Exception($"Failed to load framework at \"{path}\": {error}");
 		}
 

--- a/Core/Beyond.NET.Core/CLIApp.cs
+++ b/Core/Beyond.NET.Core/CLIApp.cs
@@ -11,7 +11,7 @@ public class CLIApp
         public string? WorkingDirectory { get; }
         public int ExitCode { get; }
         public Exception? LaunchException { get; init; }
-        
+
         public string? StandardOut { get; init; }
         public string? StandardError { get; init; }
 
@@ -19,14 +19,14 @@ public class CLIApp
         {
             get {
                 Exception innerException;
-                
+
                 if (LaunchException is not null) {
                     innerException = LaunchException;
                 } else if (!string.IsNullOrEmpty(StandardError)) {
                     innerException = new Exception(StandardError);
                 } else if (ExitCode != 0) {
                     if (!string.IsNullOrEmpty(StandardOut)) {
-                        innerException = new Exception(StandardOut);    
+                        innerException = new Exception(StandardOut);
                     } else {
                         innerException = new Exception("Unknown Error");
                     }
@@ -43,7 +43,7 @@ public class CLIApp
                 }
 
                 var ex = new Exception(
-                    msg, 
+                    msg,
                     innerException
                 );
 
@@ -61,7 +61,7 @@ public class CLIApp
             WorkingDirectory = workingDirectory;
             ExitCode = exitCode;
         }
-        
+
         public Result(
             string invocation,
             string? workingDirectory,
@@ -76,7 +76,7 @@ public class CLIApp
             StandardOut = standardOut;
             StandardError = standardError;
         }
-        
+
         public Result(
             string invocation,
             string? workingDirectory,
@@ -91,27 +91,27 @@ public class CLIApp
     }
 
     private ILogger Logger => Services.Shared.LoggerService;
-    
+
     public string Command { get; init; }
 
     public CLIApp(string command)
     {
         Command = command;
     }
-    
+
     public Result Launch(
         string[]? arguments,
         string? workingDirectory = null
     )
     {
         int timeout = int.MaxValue;
-        
+
         var startInfo = MakeStartInfo(
             arguments,
             workingDirectory,
             out string invocationString
         );
-        
+
         string logMsg;
 
         if (!string.IsNullOrEmpty(workingDirectory)) {
@@ -119,7 +119,7 @@ public class CLIApp
         } else {
             logMsg = $"Running command \"{invocationString}\"";
         }
-        
+
         Logger.LogDebug(logMsg);
 
         try {
@@ -136,7 +136,7 @@ public class CLIApp
 
             using var stdOutWaitHandle = new AutoResetEvent(false);
             using var stdErrWaitHandle = new AutoResetEvent(false);
-            
+
             process.OutputDataReceived += (_, e) => {
                 if (e.Data is null) {
                     stdOutWaitHandle.Set();

--- a/Core/Beyond.NET.Core/ConsoleLogger.cs
+++ b/Core/Beyond.NET.Core/ConsoleLogger.cs
@@ -21,7 +21,7 @@ public struct ConsoleLogger: ILogger
     {
         Log(message, LoggingLevel.Error);
     }
-    
+
     internal enum LoggingLevel
     {
         Debug,
@@ -50,7 +50,7 @@ public struct ConsoleLogger: ILogger
             message,
             loggingLevel
         );
-        
+
         Console.WriteLine(fullMessage);
     }
 }

--- a/Core/Beyond.NET.Core/FileSystemUtils.cs
+++ b/Core/Beyond.NET.Core/FileSystemUtils.cs
@@ -15,7 +15,7 @@ public static class FileSystemUtils
             true
         );
     }
-    
+
     private static void CopyDirectoryContents(
         string sourceDirectoryPath,
         string destinationDirectoryPath,
@@ -25,15 +25,15 @@ public static class FileSystemUtils
     {
         // Get information about the source directory
         var sourceDirectory = new DirectoryInfo(sourceDirectoryPath);
-        
+
         // Check if the source directory exists
         if (!sourceDirectory.Exists) {
             throw new DirectoryNotFoundException($"Source directory not found: {sourceDirectory.FullName}");
         }
-        
+
         // Cache directories before we start copying
         var sourceDirectories = sourceDirectory.GetDirectories();
-        
+
         if (!Directory.Exists(destinationDirectoryPath)) {
             // Destination directory does not exist, create it
             Directory.CreateDirectory(destinationDirectoryPath);
@@ -52,7 +52,7 @@ public static class FileSystemUtils
                     // Target file already exists, delete it
                     targetFile.Delete();
                 }
-                
+
                 // Re-create link
                 targetFile.CreateAsSymbolicLink(linkTarget);
             } else { // Regular file
@@ -68,7 +68,7 @@ public static class FileSystemUtils
         if (recursive) {
             foreach (DirectoryInfo sourceSubDirectory in sourceDirectories) {
                 var destinationSubDirectoryPath = Path.Combine(destinationDirectoryPath, sourceSubDirectory.Name);
-                
+
                 var targetSubDirectory = new DirectoryInfo(destinationSubDirectoryPath);
 
                 var linkTarget = sourceSubDirectory.LinkTarget;
@@ -78,7 +78,7 @@ public static class FileSystemUtils
                         // Target directory already exists, delete it
                         targetSubDirectory.Delete();
                     }
-                
+
                     // Re-create link
                     targetSubDirectory.CreateAsSymbolicLink(linkTarget);
                 } else { // Regular directory
@@ -87,7 +87,7 @@ public static class FileSystemUtils
                         // On the first level, delete any existing directories
                         targetSubDirectory.Delete(true);
                     }
-                    
+
                     // Copy directory
                     CopyDirectoryContents(
                         sourceSubDirectory.FullName,

--- a/Core/Beyond.NET.Core/StringExtensions.cs
+++ b/Core/Beyond.NET.Core/StringExtensions.cs
@@ -10,7 +10,7 @@ public static class StringExtensions
 
         return absoluteExpandedPath;
     }
-    
+
     public static string ExpandTildeInPath(this string path)
     {
         string expandedPath = path.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
@@ -31,14 +31,14 @@ public static class StringExtensions
     public static string ResolveSymlinksAndGetCanonicalPath_AppleOnly(this string path)
     {
         string? resolvedPath = null;
-		
+
         using (NSString unresolvedPathNS = new(path)) {
             using (NSString? resolvedPathNS = unresolvedPathNS.StringByResolvingSymlinksInPath) {
                 if (resolvedPathNS is not null) {
                     using (NSURL url = new(resolvedPathNS)) {
                         using (var canonicalPathKey = NSURL.NSURLCanonicalPathKey) {
                             var canonicalPathKeyStr = canonicalPathKey.UTF8String;
-    
+
                             if (!string.IsNullOrEmpty(canonicalPathKeyStr)) {
                                 using (NSString? canonicalPath = url.GetResourceValue(canonicalPathKey)) {
                                     if (canonicalPath is not null) {
@@ -55,37 +55,37 @@ public static class StringExtensions
         if (string.IsNullOrEmpty(resolvedPath)) {
             resolvedPath = path;
         }
-        
+
         return resolvedPath;
     }
-    
+
     public static string SanitizedProductNameForTempDirectory(this string productName)
     {
         return productName
             .Replace(' ', '_')
             .Replace('.', '_');
     }
-    
+
     public static string IndentAllLines(this string text, int indentCount)
     {
         if (indentCount < 1) {
             return text;
         }
-        
+
         string newLine = Environment.NewLine;
-        
+
         string indentPrefix = string.Empty;
 
         for (int i = 0; i < indentCount; i++) {
             indentPrefix += "\t";
         }
-        
+
         var lines = text.Split(newLine);
         List<string> indentedLines = new();
 
         foreach (var line in lines) {
             string indentedLine = indentPrefix + line;
-            
+
             indentedLines.Add(indentedLine);
         }
 
@@ -93,22 +93,22 @@ public static class StringExtensions
 
         return indentedText;
     }
-    
+
     public static string PrefixAllLines(this string text, string prefixText)
     {
         if (string.IsNullOrEmpty(prefixText) ||
             string.IsNullOrEmpty(text)) {
             return text;
         }
-        
+
         string newLine = Environment.NewLine;
-        
+
         var lines = text.Split(newLine);
         List<string> prefixedLines = new();
 
         foreach (var line in lines) {
             string prefixedLine = prefixText + line;
-            
+
             prefixedLines.Add(prefixedLine);
         }
 

--- a/Core/Beyond.NET.Core/Which.cs
+++ b/Core/Beyond.NET.Core/Which.cs
@@ -6,18 +6,18 @@ public class Which
 {
     private static readonly CLIApp WhichApp = new("which");
 
-    private static ConcurrentDictionary<string, string> m_cache = new(); 
+    private static ConcurrentDictionary<string, string> m_cache = new();
 
     public static string GetAbsoluteCommandPath(string command)
     {
         if (m_cache.TryGetValue(command, out string? cachedResult)) {
             return cachedResult;
         }
-        
+
         var result = WhichApp.Launch(new[] {
             command
         });
-        
+
         Exception? failure = result.FailureAsException;
 
         if (failure is not null) {

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Beyond.NET.CodeGenerator.CLI.csproj
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Beyond.NET.CodeGenerator.CLI.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <StripSymbols>true</StripSymbols>
   </PropertyGroup>
-  
+
   <!-- Project References -->
   <ItemGroup>
     <ProjectReference Include="..\..\Builder\Beyond.NET.Builder\Beyond.NET.Builder.csproj" />

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/ArgumentParser.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/ArgumentParser.cs
@@ -7,7 +7,7 @@ internal class ArgumentParser
     internal class Result
     {
         internal string AssemblyPath { get; }
-        
+
         internal string? CSharpUnmanagedOutputPath { get; }
         internal string? COutputPath { get; }
 
@@ -24,18 +24,18 @@ internal class ArgumentParser
     }
 
     internal static bool TryParse(
-        string[] args, 
+        string[] args,
         [NotNullWhen(true)] out Result? result
     )
     {
         result = null;
-        
+
         const string cSharpFileExtension = ".cs";
         const string cHeaderFileExtension = ".h";
 
         string? cSharpUnmanagedOutputPath = null;
         string? cOutputPath = null;
-        
+
         if (args.Length <= 0) {
             return false;
         }
@@ -49,7 +49,7 @@ internal class ArgumentParser
         if (args.Length > 1) {
             for (int i = 1; i < args.Length; i++) {
                 string path = args[i].Trim();
-    
+
                 if (path.EndsWith(cSharpFileExtension, StringComparison.InvariantCultureIgnoreCase)) {
                     cSharpUnmanagedOutputPath = path;
                 } else if (path.EndsWith(cHeaderFileExtension, StringComparison.InvariantCultureIgnoreCase)) {

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/AssemblyLoader.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/AssemblyLoader.cs
@@ -15,8 +15,8 @@ internal class AssemblyEventArgs: EventArgs
     )
     {
         Assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
-        
-        AssemblyPath = !string.IsNullOrEmpty(assemblyPath) 
+
+        AssemblyPath = !string.IsNullOrEmpty(assemblyPath)
             ? assemblyPath
             : throw new ArgumentOutOfRangeException(nameof(assemblyPath));
     }
@@ -26,15 +26,15 @@ internal class AssemblyLoader: IDisposable
 {
     private readonly List<string> m_searchPaths = new();
 
-    internal event EventHandler<AssemblyEventArgs>? GetDocumentation; 
+    internal event EventHandler<AssemblyEventArgs>? GetDocumentation;
     internal event EventHandler<AssemblyEventArgs>? AssemblyResolved;
 
     internal AssemblyLoader() : this(Array.Empty<string>()) { }
-    
+
     internal AssemblyLoader(IEnumerable<string> searchPaths)
     {
         m_searchPaths.AddRange(GetAssemblySearchPaths(searchPaths));
-        
+
         AppDomain.CurrentDomain.AssemblyResolve += AppDomain_OnAssemblyResolve;
     }
 
@@ -46,18 +46,18 @@ internal class AssemblyLoader: IDisposable
             !m_searchPaths.Contains(assemblyDirectoryPath)) {
             m_searchPaths.Add(assemblyDirectoryPath);
         }
-        
+
         Assembly assembly = Assembly.LoadFrom(assemblyPath);
-        
+
         GetDocumentation?.Invoke(this, new(assembly, assemblyPath));
 
         return assembly;
     }
-    
+
     /* internal IEnumerable<Assembly> LoadReferences(Assembly assembly)
     {
         HashSet<Assembly> references = new();
-        
+
         var referencedAssemblies = assembly.GetReferencedAssemblies();
 
         foreach (var referencedAssemblyNameObject in referencedAssemblies) {
@@ -74,7 +74,7 @@ internal class AssemblyLoader: IDisposable
 
         return references;
     } */
-    
+
     private Assembly? AppDomain_OnAssemblyResolve(object? sender, ResolveEventArgs args)
     {
         string assemblyFullName = args.Name;
@@ -88,10 +88,10 @@ internal class AssemblyLoader: IDisposable
         if (!assemblyName.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase)) {
             assemblyName += ".dll";
         }
-        
+
         try {
             Assembly assembly = Assembly.LoadFrom(assemblyName);
-            
+
             GetDocumentation?.Invoke(this, new(assembly, assemblyName));
 
             return assembly;
@@ -104,7 +104,7 @@ internal class AssemblyLoader: IDisposable
 
                 try {
                     Assembly assembly = Assembly.LoadFrom(potentialAssemblyPath);
-                    
+
                     AssemblyResolved?.Invoke(this, new(assembly, potentialAssemblyPath));
                     GetDocumentation?.Invoke(this, new(assembly, potentialAssemblyPath));
 
@@ -117,14 +117,14 @@ internal class AssemblyLoader: IDisposable
 
         return null;
     }
-    
+
     private static IEnumerable<string> GetAssemblySearchPaths(IEnumerable<string> configuredSearchPaths)
     {
         List<string> searchPaths = new();
 
         foreach (string searchPath in configuredSearchPaths) {
             string expandedSearchPath = searchPath.ExpandTildeAndGetAbsolutePath();
-            
+
             searchPaths.Add(expandedSearchPath);
         }
 
@@ -134,7 +134,7 @@ internal class AssemblyLoader: IDisposable
 
         if (!string.IsNullOrEmpty(processPath)) {
             string? processDirectoryPath = Path.GetDirectoryName(processPath);
-    
+
             if (!string.IsNullOrEmpty(processDirectoryPath)) {
                 if (!searchPaths.Contains(processDirectoryPath)) {
                     searchPaths.Add(processDirectoryPath);

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/BuildConfiguration.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/BuildConfiguration.cs
@@ -3,14 +3,14 @@ namespace Beyond.NET.CodeGenerator.CLI;
 public record BuildConfiguration
 (
     string Target,
-    
+
     string? ProductName,
     string? ProductBundleIdentifier,
     string? ProductOutputPath,
-    
+
     string? MacOSDeploymentTarget,
     string? iOSDeploymentTarget,
-    
+
     bool DisableParallelBuild,
     bool DisableStripDotNETSymbols
 );

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/Configuration.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/Configuration.cs
@@ -2,28 +2,28 @@ namespace Beyond.NET.CodeGenerator.CLI;
 
 public record Configuration(
     string AssemblyPath,
-    
+
     BuildConfiguration? Build,
-    
+
     string? CSharpUnmanagedOutputPath,
     string? COutputPath,
     string? SwiftOutputPath,
     string? KotlinOutputPath,
-    
+
     string? KotlinPackageName,
     string? KotlinNativeLibraryName,
-    
+
     bool? EmitUnsupported,
     bool? GenerateTypeCheckedDestroyMethods,
     bool? EnableGenericsSupport,
     bool? DoNotGenerateSwiftNestedTypeAliases,
     bool? DoNotGenerateDocumentation,
     bool? DoNotDeleteTemporaryDirectories,
-    
+
     string[]? IncludedTypeNames,
     string[]? ExcludedTypeNames,
-    
+
     string[]? ExcludedAssemblyNames,
-    
+
     string[]? AssemblySearchPaths
 );

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/ConfigurationSerializer.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/ConfigurationSerializer.cs
@@ -19,7 +19,7 @@ internal class ConfigurationSerializer
 
         return configuration;
     }
-    
+
     internal Configuration? DeserializeFromJsonFilePath(string jsonFilePath)
     {
         string jsonString = File.ReadAllText(jsonFilePath);

--- a/Generator/Beyond.NET.CodeGenerator.CLI/Source/Program.cs
+++ b/Generator/Beyond.NET.CodeGenerator.CLI/Source/Program.cs
@@ -15,32 +15,32 @@ static class Program
         }
 
         ConfigurationSerializer serializer = new();
-        
-        Configuration configuration = serializer.DeserializeFromJsonFilePath(configFilePath) 
+
+        Configuration configuration = serializer.DeserializeFromJsonFilePath(configFilePath)
                                       ?? throw new Exception("Error while parsing configuration file.");
 
         CodeGeneratorDriver driver = new(configuration);
-        
+
         driver.Generate();
 
         return 0;
     }
-    
+
     private static void ShowUsage()
     {
         var assemblyInfo = typeof(Program).Assembly.GetName();
 
         const string productName = "Beyond.NET";
         string assemblyName = assemblyInfo.Name ?? "beyondnetgen";
-        
+
         Version? version = assemblyInfo.Version;
         string versionString = version?.ToString() ?? "N/A";
-        
+
         string usageText = $"""
 {productName} Version {versionString}
 Usage: {assemblyName} <PathToConfig.json>
 """;
-        
-        Console.WriteLine(usageText);    
+
+        Console.WriteLine(usageText);
     }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Collectors/ParameterlessStructConstructor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Collectors/ParameterlessStructConstructor.cs
@@ -12,25 +12,25 @@ public class ParameterlessStructConstructorInfo: ConstructorInfo
         if (!declaringType.IsStruct()) {
             throw new Exception("Declaring Type must be a struct");
         }
-        
+
         DeclaringType = declaringType;
     }
-    
+
     public override Type DeclaringType { get; }
     public override string Name => ".ctor";
     public override ParameterInfo[] GetParameters() => Array.Empty<ParameterInfo>();
-    
-    public override MethodAttributes Attributes => MethodAttributes.FamANDAssem | 
+
+    public override MethodAttributes Attributes => MethodAttributes.FamANDAssem |
                                                    MethodAttributes.Family |
                                                    MethodAttributes.Public |
                                                    MethodAttributes.HideBySig |
                                                    MethodAttributes.SpecialName |
                                                    MethodAttributes.RTSpecialName;
-    
+
     public override object[] GetCustomAttributes(bool inherit) => Array.Empty<object>();
     public override object[] GetCustomAttributes(Type attributeType, bool inherit) => Array.Empty<object>();
     public override bool IsDefined(Type attributeType, bool inherit) => false;
-    
+
     public override Type ReflectedType => throw new NotImplementedException();
     public override MethodImplAttributes GetMethodImplementationFlags() => throw new NotImplementedException();
     public override RuntimeMethodHandle MethodHandle => throw new NotImplementedException();

--- a/Generator/Beyond.NET.CodeGenerator/Collectors/TypeCollector.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Collectors/TypeCollector.cs
@@ -43,7 +43,7 @@ public class TypeCollector
         typeof(System.Runtime.InteropServices.GCHandle),
         typeof(System.ReadOnlySpan<byte>)
     };
-    
+
     private static readonly Type[] UNSUPPORTED_TYPES = new [] {
         typeof(System.Runtime.CompilerServices.DefaultInterpolatedStringHandler),
         typeof(System.Runtime.InteropServices.ComTypes.ITypeInfo),
@@ -77,7 +77,7 @@ public class TypeCollector
     private readonly Type[] m_excludedTypes;
     private readonly HashSet<string> m_excludedFullAssemblyNames;
     private readonly HashSet<string> m_excludedSimpleAssemblyNames;
-    
+
     public TypeCollector(
         Assembly? assembly,
         TypeCollectorSettings settings
@@ -85,7 +85,7 @@ public class TypeCollector
     {
         List<Type> whitelist = new(INCLUDED_TYPES);
         whitelist.AddRange(settings.IncludedTypes);
-        
+
         List<Type> blacklist = new(UNSUPPORTED_TYPES);
         blacklist.AddRange(settings.ExcludedTypes);
 
@@ -94,7 +94,7 @@ public class TypeCollector
 
         m_excludedFullAssemblyNames = settings.ExcludedFullAssemblyNames;
         m_excludedSimpleAssemblyNames = settings.ExcludedSimpleAssemblyNames;
-        
+
         m_assembly = assembly;
         EnableGenericsSupport = settings.EnableGenericsSupport;
     }
@@ -105,7 +105,7 @@ public class TypeCollector
         unsupportedTypes = new();
 
         List<Type> typesToCollect = new(m_includedTypes);
-        
+
         var assemblyTypes = m_assembly?.ExportedTypes;
 
         if (assemblyTypes is not null) {
@@ -132,32 +132,32 @@ public class TypeCollector
         if (m_excludedTypes.Contains(type) &&
             !m_includedTypes.Contains(type)) {
             unsupportedTypes[type] = "Excluded";
-            
+
             return;
         }
 
         var assemblyName = type.Assembly.GetName();
-        
+
         var fullNameOfAssemblyName = assemblyName.FullName;
-        
+
         if (m_excludedFullAssemblyNames.Contains(fullNameOfAssemblyName)) {
             unsupportedTypes[type] = $"Excluded by assembly name '{fullNameOfAssemblyName}'";
 
             return;
         }
-        
+
         var nameOfAssemblyName = assemblyName.Name;
-        
+
         if (!string.IsNullOrEmpty(nameOfAssemblyName) &&
             m_excludedSimpleAssemblyNames.Contains(nameOfAssemblyName)) {
             unsupportedTypes[type] = $"Excluded by assembly name '{nameOfAssemblyName}'";
 
             return;
         }
-        
+
         if (!IsSupportedType(type, out string? unsupportedReason)) {
             unsupportedTypes[type] = unsupportedReason ?? string.Empty;
-            
+
             return;
         }
 
@@ -189,7 +189,7 @@ public class TypeCollector
 
         if (!added) {
             // Already added, so skip this type
-            
+
             return;
         }
 
@@ -222,13 +222,13 @@ public class TypeCollector
                 unsupportedTypes
             );
         } else {
-            BindingFlags getMembersFlags = BindingFlags.Public | 
+            BindingFlags getMembersFlags = BindingFlags.Public |
                                            BindingFlags.DeclaredOnly |
                                            BindingFlags.Instance |
                                            BindingFlags.Static;
-    
+
             var memberInfos = type.GetMembers(getMembersFlags);
-    
+
             foreach (var memberInfo in memberInfos) {
                 CollectMember(
                     memberInfo,
@@ -248,30 +248,30 @@ public class TypeCollector
         switch (memberInfo.MemberType) {
             case MemberTypes.Constructor:
                 CollectConstructor((ConstructorInfo)memberInfo, collectedTypes, unsupportedTypes);
-                
+
                 break;
             case MemberTypes.Method:
                 CollectMethod((MethodInfo)memberInfo, collectedTypes, unsupportedTypes);
-                
+
                 break;
             case MemberTypes.Property:
                 CollectProperty((PropertyInfo)memberInfo, collectedTypes, unsupportedTypes);
-                
+
                 break;
             case MemberTypes.Field:
                 CollectField((FieldInfo)memberInfo, collectedTypes, unsupportedTypes);
-                
+
                 break;
             case MemberTypes.Event:
                 CollectEvent((EventInfo)memberInfo, collectedTypes, unsupportedTypes);
-                
+
                 break;
         }
     }
 
     private void CollectConstructor(
         ConstructorInfo constructorInfo,
-        HashSet<Type> collectedTypes, 
+        HashSet<Type> collectedTypes,
         Dictionary<Type, string> unsupportedTypes
     )
     {
@@ -281,7 +281,7 @@ public class TypeCollector
             CollectParameter(parameterInfo, collectedTypes, unsupportedTypes);
         }
     }
-    
+
     private void CollectMethod(
         MethodInfo methodInfo,
         HashSet<Type> collectedTypes,
@@ -291,7 +291,7 @@ public class TypeCollector
         Type returnType = methodInfo.ReturnType;
 
         CollectType(returnType, collectedTypes, unsupportedTypes);
-        
+
         var parameterInfos = methodInfo.GetParameters();
 
         foreach (var parameterInfo in parameterInfos) {
@@ -310,14 +310,14 @@ public class TypeCollector
         if (invokeMethod is null) {
             return;
         }
-        
+
         CollectMethod(
             invokeMethod,
             collectedTypes,
             unsupportedTypes
         );
     }
-    
+
     private void CollectProperty(
         PropertyInfo propertyInfo,
         HashSet<Type> collectedTypes,
@@ -328,7 +328,7 @@ public class TypeCollector
 
         CollectType(propertyType, collectedTypes, unsupportedTypes);
     }
-    
+
     private void CollectField(
         FieldInfo fieldInfo,
         HashSet<Type> collectedTypes,
@@ -339,7 +339,7 @@ public class TypeCollector
 
         CollectType(fieldType, collectedTypes, unsupportedTypes);
     }
-    
+
     private void CollectEvent(
         EventInfo eventInfo,
         HashSet<Type> collectedTypes,
@@ -368,14 +368,14 @@ public class TypeCollector
     {
         return IsSupportedType(type, out _);
     }
-    
+
     public bool IsSupportedType(
         Type type,
         out string? unsupportedReason
     )
     {
         unsupportedReason = null;
-        
+
         if (type.IsByRef) {
             Type nonByRefType = type.GetNonByRefType();
 
@@ -384,7 +384,7 @@ public class TypeCollector
 
                 if (!isNonByRefTypeSupported) {
                     unsupportedReason = innerUnsupportedReason;
-                    
+
                     return false;
                 }
             }
@@ -405,7 +405,7 @@ public class TypeCollector
         //     unsupportedReason = $"Is Nullable Value Type ({nullableValueType.FullName}?)";
         //     return false;
         // }
-        
+
         if (isNullableValueType &&
             !isNullableStruct) {
             unsupportedReason = $"Is Nullable Value Type, but not a struct ({nullableValueType?.FullName}?)";
@@ -427,7 +427,7 @@ public class TypeCollector
             unsupportedReason = "Is Generic Delegate Type";
             return false;
         }
-        
+
         // TODO: Generic Types as arguments, properties, etc.
         if (!isNullableValueType &&
             !isReadOnlySpanOfByte &&
@@ -438,7 +438,7 @@ public class TypeCollector
                 unsupportedReason = "Is unsupported Type";
                 return false;
             }
-            
+
             if (type.ContainsNonConstructedGenericTypes()) {
                 unsupportedReason = "Is Constructed Generic Type with non-constructed generic types";
                 return false;
@@ -460,7 +460,7 @@ public class TypeCollector
                     return false;
                 } else if (elementType.IsInterface) {
                     // TODO: Skipped for now because of problems with DNArray<T> in Swift (maybe Kotlin as well; C should be fine)
-                    
+
                     unsupportedReason = "Is Array of Interface Type";
                     return false;
                 }
@@ -486,28 +486,28 @@ public class TypeCollector
 
             if (invokeMethod is not null) {
                 var delegateReturnType = invokeMethod.ReturnType;
-    
+
                 if (!IsSupportedType(delegateReturnType)) {
                     unsupportedReason = "Unsupported delegate return type";
                     return false;
                 }
-                
+
                 var delegateParameters = invokeMethod.GetParameters();
-    
+
                 foreach (var delegateParameter in delegateParameters) {
                     if (!IsSupportedType(delegateParameter.ParameterType)) {
                         unsupportedReason = "Unsupported delegate paramter type";
-                        return false;        
+                        return false;
                     }
                 }
             }
         }
-            
+
         if (m_excludedTypes.Contains(type)) {
             unsupportedReason = "Is unsupported Type";
             return false;
         }
 
         return true;
-    } 
+    }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Documentation/XmlDocumentationMember.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Documentation/XmlDocumentationMember.cs
@@ -34,13 +34,13 @@ public struct XmlDocumentationMember
         foreach (var paramString in paramStrings) {
             lines.Add($"{commentPrefix}- Parameter {paramString}");
         }
-        
+
         var exceptionStrings = Node.ExceptionsAsPlainText;
 
         foreach (var exceptionString in exceptionStrings) {
             lines.Add($"{commentPrefix}- Throws: {exceptionString}");
         }
-        
+
         var returns = Node.ReturnsAsPlainText;
         var returnsAsSingleLine = string.Join(' ', returns.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries));
 
@@ -53,7 +53,7 @@ public struct XmlDocumentationMember
         }
 
         var linesJoined = string.Join('\n', lines);
-        
+
         return linesJoined;
     }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Documentation/XmlDocumentationMemberIdentifier.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Documentation/XmlDocumentationMemberIdentifier.cs
@@ -35,36 +35,36 @@ internal struct XmlDocumentationMemberIdentifier
     {
         if (type.IsArray) {
             m_key = string.Empty;
-            
+
             return;
         }
-        
+
         var typeFullName = type.FullName;
 
         if (string.IsNullOrEmpty(typeFullName)) {
             m_key = string.Empty;
-            
+
             return;
         }
-        
+
         m_key = $"{IDENTIFIER_TYPE}:{EncodeKey(typeFullName)}";
     }
-    
+
     internal XmlDocumentationMemberIdentifier(FieldInfo fieldInfo)
     {
         var type = fieldInfo.DeclaringType;
 
         if (type is null) {
             m_key = string.Empty;
-            
+
             return;
         }
-        
+
         var typeFullName = type.FullName;
 
         if (string.IsNullOrEmpty(typeFullName)) {
             m_key = string.Empty;
-            
+
             return;
         }
 
@@ -72,22 +72,22 @@ internal struct XmlDocumentationMemberIdentifier
 
         m_key = $"{IDENTIFIER_FIELD}:{EncodeKey(typeFullName, memberName)}";
     }
-    
+
     internal XmlDocumentationMemberIdentifier(PropertyInfo propertyInfo)
     {
         var type = propertyInfo.DeclaringType;
 
         if (type is null) {
             m_key = string.Empty;
-            
+
             return;
         }
-        
+
         var typeFullName = type.FullName;
 
         if (string.IsNullOrEmpty(typeFullName)) {
             m_key = string.Empty;
-            
+
             return;
         }
 
@@ -95,22 +95,22 @@ internal struct XmlDocumentationMemberIdentifier
 
         m_key = $"{IDENTIFIER_PROPERTY}:{EncodeKey(typeFullName, memberName)}";
     }
-    
+
     internal XmlDocumentationMemberIdentifier(EventInfo eventInfo)
     {
         var type = eventInfo.DeclaringType;
 
         if (type is null) {
             m_key = string.Empty;
-            
+
             return;
         }
-        
+
         var typeFullName = type.FullName;
 
         if (string.IsNullOrEmpty(typeFullName)) {
             m_key = string.Empty;
-            
+
             return;
         }
 
@@ -119,16 +119,16 @@ internal struct XmlDocumentationMemberIdentifier
         m_key = $"{IDENTIFIER_EVENT}:{EncodeKey(typeFullName, memberName)}";
     }
 
-    internal XmlDocumentationMemberIdentifier(MethodInfo methodInfo) 
+    internal XmlDocumentationMemberIdentifier(MethodInfo methodInfo)
 	    : this(methodInfo, false)
     {
     }
-    
-    internal XmlDocumentationMemberIdentifier(ConstructorInfo constructorInfo) 
+
+    internal XmlDocumentationMemberIdentifier(ConstructorInfo constructorInfo)
 	    : this(constructorInfo, true)
     {
     }
-    
+
     private XmlDocumentationMemberIdentifier(
 	    MethodBase methodBase,
 	    bool isConstructor
@@ -138,15 +138,15 @@ internal struct XmlDocumentationMemberIdentifier
 
         if (type is null) {
             m_key = string.Empty;
-            
+
             return;
         }
-        
+
         var typeFullName = type.FullName;
 
         if (string.IsNullOrEmpty(typeFullName)) {
             m_key = string.Empty;
-            
+
             return;
         }
 
@@ -171,27 +171,27 @@ internal struct XmlDocumentationMemberIdentifier
             methodBase.Name is "op_Explicit") {
 			return null;
 		}
-		
+
 		var parameterInfos = methodBase.GetParameters();
 
 		var declarationTypeString = GetXmlDocumenationFormattedString(
 			declaringType,
 			false
 		);
-		
+
 		var memberNameString = isConstructor
-            ? "#ctor" 
+            ? "#ctor"
             : methodBase.Name;
-		
-		string parametersString = parameterInfos.Length > 0 
-			? "(" + string.Join(",", methodBase.GetParameters().Select(x => GetXmlDocumenationFormattedString(x.ParameterType, true))) + ")" 
+
+		string parametersString = parameterInfos.Length > 0
+			? "(" + string.Join(",", methodBase.GetParameters().Select(x => GetXmlDocumenationFormattedString(x.ParameterType, true))) + ")"
 			: string.Empty;
 
 		string methodName = declarationTypeString +
 		                    "." +
 		                    memberNameString +
 		                    parametersString;
-        
+
 		return methodName;
 	}
 
@@ -209,7 +209,7 @@ internal struct XmlDocumentationMemberIdentifier
 			if (elementType is null) {
 				return null;
 			}
-			
+
 			var elementTypeString = GetXmlDocumenationFormattedString(
 				elementType,
 				isMethodParameter
@@ -221,11 +221,11 @@ internal struct XmlDocumentationMemberIdentifier
 				return elementTypeString + "@";
 			} else if (type.IsArray) {
 				int rank = type.GetArrayRank();
-				
+
 				string arrayDimensionsString = rank > 1
 					? "[" + string.Join(",", Enumerable.Repeat("0:", rank)) + "]"
 					: "[]";
-				
+
 				return elementTypeString + arrayDimensionsString;
 			} else {
 				return null;
@@ -234,14 +234,14 @@ internal struct XmlDocumentationMemberIdentifier
 			var isNested = type.IsNested;
 
 			string prefaceString;
-			
+
 			if (isNested) {
 				var declaringType = type.DeclaringType;
 
 				if (declaringType is null) {
 					return null;
 				}
-				
+
 				prefaceString = GetXmlDocumenationFormattedString(
 					declaringType,
 					isMethodParameter
@@ -257,13 +257,13 @@ internal struct XmlDocumentationMemberIdentifier
 			return prefaceString + typeNameString;
 		}
 	}
-    
+
     private static string EncodeKey(
         string fullTypeName,
         string? memberName = null
     ) {
         string key = Regex.Replace(
-            fullTypeName, 
+            fullTypeName,
             @"\[.*\]",
             string.Empty
         ).Replace('+', '.');
@@ -271,7 +271,7 @@ internal struct XmlDocumentationMemberIdentifier
         if (!string.IsNullOrEmpty(memberName)) {
             key += "." + memberName;
         }
-        
+
         return key;
     }
 
@@ -287,10 +287,10 @@ internal struct XmlDocumentationMemberIdentifier
 	    if (string.IsNullOrEmpty(key)) {
 		    return key;
 	    }
-	    
+
 	    foreach (var identifier in Identifiers) {
 		    var identifierPrefix = $"{identifier}:";
-                    
+
 		    if (!key.StartsWith(identifierPrefix) ||
 		        key.Length <= identifierPrefix.Length) {
 			    continue;

--- a/Generator/Beyond.NET.CodeGenerator/Documentation/XmlDocumentationNode.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Documentation/XmlDocumentationNode.cs
@@ -11,9 +11,9 @@ internal struct XmlDocumentationNode
     private XmlNode? ReturnsNode => MemberNode.SelectSingleNode(".//returns");
     private XmlNodeList? ParamNodes => MemberNode.SelectNodes(".//param");
     private XmlNodeList? ExceptionNodes => MemberNode.SelectNodes(".//exception");
-    
+
     private static readonly char[] NEW_LINES = new char[] { '\r', '\n' };
-    
+
     internal XmlDocumentationNode(XmlNode xmlMemberNode)
     {
         MemberNode = xmlMemberNode;
@@ -33,7 +33,7 @@ internal struct XmlDocumentationNode
             if (node is null) {
                 return string.Empty;
             }
-            
+
             var str = ConvertNodeToPlainText(node)
                 .Replace("\r\n", Environment.NewLine)
                 .Trim(NEW_LINES);
@@ -50,7 +50,7 @@ internal struct XmlDocumentationNode
             if (node is null) {
                 return string.Empty;
             }
-            
+
             var str = ConvertNodeToPlainText(node)
                 .Replace("\r\n", Environment.NewLine)
                 .Trim(NEW_LINES);
@@ -77,7 +77,7 @@ internal struct XmlDocumentationNode
                 if (string.IsNullOrEmpty(paramName)) {
                     continue;
                 }
-                
+
                 var str = ConvertNodeToPlainText(node)
                     .Replace("\r\n", Environment.NewLine)
                     .Trim(NEW_LINES);
@@ -85,19 +85,19 @@ internal struct XmlDocumentationNode
                 if (string.IsNullOrEmpty(str)) {
                     continue;
                 }
-                
+
                 var strSplit = str.Split(NEW_LINES, StringSplitOptions.RemoveEmptyEntries);
                 var strJoined = string.Join(' ', strSplit);
 
                 var paramStr = $"{paramName}: {strJoined}";
-                
+
                 paramStrings.Add(paramStr);
             }
 
             return paramStrings.ToArray();
         }
     }
-    
+
     public string[] ExceptionsAsPlainText
     {
         get {
@@ -121,7 +121,7 @@ internal struct XmlDocumentationNode
                 } else {
                     exceptionType = "N/A";
                 }
-                
+
                 var str = ConvertNodeToPlainText(node)
                     .Replace("\r\n", Environment.NewLine)
                     .Trim(NEW_LINES);
@@ -129,12 +129,12 @@ internal struct XmlDocumentationNode
                 if (string.IsNullOrEmpty(str)) {
                     continue;
                 }
-                
+
                 var strSplit = str.Split(NEW_LINES, StringSplitOptions.RemoveEmptyEntries);
                 var strJoined = string.Join(' ', strSplit);
 
                 var paramStr = $"{exceptionType}: {strJoined}";
-                
+
                 exceptionStrings.Add(paramStr);
             }
 
@@ -186,7 +186,7 @@ internal struct XmlDocumentationNode
             } else {
                 // throw new NotImplementedException();
                 // Console.WriteLine($"Unknown node type: {child.Name}");
-                
+
                 sb.Append(ConvertNodeToPlainText(child));
             }
         }
@@ -211,7 +211,7 @@ internal struct XmlDocumentationNode
         var hrefAttr = node.Attributes?["href"];
 
         string? value;
-        
+
         if (crefAttr is not null) {
             value = crefAttr.Value;
         } else if (langwordAttr is not null) {
@@ -231,7 +231,7 @@ internal struct XmlDocumentationNode
 
         return plainText;
     }
-    
+
     private const string TAG_PARAMREF = "paramref";
     private static string ConvertParamRefNodeToPlainText(XmlNode node)
     {
@@ -249,7 +249,7 @@ internal struct XmlDocumentationNode
 
         return value;
     }
-    
+
     private const string TAG_TYPEPARAMREF = "typeparamref";
     private static string ConvertTypeParamRefNodeToPlainText(XmlNode node)
     {
@@ -273,19 +273,19 @@ internal struct XmlDocumentationNode
     {
         return ConvertNodeToPlainText(node);
     }
-    
+
     private const string TAG_C = "c";
     private static string ConvertCNodeToPlainText(XmlNode node)
     {
         return node.InnerText;
     }
-    
+
     private const string TAG_CODE = "code";
     private static string ConvertCodeNodeToPlainText(XmlNode node)
     {
         return node.InnerText;
     }
-    
+
     private const string TAG_XREF = "xref";
     private static string ConvertXrefNodeToPlainText(XmlNode node)
     {
@@ -309,43 +309,43 @@ internal struct XmlDocumentationNode
     {
         return ConvertNodeToPlainText(node);
     }
-    
+
     private const string TAG_LISTHEADER = "listheader";
     private static string ConvertListHeaderNodeToPlainText(XmlNode node)
     {
         return ConvertNodeToPlainText(node);
     }
-    
+
     private const string TAG_ITEM = "item";
     private static string ConvertItemNodeToPlainText(XmlNode node)
     {
         return ConvertNodeToPlainText(node);
     }
-    
+
     private const string TAG_TERM = "term";
     private static string ConvertTermNodeToPlainText(XmlNode node)
     {
         return ConvertNodeToPlainText(node);
     }
-    
+
     private const string TAG_DESCRIPTION = "description";
     private static string ConvertDescriptionNodeToPlainText(XmlNode node)
     {
         return ConvertNodeToPlainText(node);
     }
-    
+
     private const string TAG_TABLE = "table";
     private static string ConvertTableNodeToPlainText(XmlNode node)
     {
         return ConvertNodeToPlainText(node);
     }
-    
+
     private const string TAG_BR = "br";
     private static string ConvertBrNodeToPlainText(XmlNode node)
     {
         return Environment.NewLine;
     }
-    
+
     private const string TAG_P = "p";
     private static string ConvertPNodeToPlainText(XmlNode node)
     {

--- a/Generator/Beyond.NET.CodeGenerator/Documentation/XmlDocumentationReflectionExtensions.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Documentation/XmlDocumentationReflectionExtensions.cs
@@ -5,22 +5,22 @@ namespace Beyond.NET.CodeGenerator;
 public static class XmlDocumentationReflectionExtensions
 {
     private static XmlDocumentationStore Store => XmlDocumentationStore.Shared;
-    
-    public static XmlDocumentationMember? GetDocumentation(this Type type) 
+
+    public static XmlDocumentationMember? GetDocumentation(this Type type)
         => Store.GetDocumentation(new(type));
-    
+
     public static XmlDocumentationMember? GetDocumentation(this FieldInfo fieldInfo)
         => Store.GetDocumentation(new(fieldInfo));
-    
+
     public static XmlDocumentationMember? GetDocumentation(this PropertyInfo propertyInfo)
         => Store.GetDocumentation(new(propertyInfo));
-    
+
     public static XmlDocumentationMember? GetDocumentation(this EventInfo eventInfo)
         => Store.GetDocumentation(new(eventInfo));
-    
+
     public static XmlDocumentationMember? GetDocumentation(this MethodInfo methodInfo)
         => Store.GetDocumentation(new(methodInfo));
-    
+
     public static XmlDocumentationMember? GetDocumentation(this ConstructorInfo constructorInfo)
         => Store.GetDocumentation(new(constructorInfo));
 }

--- a/Generator/Beyond.NET.CodeGenerator/Documentation/XmlDocumentationStore.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Documentation/XmlDocumentationStore.cs
@@ -8,7 +8,7 @@ namespace Beyond.NET.CodeGenerator;
 public class XmlDocumentationStore
 {
     private ILogger Logger => Services.Shared.LoggerService;
-    
+
     private static readonly Lazy<XmlDocumentationStore> m_shared = new(() => new XmlDocumentationStore());
     public static XmlDocumentationStore Shared => m_shared.Value;
 
@@ -19,20 +19,20 @@ public class XmlDocumentationStore
     public void ParseDocumentation(Assembly assembly)
     {
         var assemblyName = assembly.GetName().Name ?? "N/A";
-        
+
         if (!m_assemblies.Add(assembly)) {
             Logger.LogDebug($"Skipping parsing documentation for assembly \"{assemblyName}\" because it has already been parsed");
-            
+
             return;
         }
-        
+
         var assemblyFilePath = assembly.Location;
-        
+
         Logger.LogDebug($"Going to parse documentation for assembly \"{assemblyName}\" at \"{assemblyFilePath}\"");
 
         if (!File.Exists(assemblyFilePath)) {
             Logger.LogDebug($"Assembly does not exist on disk at \"{assemblyFilePath}\" so we cannot parse documentation");
-            
+
             return;
         }
 
@@ -40,15 +40,15 @@ public class XmlDocumentationStore
 
         if (string.IsNullOrEmpty(xmlDocumentationFilePath)) {
             Logger.LogDebug($"XML documentation file for assembly \"{assemblyName}\" was not found");
-            
+
             return;
         }
-        
+
         Logger.LogDebug($"XML documentation file for assembly \"{assemblyName}\" was found at \"{xmlDocumentationFilePath}\"");
-        
+
         ParseDocumentation(xmlDocumentationFilePath);
     }
-    
+
     public void ParseSystemDocumentation(string systemXmlDocumentationDirectoryPath)
     {
         var xmlDocumentationFilePaths = GetSystemXmlDocumentationFilePaths(systemXmlDocumentationDirectoryPath);
@@ -70,7 +70,7 @@ public class XmlDocumentationStore
         if (string.IsNullOrEmpty(xmlDocumentationFilePath)) {
             return;
         }
-        
+
         Logger.LogInformation($"Parsing XML documentation file at \"{xmlDocumentationFilePath}\"");
 
         var content = File.ReadAllText(xmlDocumentationFilePath);
@@ -87,7 +87,7 @@ public class XmlDocumentationStore
 
         try {
             XmlDocument doc = new();
-            
+
             doc.LoadXml(xmlDocumentationContent);
             var root = doc.DocumentElement;
             var memberNodes = root?.SelectNodes("//doc/members/member");
@@ -99,11 +99,11 @@ public class XmlDocumentationStore
                     if (string.IsNullOrEmpty(rawName)) {
                         continue;
                     }
-                    
+
                     var memberType = new XmlDocumentationMemberIdentifier(rawName);
-                    
+
                     var memberContent = new XmlDocumentationMember(memberNode);
-                    
+
                     members[memberType] = memberContent;
                 }
             }
@@ -114,7 +114,7 @@ public class XmlDocumentationStore
         return members;
     }
     #endregion Parse
-    
+
     #region Extracting
     internal XmlDocumentationMember? GetDocumentation(XmlDocumentationMemberIdentifier memberIdentifier)
     {
@@ -139,9 +139,9 @@ public class XmlDocumentationStore
         if (string.IsNullOrEmpty(assemblyDir)) {
             return null;
         }
-        
-        var xmlFileName = assemblyName + ".xml"; 
-        
+
+        var xmlFileName = assemblyName + ".xml";
+
         var xmlFilePath = Path.Combine(
             assemblyDir,
             xmlFileName

--- a/Generator/Beyond.NET.CodeGenerator/Extensions/FieldInfoExtensions.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Extensions/FieldInfoExtensions.cs
@@ -11,20 +11,20 @@ public static class FieldInfoExtensions
         if (declaringType is null) {
             return false;
         }
-        
+
         Type? baseType = declaringType.BaseType;
 
         if (baseType is not null) {
             bool declaringTypeIsGeneric = declaringType.IsGenericType ||
                                           declaringType.IsGenericTypeDefinition;
-            
+
             bool baseTypeIsGeneric = baseType.IsGenericType ||
                                      baseType.IsGenericTypeDefinition;
-            
+
             if (declaringTypeIsGeneric != baseTypeIsGeneric) {
                 return false;
             }
-            
+
             MemberInfo[] baseMembers = baseType.GetMember(fieldInfo.Name);
 
             foreach (var baseMember in baseMembers) {

--- a/Generator/Beyond.NET.CodeGenerator/Extensions/MemberInfoExtensions.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Extensions/MemberInfoExtensions.cs
@@ -17,7 +17,7 @@ public static class MemberInfoExtensions
         if (isError) {
             return true;
         }
-        
+
         return false;
     }
 

--- a/Generator/Beyond.NET.CodeGenerator/Extensions/MemberKindExtensions.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Extensions/MemberKindExtensions.cs
@@ -7,21 +7,21 @@ public static class MemberKindExtensions
 {
     public static string SwiftName(
         this MemberKind memberKind,
-        MemberInfo? memberInfo 
+        MemberInfo? memberInfo
     )
     {
         const string getterPrefix = "get_";
         const string getterSuffix = "";
-        
+
         const string setterPrefix = "set_";
         const string setterSuffix = "_set";
-        
+
         const string adderPrefix = "add_";
         const string adderSuffix = "_add";
-        
+
         const string removerPrefix = "remove_";
         const string removerSuffix = "_remove";
-        
+
         string? originalName = memberInfo?.Name;
         MethodBase? methodBase = memberInfo as MethodBase;
         bool isSpecialName = methodBase?.IsSpecialName ?? false;
@@ -43,35 +43,35 @@ public static class MemberKindExtensions
                     break;
                 case MemberKind.FieldGetter:
                     isGetter = true;
-                    
+
                     break;
                 case MemberKind.PropertySetter:
                     isSetter = true;
-                    
+
                     if (originalName?.StartsWith(setterPrefix) ?? false) {
                         originalName = originalName.Substring(setterPrefix.Length);
                     }
-                    
+
                     break;
                 case MemberKind.FieldSetter:
                     isSetter = true;
-                    
+
                     break;
                 case MemberKind.EventHandlerAdder:
                     isAdder = true;
-                    
+
                     if (originalName?.StartsWith(adderPrefix) ?? false) {
                         originalName = originalName.Substring(adderPrefix.Length);
                     }
-                    
+
                     break;
                 case MemberKind.EventHandlerRemover:
                     isRemover = true;
-                    
+
                     if (originalName?.StartsWith(removerPrefix) ?? false) {
                         originalName = originalName.Substring(removerPrefix.Length);
                     }
-                    
+
                     break;
             }
         }
@@ -97,15 +97,15 @@ public static class MemberKindExtensions
         } else {
             if (memberKind == MemberKind.Constructor) {
                 needsEscaping = false;
-                
+
                 swiftName = "init";
             } else if (memberKind == MemberKind.Destructor) {
                 needsEscaping = false;
-                
+
                 swiftName = "destroy";
             } else if (memberKind == MemberKind.TypeOf) {
                 needsEscaping = false;
-                
+
                 swiftName = "typeOf";
             } else {
                 swiftName = swiftName ?? throw new Exception();
@@ -118,25 +118,25 @@ public static class MemberKindExtensions
 
         return swiftName;
     }
-    
+
     public static string KotlinName(
         this MemberKind memberKind,
-        MemberInfo? memberInfo 
+        MemberInfo? memberInfo
     )
     {
         // TODO: This was copied from the Swift version of the same method and modified
         const string getterPrefix = "get_";
         const string getterSuffix = "_get";
-        
+
         const string setterPrefix = "set_";
         const string setterSuffix = "_set";
-        
+
         const string adderPrefix = "add_";
         const string adderSuffix = "_add";
-        
+
         const string removerPrefix = "remove_";
         const string removerSuffix = "_remove";
-        
+
         string? originalName = memberInfo?.Name;
         MethodBase? methodBase = memberInfo as MethodBase;
         bool isSpecialName = methodBase?.IsSpecialName ?? false;
@@ -158,35 +158,35 @@ public static class MemberKindExtensions
                     break;
                 case MemberKind.FieldGetter:
                     isGetter = true;
-                    
+
                     break;
                 case MemberKind.PropertySetter:
                     isSetter = true;
-                    
+
                     if (originalName?.StartsWith(setterPrefix) ?? false) {
                         originalName = originalName.Substring(setterPrefix.Length);
                     }
-                    
+
                     break;
                 case MemberKind.FieldSetter:
                     isSetter = true;
-                    
+
                     break;
                 case MemberKind.EventHandlerAdder:
                     isAdder = true;
-                    
+
                     if (originalName?.StartsWith(adderPrefix) ?? false) {
                         originalName = originalName.Substring(adderPrefix.Length);
                     }
-                    
+
                     break;
                 case MemberKind.EventHandlerRemover:
                     isRemover = true;
-                    
+
                     if (originalName?.StartsWith(removerPrefix) ?? false) {
                         originalName = originalName.Substring(removerPrefix.Length);
                     }
-                    
+
                     break;
             }
         }
@@ -198,11 +198,11 @@ public static class MemberKindExtensions
         }
 
         string? kotlinName;
-        
+
         // TODO: Refactor
         if (originalName == "ToString") {
             kotlinName = "dnToString";
-        } else if (originalName == "Wait") { 
+        } else if (originalName == "Wait") {
             kotlinName = "dnWait";
         } else {
             kotlinName = originalName?.FirstCharToLower();
@@ -221,15 +221,15 @@ public static class MemberKindExtensions
         } else {
             if (memberKind == MemberKind.Constructor) {
                 needsEscaping = false;
-                
+
                 kotlinName = "init";
             } else if (memberKind == MemberKind.Destructor) {
                 needsEscaping = false;
-                
+
                 kotlinName = "destroy";
             } else if (memberKind == MemberKind.TypeOf) {
                 needsEscaping = false;
-                
+
                 kotlinName = "typeOf";
             } else {
                 kotlinName = kotlinName ?? throw new Exception();

--- a/Generator/Beyond.NET.CodeGenerator/Extensions/MethodInfoExtensions.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Extensions/MethodInfoExtensions.cs
@@ -6,18 +6,18 @@ namespace Beyond.NET.CodeGenerator.Extensions;
 public static class MethodInfoExtensions
 {
     public static bool IsOverridden(
-        this MethodInfo methodInfo, 
+        this MethodInfo methodInfo,
         out bool nullabilityIsCompatible
     )
     {
         nullabilityIsCompatible = true;
-        
+
         Type? declaringType = methodInfo.DeclaringType;
 
         if (declaringType is null) {
             return false;
         }
-        
+
         MethodInfo baseMethodInfo = methodInfo.GetBaseDefinition();
         Type? baseMethodDeclaringType = baseMethodInfo.DeclaringType;
 
@@ -35,7 +35,7 @@ public static class MethodInfoExtensions
             return false;
         }
 
-        bool isOverridden = methodInfo != baseMethodInfo || 
+        bool isOverridden = methodInfo != baseMethodInfo ||
                             declaringType != baseMethodDeclaringType ||
                             declaringTypeIsGeneric != baseTypeIsGeneric;
 
@@ -45,7 +45,7 @@ public static class MethodInfoExtensions
 
         if (!methodInfo.ReturnParameter.IsNullabilityInfoCompatible(baseMethodInfo.ReturnParameter)) {
             nullabilityIsCompatible = false;
-            
+
             return isOverridden;
         }
 
@@ -75,13 +75,13 @@ public static class MethodInfoExtensions
     {
         nullabilityIsCompatible = true;
         implementedInterfaceType = null;
-        
+
         Type? declaringType = methodInfo.DeclaringType;
 
         if (declaringType is null) {
             return false;
         }
-        
+
         var interfaceTypes = declaringType.GetInterfaces();
 
         foreach (var interfaceType in interfaceTypes) {
@@ -95,7 +95,7 @@ public static class MethodInfoExtensions
 
             if (isShadowedByInterface) {
                 implementedInterfaceType = interfaceType;
-                
+
                 return true;
             }
         }
@@ -110,7 +110,7 @@ public static class MethodInfoExtensions
     )
     {
         nullabilityIsCompatible = true;
-        
+
         Type? declaringType = methodInfo.DeclaringType;
 
         if (declaringType is null) {
@@ -145,7 +145,7 @@ public static class MethodInfoExtensions
     )
     {
         nullabilityIsCompatible = true;
-        
+
         bool declaringTypeIsGeneric = declaringType.IsGenericType ||
                                       declaringType.IsGenericTypeDefinition;
 

--- a/Generator/Beyond.NET.CodeGenerator/Extensions/ParameterInfoExtensions.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Extensions/ParameterInfoExtensions.cs
@@ -14,7 +14,7 @@ public static class ParameterInfoExtensions
         var nullability = ctx.Create(parameterInfo);
         var readState = nullability.ReadState;
         var writeState = nullability.WriteState;
-        
+
         var otherNullability = ctx.Create(otherParameterInfo);
         var otherReadState = otherNullability.ReadState;
         var otherWriteState = otherNullability.WriteState;
@@ -23,7 +23,7 @@ public static class ParameterInfoExtensions
             !IsNullabilityStateCompatible(readState, otherReadState)) {
             return false;
         }
-        
+
         if (writeState != otherWriteState &&
             !IsNullabilityStateCompatible(writeState, otherWriteState)) {
             return false;
@@ -40,7 +40,7 @@ public static class ParameterInfoExtensions
         bool isUnknown = state == NullabilityState.Unknown;
         bool isNullable = state == NullabilityState.Nullable;
         bool isNotNull = state == NullabilityState.NotNull;
-        
+
         bool isOtherUnknown = otherState == NullabilityState.Unknown;
         bool isOtherNullable = otherState == NullabilityState.Nullable;
         bool isOtherNotNull = otherState == NullabilityState.NotNull;

--- a/Generator/Beyond.NET.CodeGenerator/Extensions/PropertyInfoExtensions.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Extensions/PropertyInfoExtensions.cs
@@ -27,7 +27,7 @@ public static class PropertyInfoExtensions
                 }
             }
         }
-        
+
         return setterMethod;
     }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Extensions/StringExtensions.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Extensions/StringExtensions.cs
@@ -72,7 +72,7 @@ internal static class StringExtensions
         "willSet",
         "unowned"
     };
-    
+
     private static readonly string[] KOTLIN_KEYWORDS = new[] {
         "val",
         "do"
@@ -87,7 +87,7 @@ internal static class StringExtensions
         if (string.IsNullOrEmpty(cSharpCaseName)) {
             return cSharpCaseName;
         }
-        
+
         string swiftCaseName = cSharpCaseName.FirstCharToLower();
 
         if (swiftCaseName.IsSwiftKeyword()) {
@@ -96,19 +96,19 @@ internal static class StringExtensions
 
         return swiftCaseName;
     }
-    
+
     internal static string FirstCharToLower(this string input)
     {
         if (string.IsNullOrEmpty(input)) {
             return string.Empty;
         }
-        
+
         char[] stringArray = input.ToCharArray();
-        
+
         if (char.IsUpper(stringArray[0])) {
             stringArray[0] = char.ToLower(stringArray[0]);
         }
-        
+
         return new string(stringArray);
     }
 
@@ -127,18 +127,18 @@ internal static class StringExtensions
         if (!input.IsSwiftKeyword()) {
             return input;
         }
-        
+
         string output = $"`{input}`";
 
         return output;
     }
-    
+
     internal static string EscapedSwiftTypeAliasTypeName(this string input)
     {
         if (!input.IsReservedSwiftTypeName()) {
             return input;
         }
-        
+
         string output = $"`{input}`";
 
         return output;
@@ -148,13 +148,13 @@ internal static class StringExtensions
     {
         return KOTLIN_KEYWORDS.Contains(input);
     }
-    
+
     internal static string EscapedKotlinName(this string input)
     {
         if (!input.IsKotlinKeyword()) {
             return input;
         }
-        
+
         string output = $"`{input}`";
 
         return output;

--- a/Generator/Beyond.NET.CodeGenerator/Extensions/TypeExtensions.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Extensions/TypeExtensions.cs
@@ -11,7 +11,7 @@ internal static class TypeExtensions
     {
         return type.GetTypeDescriptor(TypeDescriptorRegistry.Shared);
     }
-    
+
     internal static TypeDescriptor GetTypeDescriptor(this Type type, TypeDescriptorRegistry typeDescriptorRegistry)
     {
         return typeDescriptorRegistry.GetOrCreateTypeDescriptor(type);
@@ -36,7 +36,7 @@ internal static class TypeExtensions
 
         name = name
             .Replace("+", ".");
-        
+
         bool isGeneric = type.IsGenericType ||
                          type.IsGenericTypeDefinition;
 
@@ -61,12 +61,12 @@ internal static class TypeExtensions
             name += "<";
 
             int index = 0;
-            
+
             foreach (Type genericArgument in genericArguments) {
                 if (index > 0) {
                     name += ",";
                 }
-                
+
                 if (isConstructedGeneric) {
                     string argumentTypeName = genericArgument.GetFullNameOrName();
 
@@ -75,19 +75,19 @@ internal static class TypeExtensions
 
                 index++;
             }
-            
+
             name += ">";
         }
 
         return name;
     }
-    
+
     internal static string CTypeName(this Type type)
     {
         if (type.IsNullableValueType(out Type? valueType)) {
             type = valueType;
         }
-        
+
         string fullTypeName = type.GetFullNameOrName();
 
         string cTypeName = fullTypeName
@@ -122,7 +122,7 @@ internal static class TypeExtensions
 
         if (isGeneric) {
             int genericArgsCount = type.GetGenericArguments().Length;
-            
+
             int backtickIndex = cTypeName.IndexOf('`');
 
             if (backtickIndex > 0) {
@@ -134,7 +134,7 @@ internal static class TypeExtensions
             if (lessThanIndex > 0) {
                 cTypeName = cTypeName.Substring(0, lessThanIndex);
             }
-            
+
             cTypeName += "_A" + genericArgsCount;
         }
 
@@ -150,7 +150,7 @@ internal static class TypeExtensions
     {
         return type == typeof(bool);
     }
-    
+
     internal static bool IsVoid(this Type type)
     {
         return type == typeof(void);
@@ -163,9 +163,9 @@ internal static class TypeExtensions
 
     internal static bool IsGenericInAnyWay(this Type type, bool includeBaseTypes)
     {
-        bool isGeneric = type.IsGenericType || 
-                         type.IsConstructedGenericType || 
-                         type.IsGenericTypeDefinition || 
+        bool isGeneric = type.IsGenericType ||
+                         type.IsConstructedGenericType ||
+                         type.IsGenericTypeDefinition ||
                          type.IsGenericParameter;
 
         if (isGeneric) {
@@ -195,7 +195,7 @@ internal static class TypeExtensions
         if (!type.IsGenericType ||
             type.GetGenericTypeDefinition() != typeof(Nullable<>)) {
             valueType = null;
-            
+
             return false;
         }
 
@@ -212,7 +212,7 @@ internal static class TypeExtensions
     {
         return type == typeof(ReadOnlySpan<byte>);
     }
-    
+
     internal static bool IsStruct(this Type type)
     {
         return type.IsValueType &&
@@ -224,7 +224,7 @@ internal static class TypeExtensions
     internal static MethodInfo? GetDelegateInvokeMethod(this Type delegateType)
     {
         const string invokeMethodName = "Invoke";
-        
+
         MethodInfo? invokeMethod = delegateType.GetMethod(invokeMethodName);
 
         return invokeMethod;
@@ -236,7 +236,7 @@ internal static class TypeExtensions
     )
     {
         nonByRefTypeIsStruct = false;
-        
+
         if (!type.IsByRef) {
             return false;
         }
@@ -276,7 +276,7 @@ internal static class TypeExtensions
         if (type.IsGenericParameter) {
             return true;
         }
-        
+
         Type[] genericArgs = type.GetGenericArguments();
 
         foreach (Type genericArg in genericArgs) {
@@ -295,7 +295,7 @@ internal static class TypeExtensions
 
         return hasIt;
     }
-    
+
     internal static bool DoesAnyBaseTypeImplementInterface(
         this Type derivedType,
         Type interfaceType
@@ -307,12 +307,12 @@ internal static class TypeExtensions
 
         // Iterate through the base types
         Type? currentType = derivedType.BaseType;
-        
+
         while (currentType is not null) {
             if (currentType.GetInterfaces().Contains(interfaceType)) {
                 return true;
             }
-            
+
             currentType = currentType.BaseType;
         }
 

--- a/Generator/Beyond.NET.CodeGenerator/Generator/C/CCodeBuilder.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/C/CCodeBuilder.cs
@@ -12,14 +12,14 @@ readonly struct CCodeBuilder
 
     internal CCodeBuilder([StringSyntax("C")] string? value = null) : this(new StringBuilder(value))
     { }
-    
+
     private CCodeBuilder(StringBuilder sb) => m_sb = sb;
 
     internal CCodeBuilder Append(char c) => new(m_sb.Append(c));
-    
+
     internal CCodeBuilder Append([StringSyntax("C")] string value) => new(m_sb.Append(value));
-    
+
     internal CCodeBuilder AppendLine([StringSyntax("C")] string? value = null) => new(m_sb.AppendLine(value));
-    
+
     public override string ToString() => m_sb.ToString();
 }

--- a/Generator/Beyond.NET.CodeGenerator/Generator/C/CCodeGenerator.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/C/CCodeGenerator.cs
@@ -8,7 +8,7 @@ public class CCodeGenerator: ICodeGenerator
 {
     public Settings Settings { get; }
     public Result CSharpUnmanagedResult { get; }
-    
+
     public CCodeGenerator(Settings settings, Result cSharpUnmanagedResult)
     {
         Settings = settings ?? throw new ArgumentNullException(nameof(settings));
@@ -22,7 +22,7 @@ public class CCodeGenerator: ICodeGenerator
     )
     {
         CSyntaxWriterConfiguration? syntaxWriterConfiguration = null;
-        
+
         SourceCodeSection headerSection = writer.AddSection("Header");
         SourceCodeSection commonTypesSection = writer.AddSection("Common Types");
         SourceCodeSection unsupportedTypesSection = writer.AddSection("Unsupported Types");
@@ -30,7 +30,7 @@ public class CCodeGenerator: ICodeGenerator
         SourceCodeSection apisSection = writer.AddSection("APIs");
         SourceCodeSection utilsSection = writer.AddSection("Utils");
         SourceCodeSection footerSection = writer.AddSection("Footer");
-        
+
         string header = CSharedCode.HeaderCode;
         headerSection.Code.AppendLine(header);
 
@@ -41,7 +41,7 @@ public class CCodeGenerator: ICodeGenerator
             foreach (var kvp in unsupportedTypes) {
                 Type type = kvp.Key;
                 string reason = kvp.Value;
-    
+
                 string typeName = type.FullName ?? type.Name;
 
                 unsupportedTypesSection.Code.AppendLine(
@@ -61,22 +61,22 @@ public class CCodeGenerator: ICodeGenerator
         var orderedTypes = types
             .OrderByDescending(t => t.IsEnum)
             .ThenByDescending(t => !t.IsDelegate());
-        
+
         foreach (Type type in orderedTypes) {
             Syntax.State state = new(CSharpUnmanagedResult);
-            
+
             string typeCode = typeSyntaxWriter.Write(type, state, syntaxWriterConfiguration);
             typedefsSection.Code.AppendLine(typeCode);
 
             string membersCode = typeSyntaxWriter.WriteMembers(type, state, syntaxWriterConfiguration);
             apisSection.Code.AppendLine(membersCode);
-            
+
             result.AddGeneratedType(
                 type,
                 state.GeneratedMembers
             );
         }
-        
+
         string utilsCode = CSharedCode.UtilsCode;
         utilsSection.Code.AppendLine(utilsCode);
 

--- a/Generator/Beyond.NET.CodeGenerator/Generator/C/CSharedCode.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/C/CSharedCode.cs
@@ -23,7 +23,7 @@ typedef struct DNReadOnlySpanOfByte {
     int32_t dataLength;
 } DNReadOnlySpanOfByte;
 """;
-    
+
     internal const string UtilsCode = /*lang=C*/"""
 _Nonnull DNCString
 DNStringToC(_Nonnull System_String_t systemString);
@@ -115,7 +115,7 @@ DNObjectFromUInt64(uint64_t number);
 void*
 DNGetPinnedPointerToByteArray(_Nonnull System_Byte_Array_t byteArray, _Nullable System_Runtime_InteropServices_GCHandle_t* outGCHandle, _Nullable System_Exception_t* outException);
 """;
-    
+
         internal const string FooterCode = /*lang=C*/"""
 #pragma clang diagnostic pop
 

--- a/Generator/Beyond.NET.CodeGenerator/Generator/C/Settings.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/C/Settings.cs
@@ -4,6 +4,6 @@ public class Settings: Generator.Settings
 {
     public Settings()
     {
-        
+
     }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Generator/CSharpUnmanaged/CSharpCodeBuilder.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/CSharpUnmanaged/CSharpCodeBuilder.cs
@@ -12,13 +12,13 @@ readonly struct CSharpCodeBuilder
 
     internal CSharpCodeBuilder([StringSyntax("C#")] string? value = null) : this(new StringBuilder(value))
     { }
-    
+
     private CSharpCodeBuilder(StringBuilder sb) => m_sb = sb;
 
     internal CSharpCodeBuilder Append(char c) => new(m_sb.Append(c));
-    
+
     internal CSharpCodeBuilder Append([StringSyntax("C#")] string value) => new(m_sb.Append(value));
-    
+
     internal CSharpCodeBuilder AppendLine([StringSyntax("C#")] string? value = null) => new(m_sb.AppendLine(value));
 
     public override string ToString() => m_sb.ToString();

--- a/Generator/Beyond.NET.CodeGenerator/Generator/CSharpUnmanaged/CSharpUnmanagedCodeGenerator.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/CSharpUnmanaged/CSharpUnmanagedCodeGenerator.cs
@@ -6,12 +6,12 @@ namespace Beyond.NET.CodeGenerator.Generator.CSharpUnmanaged;
 public class CSharpUnmanagedCodeGenerator: ICodeGenerator
 {
     public Settings Settings { get; }
-    
+
     public CSharpUnmanagedCodeGenerator(Settings settings)
     {
         Settings = settings ?? throw new ArgumentNullException(nameof(settings));
     }
-    
+
     public Result Generate(
         IEnumerable<Type> types,
         Dictionary<Type, string> unsupportedTypes,
@@ -19,7 +19,7 @@ public class CSharpUnmanagedCodeGenerator: ICodeGenerator
     )
     {
         CSharpUnmanagedSyntaxWriterConfiguration? syntaxWriterConfiguration = new(Settings.TypeCollectorSettings!);
-        
+
         SourceCodeSection headerSection = writer.AddSection("Header");
         SourceCodeSection sharedCodeSection = writer.AddSection("Shared Code");
         SourceCodeSection unsupportedTypesSection = writer.AddSection("Unsupported Types");
@@ -35,9 +35,9 @@ public class CSharpUnmanagedCodeGenerator: ICodeGenerator
             foreach (var kvp in unsupportedTypes) {
                 Type type = kvp.Key;
                 string reason = kvp.Value;
-    
+
                 string typeName = type.FullName ?? type.Name;
-    
+
                 unsupportedTypesSection.Code.AppendLine($"// Unsupported Type \"{typeName}\": {reason}");
             }
         } else {
@@ -47,16 +47,16 @@ public class CSharpUnmanagedCodeGenerator: ICodeGenerator
         CSharpUnmanagedTypeSyntaxWriter typeSyntaxWriter = new(Settings);
 
         Result result = new();
-        
+
         foreach (Type type in types) {
             Syntax.State state = new() {
                 Settings = Settings
             };
-            
+
             string typeCode = typeSyntaxWriter.Write(type, state, syntaxWriterConfiguration);
-            
+
             apisSection.Code.AppendLine(typeCode);
-            
+
             result.AddGeneratedType(
                 type,
                 state.GeneratedMembers

--- a/Generator/Beyond.NET.CodeGenerator/Generator/CSharpUnmanaged/CSharpUnmanagedSharedCode.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/CSharpUnmanaged/CSharpUnmanagedSharedCode.cs
@@ -10,7 +10,7 @@ internal class __BeyondNETNativeModuleInitializer
     internal static unsafe void BeyondNETNativeModuleInitializer()
     {
         // TODO: We could probably remove the native implementation if we port it to C# by using DllImport's for CoreFoundation stuff
-         
+
         const string dnLibraryInitFuncName = "_DNLibraryInit";
 
         var selfHandle = System.Runtime.InteropServices.NativeLibrary.GetMainProgramHandle();
@@ -29,7 +29,7 @@ internal class __BeyondNETNativeModuleInitializer
             dnLibraryInitSymbol == IntPtr.Zero) {
             return;
         }
-    
+
         delegate* unmanaged<void> dnLibraryInitFunc = (delegate* unmanaged<void>)dnLibraryInitSymbol;
 
         dnLibraryInitFunc();
@@ -65,13 +65,13 @@ internal static unsafe class InteropUtils
 
         return handle;
     }
-    
+
     internal static void* AllocateGCHandleAndGetAddress(this object? instance)
     {
         if (instance is null) {
             return null;
         }
-        
+
         GCHandle handle = instance.AllocateGCHandle(GCHandleType.Normal);
         void* handleAddress = handle.ToHandleAddress();
 
@@ -87,7 +87,7 @@ internal static unsafe class InteropUtils
         }
 
         GCHandle? handle = GetGCHandle(handleAddress);
-        
+
         handle?.FreeIfAllocated();
     }
 
@@ -109,10 +109,10 @@ internal static unsafe class InteropUtils
             !(target is T)) {
             throw new Exception("Type of handle is unexpected");
         }
-        
+
         handle?.FreeIfAllocated();
     }
-    
+
     internal static void FreeIfAllocated(this GCHandle handle)
     {
         if (!handle.IsAllocated) {
@@ -136,7 +136,7 @@ internal static unsafe class InteropUtils
         if (handleAddress is null) {
             return null;
         }
-        
+
         GCHandle handle = GCHandle.FromIntPtr((nint)handleAddress);
 
         return handle;
@@ -166,7 +166,7 @@ internal static unsafe class InteropUtils
         }
 
         GCHandle handle = maybeHandle.Value;
-        
+
         handle.Target = newInstance;
     }
     #endregion Handle Address/GCHandle <-> Object Conversion
@@ -177,7 +177,7 @@ internal static unsafe class InteropUtils
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
         System.Type typeConverted = InteropUtils.GetInstance<System.Type>(type);
-    
+
         try {
 	        System.Type currentType = objectConverted.GetType();
 	        bool isValidCast = currentType.IsAssignableTo(typeConverted);
@@ -185,19 +185,19 @@ internal static unsafe class InteropUtils
 	        if (!isValidCast) {
 		        throw new InvalidCastException();
 	        }
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return objectConverted.AllocateGCHandleAndGetAddress();
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return null;
         }
     }
@@ -207,7 +207,7 @@ internal static unsafe class InteropUtils
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
         System.Type typeConverted = InteropUtils.GetInstance<System.Type>(type);
-    
+
         try {
 	        System.Type currentType = objectConverted.GetType();
 	        bool isValidCast = currentType.IsAssignableTo(typeConverted);
@@ -215,7 +215,7 @@ internal static unsafe class InteropUtils
 	        if (!isValidCast) {
 		        return null;
 	        }
-    
+
             return objectConverted.AllocateGCHandleAndGetAddress();
         } catch {
             return null;
@@ -227,7 +227,7 @@ internal static unsafe class InteropUtils
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
         System.Type typeConverted = InteropUtils.GetInstance<System.Type>(type);
-    
+
         try {
 	        System.Type currentType = objectConverted.GetType();
 	        bool isValidCast = currentType.IsAssignableTo(typeConverted);
@@ -258,7 +258,7 @@ internal static unsafe class InteropUtils
         }
 
         byte* cString = (byte*)Marshal.StringToHGlobalAuto(systemStringConverted);
-        
+
         return cString;
     }
 
@@ -271,13 +271,13 @@ internal static unsafe class InteropUtils
         if (cString is null) {
             return null;
         }
-        
+
         System.String? systemString = Marshal.PtrToStringAuto((nint)cString);
 
         if (systemString is null) {
             return null;
         }
-        
+
         void* systemStringNative = systemString.AllocateGCHandleAndGetAddress();
 
         return systemStringNative;
@@ -306,90 +306,90 @@ internal static unsafe class InteropUtils
     internal static byte DNObjectCastToBool(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
             bool returnValue = (bool)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue.ToCBool();
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(bool).ToCBool();
         }
     }
-    
+
     [UnmanagedCallersOnly(EntryPoint = "DNObjectFromBool")]
     internal static void* /* System.Object */ DNObjectFromBool(byte value)
     {
         return ((System.Object)value.ToBool()).AllocateGCHandleAndGetAddress();
     }
     #endregion Bool
-    
+
     #region Char
     [UnmanagedCallersOnly(EntryPoint = "DNObjectCastToChar")]
     internal static char DNObjectCastToChar(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
             char returnValue = (char)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(char);
         }
     }
-    
+
     [UnmanagedCallersOnly(EntryPoint = "DNObjectFromChar")]
     internal static void* /* System.Object */ DNObjectFromChar(char value)
     {
         return ((System.Object)value).AllocateGCHandleAndGetAddress();
     }
     #endregion Char
-    
+
     #region Float
     [UnmanagedCallersOnly(EntryPoint = "DNObjectCastToFloat")]
     internal static float DNObjectCastToFloat(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
             float returnValue = (float)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(float);
         }
     }
-    
+
     [UnmanagedCallersOnly(EntryPoint = "DNObjectFromFloat")]
     internal static void* /* System.Object */ DNObjectFromFloat(float number)
     {
@@ -402,26 +402,26 @@ internal static unsafe class InteropUtils
     internal static double DNObjectCastToDouble(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
             double returnValue = (double)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(double);
         }
     }
-    
+
     [UnmanagedCallersOnly(EntryPoint = "DNObjectFromDouble")]
     internal static void* /* System.Object */ DNObjectFromDouble(double number)
     {
@@ -434,58 +434,58 @@ internal static unsafe class InteropUtils
     internal static sbyte DNObjectCastToInt8(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
             sbyte returnValue = (sbyte)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(sbyte);
         }
     }
-    
+
     [UnmanagedCallersOnly(EntryPoint = "DNObjectFromInt8")]
     internal static void* /* System.Object */ DNObjectFromInt8(sbyte number)
     {
         return ((System.Object)number).AllocateGCHandleAndGetAddress();
     }
     #endregion Int8
-    
+
     #region UInt8
     [UnmanagedCallersOnly(EntryPoint = "DNObjectCastToUInt8")]
     internal static byte DNObjectCastToUInt8(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
             byte returnValue = (byte)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(byte);
         }
     }
-    
+
     [UnmanagedCallersOnly(EntryPoint = "DNObjectFromUInt8")]
     internal static void* /* System.Object */ DNObjectFromUInt8(byte number)
     {
@@ -498,58 +498,58 @@ internal static unsafe class InteropUtils
     internal static Int16 DNObjectCastToInt16(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
             Int16 returnValue = (Int16)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(Int16);
         }
     }
-    
+
     [UnmanagedCallersOnly(EntryPoint = "DNObjectFromInt16")]
     internal static void* /* System.Object */ DNObjectFromInt16(Int16 number)
     {
         return ((System.Object)number).AllocateGCHandleAndGetAddress();
     }
     #endregion Int16
-    
+
     #region UInt16
     [UnmanagedCallersOnly(EntryPoint = "DNObjectCastToUInt16")]
     internal static UInt16 DNObjectCastToUInt16(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
             UInt16 returnValue = (UInt16)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(UInt16);
         }
     }
-    
+
     [UnmanagedCallersOnly(EntryPoint = "DNObjectFromUInt16")]
     internal static void* /* System.Object */ DNObjectFromUInt16(UInt16 number)
     {
@@ -562,22 +562,22 @@ internal static unsafe class InteropUtils
     internal static Int32 DNObjectCastToInt32(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
 	        Int32 returnValue = (Int32)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(Int32);
         }
     }
@@ -588,28 +588,28 @@ internal static unsafe class InteropUtils
         return ((System.Object)number).AllocateGCHandleAndGetAddress();
     }
     #endregion Int32
-    
+
     #region UInt32
     [UnmanagedCallersOnly(EntryPoint = "DNObjectCastToUInt32")]
     internal static UInt32 DNObjectCastToUInt32(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
 	        UInt32 returnValue = (UInt32)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(UInt32);
         }
     }
@@ -626,22 +626,22 @@ internal static unsafe class InteropUtils
     internal static Int64 DNObjectCastToInt64(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
             Int64 returnValue = (Int64)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(Int64);
         }
     }
@@ -652,28 +652,28 @@ internal static unsafe class InteropUtils
         return ((System.Object)number).AllocateGCHandleAndGetAddress();
     }
     #endregion Int64
-    
+
     #region UInt64
     [UnmanagedCallersOnly(EntryPoint = "DNObjectCastToUInt64")]
     internal static UInt64 DNObjectCastToUInt64(void* /* System.Object */ @object, void** /* out System.Exception */ outException)
     {
         System.Object objectConverted = InteropUtils.GetInstance<System.Object>(@object);
-    
+
         try {
             UInt64 returnValue = (UInt64)objectConverted;
-    
+
             if (outException is not null) {
                 *outException = null;
             }
-    
+
             return returnValue;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-    
+
             return default(UInt64);
         }
     }
@@ -685,7 +685,7 @@ internal static unsafe class InteropUtils
     }
     #endregion UInt64
     #endregion Boxing/Unboxing of primitives
-    
+
     #region Byte Conversions
     [UnmanagedCallersOnly(EntryPoint = "DNGetPinnedPointerToByteArray")]
     internal static void* DNGetPinnedPointerToByteArray(
@@ -695,57 +695,57 @@ internal static unsafe class InteropUtils
     )
     {
         byte[] byteArrayConverted = InteropUtils.GetInstance<byte[]>(byteArray);
-        
+
         if (byteArrayConverted is null) {
             if (outGCHandle is not null) {
                 *outGCHandle = null;
             }
-            
+
             if (outException is not null) {
                 *outException = null;
             }
-            
+
             return null;
         }
-        
+
         try {
             var length = byteArrayConverted.Length;
-            
+
             if (length <= 0) {
                 if (outGCHandle is not null) {
                    *outGCHandle = null;
                 }
-               
+
                 if (outException is not null) {
                     *outException = null;
                 }
-                
+
                 return null;
             }
-            
+
             var gcHandle = System.Runtime.InteropServices.GCHandle.Alloc(byteArrayConverted, GCHandleType.Pinned);
             var byteArrayConvertedPtr = System.Runtime.CompilerServices.Unsafe.AsPointer(ref byteArrayConverted[0]);
-            
+
             if (outGCHandle is not null) {
                 *outGCHandle = gcHandle.AllocateGCHandleAndGetAddress();
             }
-            
+
             if (outException is not null) {
                 *outException = null;
             }
-            
+
             return byteArrayConvertedPtr;
         } catch (Exception exception) {
             if (outException is not null) {
                 void* exceptionHandleAddress = exception.AllocateGCHandleAndGetAddress();
-                    
+
                 *outException = exceptionHandleAddress;
             }
-            
+
             if (outGCHandle is not null) {
                 *outGCHandle = null;
             }
-        
+
             return null;
         }
     }
@@ -758,18 +758,18 @@ internal readonly unsafe struct DNReadOnlySpanOfByte
 {
     internal void* DataPointer { get; } = null;
     internal int DataLength { get; } = 0;
-    
+
     internal DNReadOnlySpanOfByte(ReadOnlySpan<byte> span)
     {
         var length = span.Length;
-        
+
         if (length <= 0) {
             DataPointer = null;
             DataLength = 0;
-            
+
             return;
         }
-        
+
         // For a no-copy option see: https://www.answeroverflow.com/m/1042197174982811719
 
         // Console.WriteLine($"[C#] Allocating pointer to buffer of {length} bytes to copy data of ReadOnlySpan<byte> to");
@@ -779,10 +779,10 @@ internal readonly unsafe struct DNReadOnlySpanOfByte
             destinationDataPointer,
             length
         );
-        
+
         // Console.WriteLine($"[C#] Copying ReadOnlySpan<byte> to native pointer at 0x{(nint)destinationDataPointer:X}");
         span.CopyTo(destinationSpan);
-        
+
         DataPointer = destinationDataPointer;
         DataLength = length;
     }
@@ -798,7 +798,7 @@ internal readonly unsafe struct DNReadOnlySpanOfByte
             if (dataLength > 0) {
                 // Console.WriteLine($"[C#] Allocating byte[] of {dataLength} bytes to copy data of native pointer to");
                 var array = new byte[dataLength];
-            
+
                 // Console.WriteLine($"[C#] Copying data of native pointer at 0x{(nint)dataPointer:X} to byte[]");
                 System.Runtime.InteropServices.Marshal.Copy(
                     (nint)dataPointer,
@@ -816,10 +816,10 @@ internal readonly unsafe struct DNReadOnlySpanOfByte
         } else {
             span = ReadOnlySpan<byte>.Empty;
         }
-     
+
         return span;
     }
-    
+
     internal static DNReadOnlySpanOfByte Empty => new();
 }
 

--- a/Generator/Beyond.NET.CodeGenerator/Generator/Kotlin/KotlinCodeBuilder.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/Kotlin/KotlinCodeBuilder.cs
@@ -12,14 +12,14 @@ readonly struct KotlinCodeBuilder
 
     internal KotlinCodeBuilder([StringSyntax("Kt")] string? value = null) : this(new StringBuilder(value))
     { }
-    
+
     private KotlinCodeBuilder(StringBuilder sb) => m_sb = sb;
-    
+
     internal KotlinCodeBuilder Append(char c) => new(m_sb.Append(c));
-    
+
     internal KotlinCodeBuilder Append([StringSyntax("Kt")] string value) => new(m_sb.Append(value));
-    
+
     internal KotlinCodeBuilder AppendLine([StringSyntax("Kt")] string? value = null) => new(m_sb.AppendLine(value));
-    
+
     public override string ToString() => m_sb.ToString();
 }

--- a/Generator/Beyond.NET.CodeGenerator/Generator/Kotlin/KotlinSharedCode.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/Kotlin/KotlinSharedCode.cs
@@ -14,27 +14,27 @@ open class DNObject(handle: Pointer): IDNObject {
         Normal,
         Skip
     }
-    
+
     final override val __handle: Pointer = handle
     var __destroyMode: DestroyMode = DestroyMode.Normal
-    
+
     init {
         require(handle != null) {
             "Cannot initialize DNObject with a null pointer"
         }
     }
-    
+
     protected fun finalize() {
         if (__handle == null) {
             return
         }
-        
+
         when (__destroyMode) {
             DestroyMode.Normal -> destroy()
             DestroyMode.Skip -> {}
         }
     }
-    
+
     override fun destroy() {
         // Override in subclass
     }
@@ -99,7 +99,7 @@ fun IDNObject?.getHandleOrNull(): Pointer? {
     this?.let {
         return this.__handle
     }
-    
+
     return null
 }
 
@@ -115,11 +115,11 @@ fun Pointer.toUPointer(): UPointer {
 // TODO: Is this correct? Unlikely
 public class UPointerByReference : PointerByReference {
     constructor(value: UPointer) : super(value.toPointer()) {
-        
+
     }
 
     constructor() : super() {
-        
+
     }
 }
 
@@ -544,19 +544,19 @@ open class DNNullableArray<T: System_Object?>(handle: Pointer, klassOfT: Class<T
         return /*lang=Kt*/$$"""
 fun IDNObject.castTo(type: System_Type): System_Object? {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = {{jnaClassName}}.DNObjectCastTo(this.__handle, type.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     if (__returnValueC == null) {
         return null
     }
-    
+
     val __returnValue = System_Object(__returnValueC)
 
     return __returnValue
@@ -611,15 +611,15 @@ fun IDNObject.`is`(type: System_Type): Boolean {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToBool(): Boolean {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToBool(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC
 }
 
@@ -627,7 +627,7 @@ fun IDNObject.castToBool(): Boolean {
 /// - Returns: An .NET object containing the boxed value.
 fun Boolean.toDotNETObject(): System_Boolean {
     val castedObjectC = CAPI.DNObjectFromBool(this)
-    
+
     return System_Boolean(castedObjectC)
 }
 
@@ -636,15 +636,15 @@ fun Boolean.toDotNETObject(): System_Boolean {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToChar(): Char {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToChar(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC
 }
 
@@ -652,7 +652,7 @@ fun IDNObject.castToChar(): Char {
 /// - Returns: An .NET object containing the boxed value.
 fun Char.toDotNETObject(): System_Char {
     val castedObjectC = CAPI.DNObjectFromChar(this)
-    
+
     return System_Char(castedObjectC)
 }
 
@@ -661,15 +661,15 @@ fun Char.toDotNETObject(): System_Char {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToFloat(): Float {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToFloat(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC
 }
 
@@ -677,7 +677,7 @@ fun IDNObject.castToFloat(): Float {
 /// - Returns: An .NET object containing the boxed value.
 fun Float.toDotNETObject(): System_Single {
     val castedObjectC = CAPI.DNObjectFromFloat(this)
-    
+
     return System_Single(castedObjectC)
 }
 
@@ -686,15 +686,15 @@ fun Float.toDotNETObject(): System_Single {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToDouble(): Double {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToDouble(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC
 }
 
@@ -702,7 +702,7 @@ fun IDNObject.castToDouble(): Double {
 /// - Returns: An .NET object containing the boxed value.
 fun Double.toDotNETObject(): System_Double {
     val castedObjectC = CAPI.DNObjectFromDouble(this)
-    
+
     return System_Double(castedObjectC)
 }
 
@@ -711,15 +711,15 @@ fun Double.toDotNETObject(): System_Double {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToByte(): Byte {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToInt8(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC
 }
 
@@ -727,7 +727,7 @@ fun IDNObject.castToByte(): Byte {
 /// - Returns: An .NET object containing the boxed value.
 fun Byte.toDotNETObject(): System_SByte {
     val castedObjectC = CAPI.DNObjectFromInt8(this)
-    
+
     return System_SByte(castedObjectC)
 }
 
@@ -736,15 +736,15 @@ fun Byte.toDotNETObject(): System_SByte {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToUByte(): UByte {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToUInt8(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC.toUByte()
 }
 
@@ -752,7 +752,7 @@ fun IDNObject.castToUByte(): UByte {
 /// - Returns: An .NET object containing the boxed value.
 fun UByte.toDotNETObject(): System_Byte {
     val castedObjectC = CAPI.DNObjectFromUInt8(this.toByte())
-    
+
     return System_Byte(castedObjectC)
 }
 
@@ -761,15 +761,15 @@ fun UByte.toDotNETObject(): System_Byte {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToShort(): Short {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToInt16(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC
 }
 
@@ -777,7 +777,7 @@ fun IDNObject.castToShort(): Short {
 /// - Returns: An .NET object containing the boxed value.
 fun Short.toDotNETObject(): System_Int16 {
     val castedObjectC = CAPI.DNObjectFromInt16(this)
-    
+
     return System_Int16(castedObjectC)
 }
 
@@ -786,15 +786,15 @@ fun Short.toDotNETObject(): System_Int16 {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToUShort(): UShort {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToUInt16(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC.toUShort()
 }
 
@@ -802,7 +802,7 @@ fun IDNObject.castToUShort(): UShort {
 /// - Returns: An .NET object containing the boxed value.
 fun UShort.toDotNETObject(): System_UInt16 {
     val castedObjectC = CAPI.DNObjectFromUInt16(this.toShort())
-    
+
     return System_UInt16(castedObjectC)
 }
 
@@ -811,15 +811,15 @@ fun UShort.toDotNETObject(): System_UInt16 {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToInt(): Int {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToInt32(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC
 }
 
@@ -827,7 +827,7 @@ fun IDNObject.castToInt(): Int {
 /// - Returns: An .NET object containing the boxed value.
 fun Int.toDotNETObject(): System_Int32 {
     val castedObjectC = CAPI.DNObjectFromInt32(this)
-    
+
     return System_Int32(castedObjectC)
 }
 
@@ -836,15 +836,15 @@ fun Int.toDotNETObject(): System_Int32 {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToUInt(): UInt {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToUInt32(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC.toUInt()
 }
 
@@ -852,7 +852,7 @@ fun IDNObject.castToUInt(): UInt {
 /// - Returns: An .NET object containing the boxed value.
 fun UInt.toDotNETObject(): System_UInt32 {
     val castedObjectC = CAPI.DNObjectFromUInt32(this.toInt())
-    
+
     return System_UInt32(castedObjectC)
 }
 
@@ -861,15 +861,15 @@ fun UInt.toDotNETObject(): System_UInt32 {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToLong(): Long {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToInt64(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC
 }
 
@@ -877,7 +877,7 @@ fun IDNObject.castToLong(): Long {
 /// - Returns: An .NET object containing the boxed value.
 fun Long.toDotNETObject(): System_Int64 {
     val castedObjectC = CAPI.DNObjectFromInt64(this)
-    
+
     return System_Int64(castedObjectC)
 }
 
@@ -886,15 +886,15 @@ fun Long.toDotNETObject(): System_Int64 {
 /// - Throws: If the cast fails, an exception is thrown.
 fun IDNObject.castToULong(): ULong {
     val __exceptionC = PointerByReference()
-    
+
     val __returnValueC = CAPI.DNObjectCastToUInt64(this.__handle, __exceptionC)
-    
+
     val __exceptionCHandle = __exceptionC.value
-    
+
     if (__exceptionCHandle != null) {
         throw System_Exception(__exceptionCHandle).toKException()
     }
-    
+
     return __returnValueC.toULong()
 }
 
@@ -902,7 +902,7 @@ fun IDNObject.castToULong(): ULong {
 /// - Returns: An .NET object containing the boxed value.
 fun ULong.toDotNETObject(): System_UInt64 {
     val castedObjectC = CAPI.DNObjectFromUInt64(this.toLong())
-    
+
     return System_UInt64(castedObjectC)
 }
 

--- a/Generator/Beyond.NET.CodeGenerator/Generator/Result.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/Result.cs
@@ -36,7 +36,7 @@ public class Result
 
         return destructors.FirstOrDefault();
     }
-    
+
     public GeneratedMember? GetGeneratedTypeOf(Type type)
     {
         var typeOfs = GetGeneratedMembers(
@@ -59,7 +59,7 @@ public class Result
         var generatedMembers = m_generatedTypes[type];
 
         List<GeneratedMember> members = new();
-        
+
         foreach (var generatedMember in generatedMembers) {
             if (generatedMember.MemberKind == memberKind) {
                 members.Add(generatedMember);
@@ -68,7 +68,7 @@ public class Result
 
         return members;
     }
-    
+
     public GeneratedMember? GetGeneratedMember(MemberInfo member)
     {
         Type declaringType = member.DeclaringType ?? throw new Exception("No declaring type");
@@ -83,7 +83,7 @@ public class Result
 
         return null;
     }
-    
+
     public GeneratedMember? GetGeneratedMember(
         MemberInfo member,
         MemberKind memberKind

--- a/Generator/Beyond.NET.CodeGenerator/Generator/Swift/Settings.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/Swift/Settings.cs
@@ -4,6 +4,6 @@ public class Settings: Generator.Settings
 {
     public Settings()
     {
-        
+
     }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Generator/Swift/SwiftCodeBuilder.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/Swift/SwiftCodeBuilder.cs
@@ -12,14 +12,14 @@ readonly struct SwiftCodeBuilder
 
     internal SwiftCodeBuilder([StringSyntax("Swift")] string? value = null) : this(new StringBuilder(value))
     { }
-    
+
     private SwiftCodeBuilder(StringBuilder sb) => m_sb = sb;
-    
+
     internal SwiftCodeBuilder Append(char c) => new(m_sb.Append(c));
-    
+
     internal SwiftCodeBuilder Append([StringSyntax("Swift")] string value) => new(m_sb.Append(value));
-    
+
     internal SwiftCodeBuilder AppendLine([StringSyntax("Swift")] string? value = null) => new(m_sb.AppendLine(value));
-    
+
     public override string ToString() => m_sb.ToString();
 }

--- a/Generator/Beyond.NET.CodeGenerator/Generator/Swift/SwiftCodeGenerator.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/Swift/SwiftCodeGenerator.cs
@@ -15,7 +15,7 @@ public class SwiftCodeGenerator: ICodeGenerator
     public Settings Settings { get; }
     public Result CSharpUnmanagedResult { get; }
     public Result CResult { get; }
-    
+
     public SwiftCodeGenerator(
         Settings settings,
         Result cSharpUnmanagedResult,
@@ -34,7 +34,7 @@ public class SwiftCodeGenerator: ICodeGenerator
     )
     {
         SwiftSyntaxWriterConfiguration defaultSyntaxWriterConfiguration = new();
-        
+
         SourceCodeSection headerSection = writer.AddSection("Header");
         SourceCodeSection utilsSection = writer.AddSection("Utils");
         SourceCodeSection commonTypesSection = writer.AddSection("Common Types");
@@ -43,10 +43,10 @@ public class SwiftCodeGenerator: ICodeGenerator
         SourceCodeSection extensionsSection = writer.AddSection("API Extensions");
         SourceCodeSection namespacesSection = writer.AddSection("Namespaces");
         SourceCodeSection footerSection = writer.AddSection("Footer");
-        
+
         string header = GetHeaderCode();
         headerSection.Code.AppendLine(header);
-        
+
         string utilsCode = GetUtilsCode(types.ToArray());
         utilsSection.Code.AppendLine(utilsCode);
 
@@ -57,9 +57,9 @@ public class SwiftCodeGenerator: ICodeGenerator
             foreach (var kvp in unsupportedTypes) {
                 Type type = kvp.Key;
                 string reason = kvp.Value;
-    
+
                 string typeName = type.FullName ?? type.Name;
-    
+
                 unsupportedTypesSection.Code.AppendLine($"// Unsupported Type \"{typeName}\": {reason}");
             }
         } else {
@@ -78,9 +78,9 @@ public class SwiftCodeGenerator: ICodeGenerator
 
         foreach (Type type in orderedTypes) {
             bool isInterface = type.IsInterface;
-            
+
             Syntax.State state = new(CSharpUnmanagedResult, CResult);
-            
+
             string typeCode = typeSyntaxWriter.Write(
                 type,
                 state,
@@ -88,9 +88,9 @@ public class SwiftCodeGenerator: ICodeGenerator
                     InterfaceGenerationPhase = SwiftSyntaxWriterConfiguration.InterfaceGenerationPhases.Protocol
                 } : defaultSyntaxWriterConfiguration
             );
-            
+
             apisSection.Code.AppendLine(typeCode);
-            
+
             if (isInterface) {
                 string protocolExtensionCode = typeSyntaxWriter.Write(
                     type,
@@ -99,9 +99,9 @@ public class SwiftCodeGenerator: ICodeGenerator
                         InterfaceGenerationPhase = SwiftSyntaxWriterConfiguration.InterfaceGenerationPhases.ProtocolExtensionForDefaultImplementations
                     }
                 );
-                
+
                 apisSection.Code.AppendLine(protocolExtensionCode);
-                
+
                 string implementationClassCode = typeSyntaxWriter.Write(
                     type,
                     state,
@@ -109,28 +109,28 @@ public class SwiftCodeGenerator: ICodeGenerator
                         InterfaceGenerationPhase = SwiftSyntaxWriterConfiguration.InterfaceGenerationPhases.ImplementationClass
                     }
                 );
-                
+
                 apisSection.Code.AppendLine(implementationClassCode);
             }
 
             if (state.SkippedTypes.Contains(type)) {
                 continue;
             }
-            
+
             result.AddGeneratedType(
                 type,
                 state.GeneratedMembers
-            );                
+            );
 
             /* if (isInterface) {
                 syntaxWriterConfiguration.OnlyWriteSignatureForProtocol = false;
-                
+
                 string typeImplCode = typeSyntaxWriter.Write(
                     type,
                     state,
                     syntaxWriterConfiguration
                 );
-            
+
                 apisSection.Code.AppendLine(typeImplCode);
             } */
 
@@ -150,11 +150,11 @@ public class SwiftCodeGenerator: ICodeGenerator
                 }
 
                 Type extendedType = firstParameter.ParameterType;
-                
+
                 if (!typeExtensionMembers.TryGetValue(extendedType, out List<GeneratedMember>? extensionMembers)) {
                     extensionMembers = new();
                 }
-            
+
                 extensionMembers.Add(generatedMember);
 
                 if (extensionMembers.Count > 0) {
@@ -182,12 +182,12 @@ public class SwiftCodeGenerator: ICodeGenerator
                 result,
                 TypeDescriptorRegistry.Shared
             );
-            
+
             namespacesSection.Code.AppendLine(namespacesCode);
         } else {
             namespacesSection.Code.AppendLine("// Omitted due to settings");
         }
-        
+
         string footerCode = GetFooterCode();
         footerSection.Code.AppendLine(footerCode);
 
@@ -200,9 +200,9 @@ public class SwiftCodeGenerator: ICodeGenerator
     )
     {
         SwiftCodeBuilder sb = new();
-        
+
         var namespaceTree = result.GetNamespaceTreeOfGeneratedTypes();
-        
+
         foreach (var node in namespaceTree.Children) {
             string nodeCode = GetNamespaceCode(
                 node,
@@ -229,9 +229,9 @@ public class SwiftCodeGenerator: ICodeGenerator
         }
 
         SwiftCodeBuilder sb = new();
-        
+
         string name = namespaceNode.Name;
-        
+
         string parentNames = namespaceNode.CompoundParentNames;
         string fullNamespaceName = namespaceNode.FullName;
         var typesInNamespace = result.GetTypesInNamespace(fullNamespaceName);
@@ -242,14 +242,14 @@ public class SwiftCodeGenerator: ICodeGenerator
             if (type.IsArray) {
                 continue;
             }
-            
+
             Type nonByRefType = type.GetNonByRefType();
 
             if (nonByRefType.IsArray) {
                 continue;
             }
 
-            if (nonByRefType.IsGenericType || 
+            if (nonByRefType.IsGenericType ||
                 nonByRefType.IsConstructedGenericType ||
                 nonByRefType.IsGenericTypeDefinition ||
                 nonByRefType.IsGenericParameter) {
@@ -260,7 +260,7 @@ public class SwiftCodeGenerator: ICodeGenerator
                 Type? elementType = nonByRefType.GetElementType();
 
                 if (elementType is not null) {
-                    if (elementType.IsGenericType || 
+                    if (elementType.IsGenericType ||
                         elementType.IsConstructedGenericType ||
                         elementType.IsGenericTypeDefinition ||
                         elementType.IsGenericParameter) {
@@ -281,7 +281,7 @@ public class SwiftCodeGenerator: ICodeGenerator
             }
 
             string swiftNamespacePrefix = fullNamespaceName.Replace('.', '_') + "_";
-            
+
             string swiftTypeNameWithoutNamespace = swiftTypeName
                 .Replace(swiftNamespacePrefix, string.Empty)
                 .EscapedSwiftTypeAliasTypeName();
@@ -295,12 +295,12 @@ public class SwiftCodeGenerator: ICodeGenerator
             var swiftTypeName = kvp.Key;
             var type = kvp.Value.Item1;
             var swiftTypeNameWithoutNamespace = kvp.Value.Item2;
-            
+
             var typeAlias = Builder.TypeAlias(swiftTypeNameWithoutNamespace, swiftTypeName)
                 .Public()
                 .Build()
                 .ToString();
-            
+
             var typeDocumentationComment = type.GetDocumentation()
                 ?.GetFormattedDocumentationComment();
 
@@ -312,16 +312,16 @@ public class SwiftCodeGenerator: ICodeGenerator
                     .Public()
                     .Build()
                     .ToString();
-            
+
                 sbTypeAliases.AppendLine(typeDocumentationComment);
                 sbTypeAliases.AppendLine(interfaceImplTypeAlias);
             }
         }
 
         string typeAliasesCode = sbTypeAliases.ToString();
-        
+
         string nodeCode;
-            
+
         if (string.IsNullOrEmpty(parentNames)) {
             nodeCode = $@"
 public struct {name} {{
@@ -339,14 +339,14 @@ public extension {parentNames} {{
         }
 
         sb.AppendLine(nodeCode);
-        
+
         foreach (var subNode in namespaceNode.Children) {
             string subNodeCode = GetNamespaceCode(
                 subNode,
                 result,
                 typeDescriptorRegistry
             );
-                
+
             sb.AppendLine(subNodeCode);
         }
 
@@ -361,11 +361,11 @@ public extension {parentNames} {{
 import Foundation
 """;
     }
-    
+
     private string GetUtilsCode(Type[] types)
     {
         SwiftCodeBuilder sb = new();
-        
+
         sb.AppendLine(SwiftSharedCode.SharedCode);
         sb.AppendLine();
 
@@ -380,7 +380,7 @@ import Foundation
         }
 
         string code = sb.ToString();
-        
+
         return code;
     }
 
@@ -388,7 +388,7 @@ import Foundation
     {
         return "";
     }
-    
+
     private string GetFooterCode()
     {
         return """

--- a/Generator/Beyond.NET.CodeGenerator/Generator/Swift/SwiftSharedCode.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Generator/Swift/SwiftSharedCode.cs
@@ -9,25 +9,25 @@ public struct DNChar: Equatable {
     public init(cValue: wchar_t) {
         self.cValue = cValue
     }
-    
+
     public init?(character: Character) {
         guard let unicodeScalar = character.unicodeScalars.first else {
             return nil
         }
-        
+
         let unicodeScalarValue = unicodeScalar.value
         let wcharValue = wchar_t(unicodeScalarValue)
-        
+
         self.init(cValue: wcharValue)
     }
-    
+
     public var character: Character? {
         guard let unicodeScalarValue = UnicodeScalar(UInt32(cValue)) else {
             return nil
         }
-        
+
         let character = Character(unicodeScalarValue)
-        
+
         return character
     }
 
@@ -45,22 +45,22 @@ public class DNObject {
         case deallocateHandle
         case skip
     }
-    
+
     let __handle: UnsafeMutableRawPointer
     var __destroyMode = DestroyMode.normal
-    
+
     public private(set) var isOutParameterPlaceholder = false
 
     /// The .NET type name of this type.
     /// - Returns: The equivalent of calling `typeof(ADotNETType).Name` in C#.
     public class var typeName: String { "" }
-    
+
     /// The .NET full type name of this type.
     /// - Returns: The equivalent of calling `typeof(ADotNETType).FullName` in C#.
     public class var fullTypeName: String { "" }
-    
+
     /// The .NET System.Type of this type.
-    /// - Returns: The equivalent of calling `typeof(ADotNETType)` in C#. 
+    /// - Returns: The equivalent of calling `typeof(ADotNETType)` in C#.
     public class var typeOf: System_Type /* System.Type */ {
         fatalError("Override in subclass")
     }
@@ -68,7 +68,7 @@ public class DNObject {
     required init(handle: UnsafeMutableRawPointer) {
         // Enable for debugging
         // print("[DEBUG] Initializing \(Self.fullTypeName) with handle \(handle)")
-        
+
 		self.__handle = handle
 	}
 
@@ -77,30 +77,30 @@ public class DNObject {
 
 		self.init(handle: handle)
 	}
-	
+
 	/// This returns a "placeholder" object for calling .NET APIs that return a non-optional value as `out` parameter. In this case, you can either provide a proper default value (which will never be used) or you can get an out parameter placeholder using this function.
 	/// Because Swift does not support `out` parameters like .NET does, you might run into situations where you need to provide a default value to satisfy the compiler but you don't want to or simply can't create an object of the `out` parameter's type.
-	/// Do NOT(!) call any APIs on this "placeholder" object as it will crash the program! Use it ONLY(!) to provide a "fake" default value for .NET APIs that receive a value via an `out` parameter. 
-	/// Do NOT(!) use this to pass a default value to .NET APIs that receive an optional(!) value as `out` parameter! In this case, just use a regular Swift optional. 
+	/// Do NOT(!) call any APIs on this "placeholder" object as it will crash the program! Use it ONLY(!) to provide a "fake" default value for .NET APIs that receive a value via an `out` parameter.
+	/// Do NOT(!) use this to pass a default value to .NET APIs that receive an optional(!) value as `out` parameter! In this case, just use a regular Swift optional.
 	public static var outParameterPlaceholder: Self {
         let byteCount = MemoryLayout<AnyObject>.stride
         let alignment = MemoryLayout<AnyObject>.alignment
-        
+
         let handle = UnsafeMutableRawPointer.allocate(byteCount: byteCount,
                                                       alignment: alignment)
-        
+
         handle.initializeMemory(as: Int.self, to: 0)
-        
+
         let inst = self.init(handle: handle)
-        
+
         // Mark this instance as being an out parameter placeholder. Makes debugging easier in case something goes wrong.
         inst.isOutParameterPlaceholder = true
-        
+
         inst.__destroyMode = .deallocateHandle
-        
+
         return inst
     }
-	
+
     internal func destroy() {
         // Override in subclass
     }
@@ -110,17 +110,17 @@ public class DNObject {
             case .normal:
                 // Enable for debugging
                 // print("[DEBUG] Will destroy \(Self.fullTypeName) with handle \(self.__handle)")
-        
+
                 destroy()
-        
+
                 // Enable for debugging
                 // print("[DEBUG] Did destroy \(Self.fullTypeName) with handle \(self.__handle)")
             case .deallocateHandle:
                 // Enable for debugging
                 // print("[DEBUG] Will deallocate \(Self.fullTypeName) with handle \(self.__handle)")
-                
+
                 self.__handle.deallocate()
-                
+
                 // Enable for debugging
                 // print("[DEBUG] Did deallocate \(Self.fullTypeName) with handle \(self.__handle)")
             case .skip:
@@ -136,91 +136,91 @@ public class DNObject {
 public class DNNullableArray<T: System_Object>: System_Array, MutableCollection {
     public typealias Element = T?
     public typealias Index = Int32
-    
+
     public override class var typeOf: System_Type /* System.Type */ {
         let elementType = T.typeOf
-        
+
         if let arrayType = try? elementType.makeArrayType() {
             return arrayType
         }
-        
+
         return super.typeOf
     }
-    
+
     public override class var typeName: String {
         let type = typeOf
-        
+
         if let name = try? type.name.string() {
             return name
         }
-        
+
         return "\(T.typeName)[]"
     }
-    
+
     public override class var fullTypeName: String {
         let type = typeOf
-        
+
         if let name = try? type.fullName?.string() {
             return name
         }
-        
+
         return "\(T.fullTypeName)[]"
     }
-    
+
     /// - Returns: An empty .NET array of the specified type.
     public static var empty: DNNullableArray<T> { get throws {
         try DNNullableArray<T>.init()
     }}
-    
+
     /// Creates and initializes an empty .NET array of the specified type.
     public convenience init() throws {
         let elementType = T.typeOf
         let elementTypeC = elementType.__handle
-        
+
         var __exceptionC: System_Exception_t?
-        
+
         let newArrayC = System_Array_CreateInstance(elementTypeC, 0, &__exceptionC)
-        
+
         if let __exceptionC {
             let __exception = System_Exception(handle: __exceptionC)
             let __error = __exception.swiftError
-            
+
             throw __error
         }
-        
+
         self.init(handle: newArrayC)
     }
-    
+
     /// Creates and initializes a .NET array of the specified type and length.
     public convenience init(length: Index) throws {
         let elementType = T.typeOf
         let elementTypeC = elementType.__handle
-        
+
         var __exceptionC: System_Exception_t?
-        
+
         let newArrayC = System_Array_CreateInstance(elementTypeC, length, &__exceptionC)
-        
+
         if let __exceptionC {
             let __exception = System_Exception(handle: __exceptionC)
             let __error = __exception.swiftError
-            
+
             throw __error
         }
-        
+
         self.init(handle: newArrayC)
     }
-    
+
     /// Get or set and element of this .NET array at the specified position/index.
     /// If an exception is raised on the .NET side while indexing into the array, a fatalError will be raised on the Swift side of things.
     public subscript(position: Index) -> Element {
         get {
             assert(position >= startIndex && position < endIndex, "Out of bounds")
-            
+
             do {
                 guard let element = try getValue(position) else {
                     return nil
                 }
-                
+
                 return try element.castTo()
             } catch {
                 fatalError("An exception was thrown while calling System.Array.GetValue: \(error.localizedDescription)")
@@ -236,7 +236,7 @@ public class DNNullableArray<T: System_Object>: System_Array, MutableCollection 
             }
         }
     }
-    
+
     public func nonNullable() throws -> DNArray<T> {
         try self.castTo()
     }
@@ -247,91 +247,91 @@ public class DNNullableArray<T: System_Object>: System_Array, MutableCollection 
 public class DNArray<T: System_Object>: System_Array, MutableCollection {
     public typealias Element = T
     public typealias Index = Int32
-    
+
     public override class var typeOf: System_Type /* System.Type */ {
         let elementType = T.typeOf
-        
+
         if let arrayType = try? elementType.makeArrayType() {
             return arrayType
         }
-        
+
         return super.typeOf
     }
-    
+
     public override class var typeName: String {
         let type = typeOf
-        
+
         if let name = try? type.name.string() {
             return name
         }
-        
+
         return "\(T.typeName)[]"
     }
-    
+
     public override class var fullTypeName: String {
         let type = typeOf
-        
+
         if let name = try? type.fullName?.string() {
             return name
         }
-        
+
         return "\(T.fullTypeName)[]"
     }
-    
+
     /// - Returns: An empty .NET array of the specified type.
     public static var empty: DNArray<T> { get throws {
         try DNArray<T>.init()
     }}
-    
+
     /// Creates and initializes an empty .NET array of the specified type.
     public convenience init() throws {
         let elementType = T.typeOf
         let elementTypeC = elementType.__handle
-        
+
         var __exceptionC: System_Exception_t?
-        
+
         let newArrayC = System_Array_CreateInstance(elementTypeC, 0, &__exceptionC)
-        
+
         if let __exceptionC {
             let __exception = System_Exception(handle: __exceptionC)
             let __error = __exception.swiftError
-            
+
             throw __error
         }
-        
+
         self.init(handle: newArrayC)
     }
-    
+
     /// Creates and initializes a .NET array of the specified type and length.
     public convenience init(length: Index) throws {
         let elementType = T.typeOf
         let elementTypeC = elementType.__handle
-        
+
         var __exceptionC: System_Exception_t?
-        
+
         let newArrayC = System_Array_CreateInstance(elementTypeC, length, &__exceptionC)
-        
+
         if let __exceptionC {
             let __exception = System_Exception(handle: __exceptionC)
             let __error = __exception.swiftError
-            
+
             throw __error
         }
-        
+
         self.init(handle: newArrayC)
     }
-    
+
     /// Get or set and element of this .NET array at the specified position/index.
     /// If an exception is raised on the .NET side while indexing into the array, a fatalError will be raised on the Swift side of things.
     public subscript(position: Index) -> Element {
         get {
             assert(position >= startIndex && position < endIndex, "Out of bounds")
-            
+
             do {
                 guard let element = try getValue(position) else {
                     throw DNSystemError.unexpectedNull
                 }
-                
+
                 return try element.castTo()
             } catch {
                 fatalError("An exception was thrown while calling System.Array.GetValue: \(error.localizedDescription)")
@@ -347,7 +347,7 @@ public class DNArray<T: System_Object>: System_Array, MutableCollection {
             }
         }
     }
-    
+
     public func nullable() throws -> DNNullableArray<T> {
         try self.castTo()
     }
@@ -358,39 +358,39 @@ public class DNArray<T: System_Object>: System_Array, MutableCollection {
 public class DNNullableMultidimensionalArray<T: System_Object>: System_Array {
     public typealias Element = T?
     public typealias Indices = [Int32]
-    
+
     /// Creates and initializes a multidimensional .NET array of the specified type and lengths.
     public convenience init(lengths: Indices) throws {
         let elementType = T.typeOf
         let elementTypeC = elementType.__handle
         let lengthsDN = try Self.indicesToDN(lengths)
         let lengthsDNC = lengthsDN.__handle
-        
+
         var __exceptionC: System_Exception_t?
-        
+
         let newArrayC = System_Array_CreateInstance_3(elementTypeC, lengthsDNC, &__exceptionC)
-        
+
         if let __exceptionC {
             let __exception = System_Exception(handle: __exceptionC)
             let __error = __exception.swiftError
-            
+
             throw __error
         }
-        
+
         self.init(handle: newArrayC)
     }
-    
+
     /// Get or set and element of this multidimensional .NET array at the specified indices.
     /// If an exception is raised on the .NET side while indexing into the array, a fatalError will be raised on the Swift side of things.
     public subscript(position: Indices) -> Element {
         get {
             do {
                 let indices = try Self.indicesToDN(position)
-                
+
                 guard let element = try getValue(indices) else {
                     return nil
                 }
-                
+
                 return try element.castTo()
             } catch {
                 fatalError("An exception was thrown while calling System.Array.GetValue: \(error.localizedDescription)")
@@ -410,14 +410,14 @@ public class DNNullableMultidimensionalArray<T: System_Object>: System_Array {
     private static func indicesToDN(_ indices: Indices) throws -> DNArray<System_Int32> {
         let count = Int32(indices.count)
         let indicesDN = try DNArray<System_Int32>(length: count)
-        
+
         for (idx, index) in indices.enumerated() {
             indicesDN[Int32(idx)] = index.dotNETObject()
         }
 
         return indicesDN
     }
-    
+
     public func nonNullable() throws -> DNMultidimensionalArray<T> {
         try self.castTo()
     }
@@ -428,39 +428,39 @@ public class DNNullableMultidimensionalArray<T: System_Object>: System_Array {
 public class DNMultidimensionalArray<T: System_Object>: System_Array {
     public typealias Element = T
     public typealias Indices = [Int32]
-    
+
     /// Creates and initializes a multidimensional .NET array of the specified type and lengths.
     public convenience init(lengths: Indices) throws {
         let elementType = T.typeOf
         let elementTypeC = elementType.__handle
         let lengthsDN = try Self.indicesToDN(lengths)
         let lengthsDNC = lengthsDN.__handle
-        
+
         var __exceptionC: System_Exception_t?
-        
+
         let newArrayC = System_Array_CreateInstance_3(elementTypeC, lengthsDNC, &__exceptionC)
-        
+
         if let __exceptionC {
             let __exception = System_Exception(handle: __exceptionC)
             let __error = __exception.swiftError
-            
+
             throw __error
         }
-        
+
         self.init(handle: newArrayC)
     }
-    
+
     /// Get or set and element of this multidimensional .NET array at the specified indices.
     /// If an exception is raised on the .NET side while indexing into the array, a fatalError will be raised on the Swift side of things.
     public subscript(position: Indices) -> Element {
         get {
             do {
                 let indices = try Self.indicesToDN(position)
-                
+
                 guard let element = try getValue(indices) else {
                     throw DNSystemError.unexpectedNull
                 }
-                
+
                 return try element.castTo()
             } catch {
                 fatalError("An exception was thrown while calling System.Array.GetValue: \(error.localizedDescription)")
@@ -480,14 +480,14 @@ public class DNMultidimensionalArray<T: System_Object>: System_Array {
     private static func indicesToDN(_ indices: Indices) throws -> DNArray<System_Int32> {
         let count = Int32(indices.count)
         let indicesDN = try DNArray<System_Int32>(length: count)
-        
+
         for (idx, index) in indices.enumerated() {
             indicesDN[Int32(idx)] = index.dotNETObject()
         }
 
         return indicesDN
     }
-    
+
     public func nullable() throws -> DNNullableMultidimensionalArray<T> {
         try self.castTo()
     }
@@ -501,60 +501,60 @@ public extension DNObject {
 
     func `is`<T>(_ type: T.Type? = nil) -> Bool where T: DNObject {
         let dnType: System_Type
-        
+
         if let type {
             dnType = type.typeOf
         } else {
             dnType = T.typeOf
         }
-        
+
         return DNObjectIs(self.__handle, dnType.__handle)
     }
 
     func castAs<T>(_ type: T.Type? = nil) -> T? where T: DNObject {
         let dnType: System_Type
-        
+
         if let type {
             dnType = type.typeOf
         } else {
             dnType = T.typeOf
         }
-        
+
         guard let castedObjectC = DNObjectCastAs(self.__handle, dnType.__handle) else {
             return nil
         }
-        
+
         let castedObject = T(handle: castedObjectC)
-        
+
         return castedObject
     }
 
     func castTo<T>(_ type: T.Type? = nil) throws -> T where T: DNObject {
         let dnType: System_Type
-        
+
         if let type {
             dnType = type.typeOf
         } else {
             dnType = T.typeOf
         }
-    
+
         var exceptionC: System_Exception_t?
-        
+
         let castedObjectC = DNObjectCastTo(self.__handle, dnType.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-    
+
         guard let castedObjectC else {
-            fatalError("DNObjectCastTo didn't throw an exception but returned nil") 
+            fatalError("DNObjectCastTo didn't throw an exception but returned nil")
         }
-        
+
         let castedObject = T(handle: castedObjectC)
-        
+
         return castedObject
     }
 }
@@ -563,81 +563,81 @@ public extension DNObject {
 public extension DNObject {
     /// Cast the targeted .NET object to a Bool.
     /// - Returns: A Bool value if the cast succeeded.
-    /// - Throws: If the cast fails, an error is thrown. 
+    /// - Throws: If the cast fails, an error is thrown.
     func castToBool() throws -> Bool {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToBool(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified Bool value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromBool(_ boolValue: Bool) -> System_Boolean {
         let castedObjectC = DNObjectFromBool(boolValue)
-		
+
 		return .init(handle: castedObjectC)
 	}
-	
+
 	/// Cast the targeted .NET object to a Char.
     /// - Returns: A Char value if the cast succeeded.
-    /// - Throws: If the cast fails, an error is thrown. 
+    /// - Throws: If the cast fails, an error is thrown.
     func castToChar() throws -> DNChar {
         var exceptionC: System_Exception_t?
-        
+
         let castedValueC = DNObjectCastToChar(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
+
         let castedValue = DNChar(cValue: castedValueC)
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified Char value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromChar(_ charValue: DNChar) -> System_Char {
         let castedObjectC = DNObjectFromChar(charValue.cValue)
-		
+
 		return .init(handle: castedObjectC)
 	}
-	
+
     /// Cast the targeted .NET object to a Float.
     /// - Returns: A Float value if the cast succeeded.
     /// - Throws: If the cast fails, an error is thrown.
     func castToFloat() throws -> Float {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToFloat(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified Float value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromFloat(_ floatValue: Float) -> System_Single {
         let castedObjectC = DNObjectFromFloat(floatValue)
-        
+
 		return .init(handle: castedObjectC)
 	}
 
@@ -646,24 +646,24 @@ public extension DNObject {
     /// - Throws: If the cast fails, an error is thrown.
     func castToDouble() throws -> Double {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToDouble(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified Double value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromDouble(_ doubleValue: Double) -> System_Double {
         let castedObjectC = DNObjectFromDouble(doubleValue)
-		
+
 		return .init(handle: castedObjectC)
 	}
 
@@ -672,24 +672,24 @@ public extension DNObject {
     /// - Throws: If the cast fails, an error is thrown.
     func castToInt8() throws -> Int8 {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToInt8(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified Int8 value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromInt8(_ int8Value: Int8) -> System_SByte {
         let castedObjectC = DNObjectFromInt8(int8Value)
-        
+
         return .init(handle: castedObjectC)
     }
 
@@ -698,24 +698,24 @@ public extension DNObject {
     /// - Throws: If the cast fails, an error is thrown.
     func castToUInt8() throws -> UInt8 {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToUInt8(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified UInt8 value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromUInt8(_ uint8Value: UInt8) -> System_Byte {
         let castedObjectC = DNObjectFromUInt8(uint8Value)
-        
+
         return .init(handle: castedObjectC)
     }
 
@@ -724,24 +724,24 @@ public extension DNObject {
     /// - Throws: If the cast fails, an error is thrown.
     func castToInt16() throws -> Int16 {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToInt16(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified Int16 value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromInt16(_ int16Value: Int16) -> System_Int16 {
         let castedObjectC = DNObjectFromInt16(int16Value)
-        
+
         return .init(handle: castedObjectC)
     }
 
@@ -750,24 +750,24 @@ public extension DNObject {
     /// - Throws: If the cast fails, an error is thrown.
     func castToUInt16() throws -> UInt16 {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToUInt16(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified UInt16 value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromUInt16(_ uint16Value: UInt16) -> System_UInt16 {
         let castedObjectC = DNObjectFromUInt16(uint16Value)
-        
+
         return .init(handle: castedObjectC)
     }
 
@@ -776,24 +776,24 @@ public extension DNObject {
     /// - Throws: If the cast fails, an error is thrown.
     func castToInt32() throws -> Int32 {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToInt32(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified Int32 value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromInt32(_ int32Value: Int32) -> System_Int32 {
         let castedObjectC = DNObjectFromInt32(int32Value)
-        
+
         return .init(handle: castedObjectC)
     }
 
@@ -802,24 +802,24 @@ public extension DNObject {
     /// - Throws: If the cast fails, an error is thrown.
     func castToUInt32() throws -> UInt32 {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToUInt32(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified UInt32 value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromUInt32(_ uint32Value: UInt32) -> System_UInt32 {
         let castedObjectC = DNObjectFromUInt32(uint32Value)
-        
+
         return .init(handle: castedObjectC)
     }
 
@@ -828,24 +828,24 @@ public extension DNObject {
     /// - Throws: If the cast fails, an error is thrown.
     func castToInt64() throws -> Int64 {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToInt64(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified Int64 value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromInt64(_ int64Value: Int64) -> System_Int64 {
         let castedObjectC = DNObjectFromInt64(int64Value)
-        
+
         return .init(handle: castedObjectC)
     }
 
@@ -854,24 +854,24 @@ public extension DNObject {
     /// - Throws: If the cast fails, an error is thrown.
     func castToUInt64() throws -> UInt64 {
         var exceptionC: System_Exception_t?
-        
+
         let castedValue = DNObjectCastToUInt64(self.__handle, &exceptionC)
-        
+
         if let exceptionC {
             let exception = System_Exception(handle: exceptionC)
             let exceptionError = exception.swiftError
-            
+
             throw exceptionError
         }
-        
-        return castedValue 
+
+        return castedValue
     }
 
     /// Boxes the specified UInt64 value in an .NET object.
     /// - Returns: An .NET object containing the boxed value.
     static func fromUInt64(_ uint64Value: UInt64) -> System_UInt64 {
         let castedObjectC = DNObjectFromUInt64(uint64Value)
-        
+
         return .init(handle: castedObjectC)
     }
 }
@@ -1084,13 +1084,13 @@ extension System_UInt64 {
 public class DNError: LocalizedError, CustomDebugStringConvertible {
     /// The underlying .NET `System.Exception` object.
     public let exception: System_Exception
-    
+
     /// Initializes an `DNError` with a .NET `System.Exception` object.
     public init(exception: System_Exception) {
         self.exception = exception
     }
-    
-    /// - Returns: The stack trace of the wrapped .NET `System.Exception` object. 
+
+    /// - Returns: The stack trace of the wrapped .NET `System.Exception` object.
     public func stackTrace() -> String? {
         do {
             return try String(dotNETString: exception.stackTrace)
@@ -1098,7 +1098,7 @@ public class DNError: LocalizedError, CustomDebugStringConvertible {
             return nil
         }
     }
-    
+
     public var errorDescription: String? {
         do {
             return try String(dotNETString: exception.message)
@@ -1106,7 +1106,7 @@ public class DNError: LocalizedError, CustomDebugStringConvertible {
             return nil
         }
     }
-    
+
     public var debugDescription: String {
         do {
             return try String(dotNETString: exception.toString())
@@ -1125,7 +1125,7 @@ extension System_Exception {
 
 public enum DNSystemError: LocalizedError {
     case unexpectedNull
-    
+
     public var errorDescription: String? {
         switch self {
             case .unexpectedNull:
@@ -1138,21 +1138,21 @@ public extension String {
     /// Converts the targeted Swift `String` to a .NET `System.String`.
 	func dotNETString() -> System_String {
 		let dotNetStringHandle = DNStringFromC(self)
-		
+
 		return System_String(handle: dotNetStringHandle)
 	}
-	
+
 	init?(dotNETString: System_String?) {
 		guard let dotNETString else { return nil }
-		
+
 		self.init(dotNETString: dotNETString)
 	}
-	
+
 	init(dotNETString: System_String) {
 		let cString = DNStringToC(dotNETString.__handle)
-		
+
 		self.init(cString: cString)
-		
+
 		cString.deallocate()
 	}
 }
@@ -1168,13 +1168,13 @@ public extension [String] {
     /// Converts a Swift String Array into a .NET `System.String` Array (`System.String[]`).
     func dotNETStringArray() throws -> DNArray<System_String> {
         let arr = try DNArray<System_String>(length: .init(count))
-        
+
         for (idx, el) in self.enumerated() {
             let elDN = el.dotNETString()
-            
+
             try arr.setValue(elDN, Int32(idx))
         }
-        
+
         return arr
     }
 }
@@ -1183,13 +1183,13 @@ public extension [String?] {
     /// Converts a Swift String? Array into a .NET `System.String?` Array (`System.String?[]`).
     func dotNETStringArray() throws -> DNNullableArray<System_String> {
         let arr = try DNNullableArray<System_String>(length: .init(count))
-        
+
         for (idx, el) in self.enumerated() {
             let elDN = el?.dotNETString()
-            
+
             try arr.setValue(elDN, Int32(idx))
         }
-        
+
         return arr
     }
 }
@@ -1198,19 +1198,19 @@ public extension DNArray<System_String> {
     /// Converts a .NET `System.String` Array (`System.String[]`) into a Swift String Array
     func array() throws -> [String] {
         let len = try self.length
-        
+
         guard len > 0 else {
             return .init()
         }
-        
+
         var arr = [String]()
-        
+
         for strDN in self {
             let str = strDN.string()
-            
+
             arr.append(str)
         }
-        
+
         return arr
     }
 }
@@ -1219,19 +1219,19 @@ public extension DNNullableArray<System_String> {
     /// Converts a .NET `System.String?` Array (`System.String?[]`) into a Swift String? Array
     func array() throws -> [String?] {
         let len = try self.length
-        
+
         guard len > 0 else {
             return .init()
         }
-        
+
         var arr = [String?]()
-        
+
         for strDN in self {
             let str = strDN?.string()
-            
+
             arr.append(str)
         }
-        
+
         return arr
     }
 }
@@ -1240,13 +1240,13 @@ extension System_Object: Equatable {
     public static func == (lhs: System_Object,
                            rhs: System_Object) -> Bool {
         let result: Bool
-        
+
         do {
             result = try System_Object.equals(lhs, rhs)
         } catch {
             result = false
         }
-        
+
         return result
     }
 }
@@ -1254,52 +1254,52 @@ extension System_Object: Equatable {
 public func == (lhs: System_Object?,
                 rhs: System_Object?) -> Bool {
     let result: Bool
-    
+
     do {
         result = try System_Object.equals(lhs, rhs)
     } catch {
         result = false
     }
-    
+
     return result
 }
 
 public func != (lhs: System_Object?,
                 rhs: System_Object?) -> Bool {
     let result: Bool
-    
+
     do {
         result = try System_Object.equals(lhs, rhs)
     } catch {
         result = false
     }
-    
+
     return !result
 }
 
 public func === (lhs: System_Object?,
                  rhs: System_Object?) -> Bool {
     let result: Bool
-    
+
     do {
         result = try System_Object.referenceEquals(lhs, rhs)
     } catch {
         result = false
     }
-    
+
     return result
 }
 
 public func !== (lhs: System_Object?,
                  rhs: System_Object?) -> Bool {
     let result: Bool
-    
+
     do {
         result = try System_Object.referenceEquals(lhs, rhs)
     } catch {
         result = false
     }
-    
+
     return !result
 }
 
@@ -1307,7 +1307,7 @@ fileprivate struct DNDateTimeUtils {
     static var calendarForDateTimeToSwiftDateConversions: Calendar {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = .gmt
-        
+
         return calendar
     }
 }
@@ -1316,7 +1316,7 @@ extension System_DateTime {
     public enum DNSystemDateTimeErrors: LocalizedError {
         case dateTimeKindIsUnspecified
         case dateFromCalendarReturnedNil
-        
+
         public var errorDescription: String? {
             switch self {
                 case .dateTimeKindIsUnspecified:
@@ -1326,24 +1326,24 @@ extension System_DateTime {
             }
         }
     }
-    
+
     private func dateComponents(fromSystemDateTime dateTime: System_DateTime) throws -> DateComponents {
         let nanoSecsPerTicks: Int64 = 100
-        
+
         let ticks = try dateTime.ticks
         let ticksPerSecond = System_TimeSpan.ticksPerSecond
-        
+
         // Compute the sub-second fraction of nanoseconds.
         let subsecondTicks = ticks % ticksPerSecond
         let nanoseconds = subsecondTicks * nanoSecsPerTicks
-        
+
         let day = try dateTime.day
         let month = try dateTime.month
         let year = try dateTime.year
         let hour = try dateTime.hour
         let minute = try dateTime.minute
         let second = try dateTime.second
-        
+
         var dateComponents = DateComponents()
         dateComponents.day = Int(day)
         dateComponents.month = Int(month)
@@ -1352,27 +1352,27 @@ extension System_DateTime {
         dateComponents.minute = Int(minute)
         dateComponents.second = Int(second)
         dateComponents.nanosecond = Int(nanoseconds)
-        
+
         return dateComponents
     }
-    
+
     /// Converts the targeted .NET `System.DateTime` to a Swift `Date` instance.
     public func swiftDate() throws -> Date {
         let dateTimeKind = try self.kind
-        
+
         guard dateTimeKind != .unspecified else {
             throw DNSystemDateTimeErrors.dateTimeKindIsUnspecified
         }
-        
+
         let universalDateTime = try self.toUniversalTime()
-        
+
         let dateComponents = try dateComponents(fromSystemDateTime: universalDateTime)
         let calendar = DNDateTimeUtils.calendarForDateTimeToSwiftDateConversions
-        
+
         guard let retDate = calendar.date(from: dateComponents) else {
             throw DNSystemDateTimeErrors.dateFromCalendarReturnedNil
         }
-        
+
         return retDate
     }
 }
@@ -1498,112 +1498,112 @@ public extension Data {
     /// Creates a .NET byte array (`System.Byte[]`) by copying the data from the Swift `Data` object.
     func dotNETByteArray() throws -> DNArray<System_Byte> {
         let bytesCount = Int32(self.count)
-        
+
         let systemByteArray = try DNArray<System_Byte>(length: bytesCount)
-        
+
         guard bytesCount > 0 else {
             return systemByteArray
         }
-        
+
         try self.withUnsafeBytes {
             guard let unsafeBytesPointer = $0.baseAddress else {
                 throw DNSystemError.unexpectedNull
             }
-            
+
             try System_Runtime_InteropServices_Marshal.copy(.init(mutating: unsafeBytesPointer),
                                                             systemByteArray,
                                                             0,
                                                             bytesCount)
         }
-        
+
         return systemByteArray
     }
 }
 
 public extension DNArray<System_Byte> {
-    /// Creates a Swift `Data` object by either copying the data from the .NET byte array (`System.Byte[]`) or getting a pinned pointer to the underlying data in .NET which is freed as soon as the Swift `Data` object is deallocated. 
+    /// Creates a Swift `Data` object by either copying the data from the .NET byte array (`System.Byte[]`) or getting a pinned pointer to the underlying data in .NET which is freed as soon as the Swift `Data` object is deallocated.
     func data(noCopy: Bool = false) throws -> Data {
         let bytesCount = try self.length
-        
+
         guard bytesCount > 0 else {
             return .init()
         }
-        
+
         if noCopy {
             var __exceptionC: System_Exception_t?
             var __gcHandleC: System_Runtime_InteropServices_GCHandle_t?
-            
+
             let ptr = DNGetPinnedPointerToByteArray(self.__handle,
                                                     &__gcHandleC,
                                                     &__exceptionC)
-                                                    
+
             if let __exceptionC {
                 let __exception = System_Exception(handle: __exceptionC)
                 let __error = __exception.swiftError
-                
+
                 throw __error
             }
-            
+
             guard let ptr else {
                 if let __gcHandleC {
                     System_Runtime_InteropServices_GCHandle_Destroy(__gcHandleC)
                 }
-                
+
                 throw DNSystemError.unexpectedNull
             }
-            
+
             guard let __gcHandleC else {
                   throw DNSystemError.unexpectedNull
             }
-            
+
             let data = Data(bytesNoCopy: .init(mutating: ptr),
                 count: .init(bytesCount),
                 deallocator: .custom({ _ /* ptr */, _ /* count */ in
                 defer {
                     System_Runtime_InteropServices_GCHandle_Destroy(__gcHandleC)
                 }
-                
+
                 let isAllocated = System_Runtime_InteropServices_GCHandle_IsAllocated_Get(__gcHandleC,
                                                                                           nil)
-                
+
                 guard isAllocated else {
                     // If the GCHandle is not allocated, there's nothing to do here
                     return
                 }
-                
+
                 var __freeExceptionC: System_Exception_t?
-                
-                System_Runtime_InteropServices_GCHandle_Free(__gcHandleC, 
+
+                System_Runtime_InteropServices_GCHandle_Free(__gcHandleC,
                                                              &__freeExceptionC)
-                
+
                 if let __freeExceptionC {
                     let errorMessage: String
-                    
+
                     if let exceptionMessage = System_String(handle: System_Exception_ToString(__freeExceptionC, nil))?.string() {
                         errorMessage = exceptionMessage
                     } else {
                         errorMessage = "N/A"
                     }
-                    
+
                     fatalError("An error occurred while freeing a GCHandle of a pinned pointer to a .NET byte[]: \(errorMessage)")
                 }
             }))
-            
+
             return data
         } else {
             var data = Data(count: .init(bytesCount))
-            
+
             try data.withUnsafeMutableBytes {
                 guard let unsafeBytesPointer = $0.baseAddress else {
                     throw DNSystemError.unexpectedNull
                 }
-                
+
                 try System_Runtime_InteropServices_Marshal.copy(self,
                                                                 0,
                                                                 unsafeBytesPointer,
                                                                 bytesCount)
             }
-            
+
             return data
         }
     }
@@ -1617,9 +1617,9 @@ fileprivate extension Data {
         }
 
         let dataLength = Int(readOnlySpanOfByte.dataLength)
-        
+
         self.init(bytesNoCopy: .init(mutating: dataPointer),
-                  count: dataLength, 
+                  count: dataLength,
                   deallocator: .free)
     }
 }
@@ -1627,7 +1627,7 @@ fileprivate extension Data {
 extension DNReadOnlySpanOfByte {
     static let empty = DNReadOnlySpanOfByte(dataPointer: nil,
                                             dataLength: 0)
-    
+
     func data() -> Data? {
         .init(readOnlySpanOfByte: self)
     }
@@ -1636,25 +1636,25 @@ extension DNReadOnlySpanOfByte {
 extension Data {
     func readOnlySpanOfByte() -> DNReadOnlySpanOfByte {
         let length = self.count
-        
+
         guard length > 0 else {
             return .empty
         }
-        
+
         guard let lengthInt32 = Int32(exactly: length) else {
             fatalError("Data is larger than \(Int32.max) bytes which cannot be represented by .NET")
         }
-        
+
         let bufferPointer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: length)
         _ = bufferPointer.initialize(from: self)
-        
+
         guard let dataPointer = bufferPointer.baseAddress else {
             fatalError("Failed to get the baseAddress of a buffer pointer")
         }
-        
+
         let span = DNReadOnlySpanOfByte(dataPointer: dataPointer,
                                         dataLength: lengthInt32)
-        
+
         return span
     }
 }
@@ -1664,22 +1664,22 @@ extension Data? {
         guard let self else {
             return .empty
         }
-        
+
         return self.readOnlySpanOfByte()
     }
 }
 
 public final class NativeBox<T> {
     public let value: T
-    
+
     public init(value: T) {
         self.value = value
     }
-    
+
     public convenience init(_ value: T) {
         self.init(value: value)
     }
-    
+
 //    deinit {
 //        print("Deinitializing \(Self.self)")
 //    }
@@ -1690,7 +1690,7 @@ public extension NativeBox {
     func unretainedPointer() -> UnsafeRawPointer {
         pointer(retained: false)
     }
-    
+
     func retainedPointer() -> UnsafeRawPointer {
         pointer(retained: true)
     }
@@ -1699,17 +1699,17 @@ public extension NativeBox {
 private extension NativeBox {
     func pointer(retained: Bool) -> UnsafeRawPointer {
         let unmanaged: Unmanaged<NativeBox<T>>
-        
+
         if retained {
             unmanaged = Unmanaged.passRetained(self)
         } else {
             unmanaged = Unmanaged.passUnretained(self)
         }
-        
+
         let opaque = unmanaged.toOpaque()
-        
+
         let pointer = UnsafeRawPointer(opaque)
-        
+
         return pointer
     }
 }
@@ -1718,9 +1718,9 @@ private extension NativeBox {
 public extension NativeBox {
     static func fromPointer(_ pointer: UnsafeRawPointer) -> Self {
         let unmanaged = Unmanaged<Self>.fromOpaque(pointer)
-        
+
         let box = unmanaged.takeUnretainedValue()
-        
+
         return box
     }
 }
@@ -1729,23 +1729,23 @@ public extension NativeBox {
 public extension NativeBox {
     static func release(_ pointer: UnsafeRawPointer) {
         let unmanaged = Unmanaged<Self>.fromOpaque(pointer)
-        
+
         unmanaged.release()
     }
-    
+
     func release(_ pointer: UnsafeRawPointer) {
         Self.release(pointer)
     }
 }
 """;
-    
+
     public const string GuidExtensions = /*lang=Swift*/"""
 extension UUID {
     /// Tries to convert the targeted Swift `UUID` object to a .NET `System.Guid`.
     /// - Returns: nil if the conversion fails or an instance of `System.Guid` if it succeeds.
     public func dotNETGuid() -> System_Guid? {
         let uuidByteTuple = self.uuid
-        
+
         let a: UInt32 = (UInt32(uuidByteTuple.0) << 24) | (UInt32(uuidByteTuple.1) << 16) | (UInt32(uuidByteTuple.2) << 8)  | UInt32(uuidByteTuple.3)
         let b: UInt16 = (UInt16(uuidByteTuple.4) << 8) | UInt16(uuidByteTuple.5)
         let c: UInt16 = (UInt16(uuidByteTuple.6) << 8) | UInt16(uuidByteTuple.7)
@@ -1757,34 +1757,34 @@ extension UUID {
         let i: UInt8 = uuidByteTuple.13
         let j: UInt8 = uuidByteTuple.14
         let k: UInt8 = uuidByteTuple.15
-        
+
         guard let systemGuid = try? System_Guid(a, b, c, d, e, f, g, h, i, j, k) else {
             assertionFailure("System.Guid.ctor(uint, ushort, ushort, byte, byte, byte, byte, byte, byte, byte, byte) either threw an exception or returned null")
-            
+
             return nil
         }
-        
+
         return systemGuid
     }
-    
+
     public init?(dotNETGuid: System_Guid) {
         // NOTE: See https://en.wikipedia.org/wiki/Universally_unique_identifier#Endianess
         let bigEndian = true
-        
+
         guard let uuidByteArray = try? dotNETGuid.toByteArray(bigEndian) else {
             assertionFailure("System.Guid.ToByteArray either threw an error or returned null")
-            
+
             return nil
         }
-        
+
         guard let uuidData = try? uuidByteArray.data(noCopy: true) else {
             assertionFailure("Failed to convert .NET byte[] to Swift Data")
-            
+
             return nil
         }
-        
+
         assert(uuidData.count == 16, "System.Guid.ToByteArray returned a byte array of length \(uuidData.count) (should be 16)")
-        
+
         let cUUID: uuid_t = (
             uuidData[0],
             uuidData[1],
@@ -1803,7 +1803,7 @@ extension UUID {
             uuidData[14],
             uuidData[15]
         )
-        
+
         self.init(uuid: cUUID)
     }
 }
@@ -1816,35 +1816,35 @@ extension System_Guid {
     }
 }
 """;
-    
+
     public const string ArrayExtensions = /*lang=Swift*/"""
 extension System_Array {
     public typealias Index = Int32
-    
+
     public var startIndex: Index {
         0
     }
-    
+
     public var endIndex: Index {
         let length: Int32
-        
+
         do {
             length = try self.length
         } catch {
             fatalError("An exception was thrown while calling System.Array.Length: \(error.localizedDescription)")
         }
-        
+
         guard length > 0 else {
             return 0
         }
-        
+
         return length
     }
-    
+
     public func index(after i: Index) -> Index {
         i + 1
     }
-    
+
     public func index(before i: Index) -> Index {
         i - 1
     }

--- a/Generator/Beyond.NET.CodeGenerator/SourceCode/SourceCodeSection.cs
+++ b/Generator/Beyond.NET.CodeGenerator/SourceCode/SourceCodeSection.cs
@@ -6,7 +6,7 @@ public class SourceCodeSection
 {
     public string Name { get; }
     public StringBuilder Code { get; } = new();
-    
+
     public SourceCodeSection() : this(string.Empty) { }
     public SourceCodeSection(string name)
     {

--- a/Generator/Beyond.NET.CodeGenerator/SourceCode/SourceCodeWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/SourceCode/SourceCodeWriter.cs
@@ -12,19 +12,19 @@ public class SourceCodeWriter
             return m_sections;
         }
     }
-    
+
     public void Write(string code)
     {
         Write(code, string.Empty);
     }
-    
+
     public void Write(string code, string sectionName)
     {
         SourceCodeSection section = GetSection(sectionName) ?? AddSection(sectionName);
 
         section.Code.AppendLine(code);
     }
-    
+
     public SourceCodeSection AddSection(string sectionName)
     {
         var tempSection = new SourceCodeSection(sectionName);
@@ -40,7 +40,7 @@ public class SourceCodeWriter
         if (m_sectionsDict.TryGetValue(section.Name, out SourceCodeSection? existingSection)) {
             return existingSection;
         }
-        
+
         m_sections.Add(section);
         m_sectionsDict[section.Name] = section;
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/Builder.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/Builder.cs
@@ -14,7 +14,7 @@ public struct Builder
             comment
         );
     }
-    
+
     public static TypeAliasTypeDef TypeAliasTypeDef
     (
         string aliasTypeName,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/Builders/PragmaMark.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/Builders/PragmaMark.cs
@@ -7,7 +7,7 @@ public struct PragmaMark
 {
     private bool m_isSeparator;
     private string? m_comment;
-    
+
     public PragmaMark() { }
 
     #region Separator
@@ -27,7 +27,7 @@ public struct PragmaMark
         return this;
     }
     #endregion Comment
-    
+
     #region Build
     public CPragmaMarkDeclaration Build()
     {
@@ -42,7 +42,7 @@ public struct PragmaMark
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/Builders/SingleLineComment.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/Builders/SingleLineComment.cs
@@ -6,14 +6,14 @@ namespace Beyond.NET.CodeGenerator.Syntax.C.Builders;
 public struct SingleLineComment
 {
     private readonly string m_comment;
-    
+
     public SingleLineComment(
         string comment
     )
     {
         m_comment = comment;
     }
-    
+
     #region Build
     public CSingleLineComment Build()
     {
@@ -27,7 +27,7 @@ public struct SingleLineComment
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/Builders/TypeAliasTypeDef.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/Builders/TypeAliasTypeDef.cs
@@ -7,7 +7,7 @@ public struct TypeAliasTypeDef
 {
     private readonly string m_aliasTypeName;
     private readonly string m_originalTypeName;
-    
+
     public TypeAliasTypeDef(
         string aliasTypeName,
         string originalTypeName
@@ -16,7 +16,7 @@ public struct TypeAliasTypeDef
         m_aliasTypeName = aliasTypeName;
         m_originalTypeName = originalTypeName;
     }
-    
+
     #region Build
     public CTypeAliasTypeDefDeclaration Build()
     {
@@ -31,7 +31,7 @@ public struct TypeAliasTypeDef
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/CConstructorSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/CConstructorSyntaxWriter.cs
@@ -16,9 +16,9 @@ public class CConstructorSyntaxWriter: CMethodSyntaxWriter, IConstructorSyntaxWr
     {
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedMember(constructor) ?? throw new Exception("No C# generated member");
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         bool mayThrow = cSharpGeneratedMember.MayThrow;
         const MemberKind methodKind = MemberKind.Constructor;
 
@@ -29,7 +29,7 @@ public class CConstructorSyntaxWriter: CMethodSyntaxWriter, IConstructorSyntaxWr
         if (declaringType.IsAbstract) {
             return string.Empty;
         }
-        
+
         Type returnType = declaringType;
         IEnumerable<ParameterInfo> parameters = constructor.GetParameters();
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/CDestructorSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/CDestructorSyntaxWriter.cs
@@ -21,7 +21,7 @@ public class CDestructorSyntaxWriter: CMethodSyntaxWriter, IDestructorSyntaxWrit
         }
 
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedDestructor(type) ?? throw new Exception("No C# generated destructor");
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/CEventSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/CEventSyntaxWriter.cs
@@ -16,7 +16,7 @@ public class CEventSyntaxWriter: CMethodSyntaxWriter, IEventSyntaxWriter
     public string Write(EventInfo @event, State state, ISyntaxWriterConfiguration? configuration)
     {
         const bool addToState = false;
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
 
@@ -30,9 +30,9 @@ public class CEventSyntaxWriter: CMethodSyntaxWriter, IEventSyntaxWriter
 
         bool adderMayThrow = generatedAdderMember?.MayThrow ?? true;
         bool removerMayThrow = generatedRemoverMember?.MayThrow ?? true;
-        
+
         string eventName = @event.Name;
-        
+
         Type declaringType = @event.DeclaringType ?? throw new Exception("No declaring type");;
 
         IEnumerable<ParameterInfo> parameters = Array.Empty<ParameterInfo>();
@@ -40,7 +40,7 @@ public class CEventSyntaxWriter: CMethodSyntaxWriter, IEventSyntaxWriter
         CCodeBuilder sb = new();
 
         Type? eventHandlerType = @event.EventHandlerType;
-        
+
         if (eventHandlerType is null) {
             return Builder.SingleLineComment($"TODO: {eventName} - Event without Event Handler Type")
                 .ToString();
@@ -52,7 +52,7 @@ public class CEventSyntaxWriter: CMethodSyntaxWriter, IEventSyntaxWriter
         if (adderMethod is not null &&
             generatedAdderMember is not null) {
             bool isStaticMethod = adderMethod.IsStatic;
-            
+
             string adderCode = WriteMethod(
                 generatedAdderMember,
                 adderMethod,
@@ -69,7 +69,7 @@ public class CEventSyntaxWriter: CMethodSyntaxWriter, IEventSyntaxWriter
             );
 
             sb.AppendLine(adderCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.EventHandlerAdder,
                 @event,
@@ -78,11 +78,11 @@ public class CEventSyntaxWriter: CMethodSyntaxWriter, IEventSyntaxWriter
                 CodeLanguage.C
             );
         }
-        
+
         if (removerMethod is not null &&
             generatedRemoverMember is not null) {
             bool isStaticMethod = removerMethod.IsStatic;
-            
+
             string removerCode = WriteMethod(
                 generatedRemoverMember,
                 removerMethod,
@@ -99,7 +99,7 @@ public class CEventSyntaxWriter: CMethodSyntaxWriter, IEventSyntaxWriter
             );
 
             sb.AppendLine(removerCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.EventHandlerRemover,
                 @event,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/CFieldSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/CFieldSyntaxWriter.cs
@@ -16,11 +16,11 @@ public class CFieldSyntaxWriter: CMethodSyntaxWriter, IFieldSyntaxWriter
     public string Write(FieldInfo field, State state, ISyntaxWriterConfiguration? configuration)
     {
         const bool addToState = false;
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
-        
+
         GeneratedMember? generatedGetterMember = cSharpUnmanagedResult.GetGeneratedMember(field, MemberKind.FieldGetter);
         GeneratedMember? generatedSetterMember = cSharpUnmanagedResult.GetGeneratedMember(field, MemberKind.FieldSetter);
 
@@ -38,7 +38,7 @@ public class CFieldSyntaxWriter: CMethodSyntaxWriter, IFieldSyntaxWriter
 
         if (generatedGetterMember is not null) {
             bool mayThrow = generatedGetterMember.MayThrow;
-            
+
             string code = WriteMethod(
                 generatedGetterMember,
                 field,
@@ -55,7 +55,7 @@ public class CFieldSyntaxWriter: CMethodSyntaxWriter, IFieldSyntaxWriter
             );
 
             sb.AppendLine(code);
-            
+
             state.AddGeneratedMember(
                 MemberKind.FieldGetter,
                 field,
@@ -67,7 +67,7 @@ public class CFieldSyntaxWriter: CMethodSyntaxWriter, IFieldSyntaxWriter
 
         if (generatedSetterMember is not null) {
             bool mayThrow = generatedSetterMember.MayThrow;
-            
+
             string code = WriteMethod(
                 generatedSetterMember,
                 field,
@@ -84,7 +84,7 @@ public class CFieldSyntaxWriter: CMethodSyntaxWriter, IFieldSyntaxWriter
             );
 
             sb.AppendLine(code);
-            
+
             state.AddGeneratedMember(
                 MemberKind.FieldSetter,
                 field,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/CMethodSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/CMethodSyntaxWriter.cs
@@ -17,7 +17,7 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
     public string Write(MethodInfo method, State state, ISyntaxWriterConfiguration? configuration)
     {
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedMember(method) ?? throw new Exception("No C# generated member");
 
@@ -68,12 +68,12 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
             memberKind != MemberKind.TypeOf) {
             throw new Exception("memberInfo may only be null when memberKind is Destructor");
         }
-        
+
         MethodBase? methodBase = memberInfo as MethodBase;
 
         bool isGenericType = declaringType.IsGenericType ||
                              declaringType.IsGenericTypeDefinition;
-        
+
         Type[] genericTypeArguments = Array.Empty<Type>();
         int numberOfGenericTypeArguments = 0;
 
@@ -81,7 +81,7 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
             genericTypeArguments = declaringType.GetGenericArguments();
             numberOfGenericTypeArguments = genericTypeArguments.Length;
         }
-        
+
         bool isGeneric = false;
         Type[] genericMethodArguments = Array.Empty<Type>();
         int numberOfGenericMethodArguments = 0;
@@ -99,7 +99,7 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
                 } catch {
                     genericMethodArguments = Array.Empty<Type>();
                 }
-                
+
                 numberOfGenericMethodArguments = genericMethodArguments.Length;
             }
         } else if (isGenericType &&
@@ -118,9 +118,9 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
             numberOfGenericMethodArguments <= 0) {
             throw new Exception("Generic Method without generic arguments");
         }
-        
+
         List<Type> tempCombinedGenericArguments = new();
-        
+
         tempCombinedGenericArguments.AddRange(genericTypeArguments);
         tempCombinedGenericArguments.AddRange(genericMethodArguments);
 
@@ -137,13 +137,13 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
 
                     if (nonByRefParameterType.IsArray) {
                         generatedName = string.Empty;
-                        
-                        return Builder.SingleLineComment("TODO: Generic Methods with out/in/ref parameters that are arrays are not supported").ToString();    
+
+                        return Builder.SingleLineComment("TODO: Generic Methods with out/in/ref parameters that are arrays are not supported").ToString();
                     }
                 }
             }
         }
-        
+
         string methodNameC = cSharpGeneratedMember.GetGeneratedName(CodeLanguage.CSharpUnmanaged) ?? throw new Exception("No native name");
 
         if (addToState) {
@@ -157,7 +157,7 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
         }
 
         bool isNullableValueTypeReturnType = returnOrSetterOrEventHandlerType.IsNullableValueType(out Type? nullableValueReturnType);
-        
+
         bool isGenericReturnType = !isNullableValueTypeReturnType &&
                                    (
                                        returnOrSetterOrEventHandlerType.IsGenericParameter ||
@@ -170,7 +170,7 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
 
         bool isConstructedGenericReturnType = !isNullableValueTypeReturnType &&
                                               returnOrSetterOrEventHandlerType.IsConstructedGenericType;
-        
+
         bool isGenericArrayReturnType = false;
 
         if (!isGenericReturnType &&
@@ -218,7 +218,7 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
                 } else {
                     returnOrSetterValueParameter = methodInfo.ReturnParameter;
                 }
-                
+
                 var nullabilityInfo = nullabilityInfoContext.Create(returnOrSetterValueParameter);
 
                 if (memberKind == MemberKind.PropertyGetter) {
@@ -277,13 +277,13 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
 
             if (returnOrSetterOrEventHandlerTypeIsByRef) {
                 returnOrSetterOrEventHandlerType = returnOrSetterOrEventHandlerType.GetNonByRefType();
-            }   
+            }
         }
-        
+
         TypeDescriptor returnOrSetterTypeDescriptor = returnOrSetterOrEventHandlerType.GetTypeDescriptor(typeDescriptorRegistry);
-        
+
         string cReturnOrSetterTypeName = returnOrSetterTypeDescriptor.GetTypeName(
-            CodeLanguage.C, 
+            CodeLanguage.C,
             true,
             returnOrSetterTypeNullability,
             Nullability.NotSpecified,
@@ -291,10 +291,10 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
             returnOrSetterOrEventHandlerTypeIsByRef,
             false
         );
-        
+
         string cReturnOrSetterTypeNameWithComment;
         Type? setterType;
-        
+
         if (memberKind == MemberKind.PropertySetter ||
             memberKind == MemberKind.FieldSetter ||
             memberKind == MemberKind.EventHandlerAdder ||
@@ -328,20 +328,20 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
             combinedGenericArguments,
             typeDescriptorRegistry
         );
-        
+
         CCodeBuilder sb = new();
 
         if (string.IsNullOrEmpty(methodSignatureParameters)) {
             methodSignatureParameters = "void";
         }
-        
+
         sb.AppendLine($"{cReturnOrSetterTypeNameWithComment}\n{methodNameC}(\n\t{methodSignatureParameters}\n);");
 
         generatedName = methodNameC;
-        
+
         return sb.ToString();
     }
-    
+
     internal static string WriteParameters(
         MemberKind memberKind,
         Type? setterOrEventHandlerType,
@@ -356,56 +356,56 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
     )
     {
         var nullabilityContext = new NullabilityInfoContext();
-        
+
         List<string> parameterList = new();
 
         if (!isStatic) {
             TypeDescriptor declaringTypeDescriptor = declaringType.GetTypeDescriptor(typeDescriptorRegistry);
-            
+
             string declaringTypeName = declaringTypeDescriptor.GetTypeName(CodeLanguage.C, true);
-            
+
             string selfParameterName = "self";
             string parameterString = $"{declaringTypeName} /* {declaringType.GetFullNameOrName()} */ {selfParameterName}";
 
             parameterList.Add(parameterString);
         }
-        
+
         if (isGeneric) {
             Type typeOfSystemType = typeof(Type);
             TypeDescriptor systemTypeTypeDescriptor = typeOfSystemType.GetTypeDescriptor(typeDescriptorRegistry);
             string systemTypeTypeName = typeOfSystemType.GetFullNameOrName();
             string nativeSystemTypeTypeName = systemTypeTypeDescriptor.GetTypeName(CodeLanguage.C, true);
-            
+
             foreach (var genericArgumentType in genericArguments) {
                 string parameterName = genericArgumentType.Name;
-            
+
                 string parameterString = $"{nativeSystemTypeTypeName} /* {systemTypeTypeName} */ {parameterName}";
-            
+
                 parameterList.Add(parameterString);
             }
         }
-        
+
         foreach (var parameter in parameters) {
             bool isOutParameter = parameter.IsOut;
             bool isInParameter = parameter.IsIn;
-                
+
             Type parameterType = parameter.ParameterType;
-                
+
             bool isByRefParameter = parameterType.IsByRef;
 
             if (isByRefParameter) {
                 parameterType = parameterType.GetNonByRefType();
             }
-                
+
             bool isGenericParameterType = parameterType.IsGenericParameter || parameterType.IsGenericMethodParameter;
-                
+
             if (isGenericParameterType) {
                 parameterType = typeof(object);
             }
-                
+
             bool isGenericArrayParameterType = false;
             Type? arrayType = parameterType.GetElementType();
-                        
+
             if (parameterType.IsArray &&
                 arrayType is not null &&
                 (arrayType.IsGenericParameter || arrayType.IsGenericMethodParameter)) {
@@ -428,13 +428,13 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
                     isNotNull = parameterNullabilityInfo.ReadState == NullabilityState.NotNull;
                 }
             }
-            
+
             Nullability parameterNullability = isNotNull
                 ? Nullability.NonNullable
                 : Nullability.NotSpecified;
-            
+
             TypeDescriptor parameterTypeDescriptor = parameterType.GetTypeDescriptor(typeDescriptorRegistry);
-                
+
             string unmanagedParameterTypeName = parameterTypeDescriptor.GetTypeName(
                 CodeLanguage.C,
                 true,
@@ -456,15 +456,15 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
             if (setterOrEventHandlerType == null) {
                 throw new Exception("Setter or Event Handler Type may not be null");
             }
-            
+
             TypeDescriptor setterOrEventHandlerTypeDescriptor = setterOrEventHandlerType.GetTypeDescriptor(typeDescriptorRegistry);
-            
+
             string cSetterOrEventHandlerTypeName = setterOrEventHandlerTypeDescriptor.GetTypeName(
                 CodeLanguage.C,
                 true,
                 setterOrEventHandlerTypeNullability
             );
-    
+
             string parameterString = $"{cSetterOrEventHandlerTypeName} /* {setterOrEventHandlerType.GetFullNameOrName()} */ value";
             parameterList.Add(parameterString);
         }
@@ -472,7 +472,7 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
         if (mayThrow) {
             Type exceptionType = typeof(Exception);
             TypeDescriptor outExceptionTypeDescriptor = exceptionType.GetTypeDescriptor(typeDescriptorRegistry);
-            
+
             string outExceptionTypeName = outExceptionTypeDescriptor.GetTypeName(
                 CodeLanguage.C,
                 true,
@@ -482,10 +482,10 @@ public class CMethodSyntaxWriter: ICSyntaxWriter, IMethodSyntaxWriter
                 true,
                 false
             );
-            
+
             string outExceptionParameterName = "outException";
 
-            string outExceptionParameterString = $"{outExceptionTypeName} /* {exceptionType.GetFullNameOrName()} */ {outExceptionParameterName}"; 
+            string outExceptionParameterString = $"{outExceptionTypeName} /* {exceptionType.GetFullNameOrName()} */ {outExceptionParameterName}";
             parameterList.Add(outExceptionParameterString);
         }
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/CPropertySyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/CPropertySyntaxWriter.cs
@@ -12,11 +12,11 @@ public class CPropertySyntaxWriter: CMethodSyntaxWriter, IPropertySyntaxWriter
     {
         return Write((PropertyInfo)@object, state, configuration);
     }
-    
+
     public string Write(PropertyInfo property, State state, ISyntaxWriterConfiguration? configuration)
     {
         const bool addToState = false;
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
 
@@ -29,8 +29,8 @@ public class CPropertySyntaxWriter: CMethodSyntaxWriter, IPropertySyntaxWriter
         }
 
         bool getterMayThrow = generatedMemberGetter?.MayThrow ?? true;
-        bool setterMayThrow = generatedMemberSetter?.MayThrow ?? true; 
-        
+        bool setterMayThrow = generatedMemberSetter?.MayThrow ?? true;
+
         Type declaringType = property.DeclaringType ?? throw new Exception("No declaring type");
 
         IEnumerable<ParameterInfo> parameters = property.GetIndexParameters();
@@ -45,7 +45,7 @@ public class CPropertySyntaxWriter: CMethodSyntaxWriter, IPropertySyntaxWriter
         if (getterMethod is not null &&
             generatedMemberGetter is not null) {
             bool isStaticMethod = getterMethod.IsStatic;
-            
+
             string getterCode = WriteMethod(
                 generatedMemberGetter,
                 getterMethod,
@@ -62,7 +62,7 @@ public class CPropertySyntaxWriter: CMethodSyntaxWriter, IPropertySyntaxWriter
             );
 
             sb.AppendLine(getterCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.PropertyGetter,
                 property,
@@ -71,11 +71,11 @@ public class CPropertySyntaxWriter: CMethodSyntaxWriter, IPropertySyntaxWriter
                 CodeLanguage.C
             );
         }
-        
+
         if (setterMethod is not null &&
             generatedMemberSetter is not null) {
             bool isStaticMethod = setterMethod.IsStatic;
-            
+
             string setterCode = WriteMethod(
                 generatedMemberSetter,
                 setterMethod,
@@ -92,7 +92,7 @@ public class CPropertySyntaxWriter: CMethodSyntaxWriter, IPropertySyntaxWriter
             );
 
             sb.AppendLine(setterCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.PropertySetter,
                 property,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/CSyntaxWriterConfiguration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/CSyntaxWriterConfiguration.cs
@@ -2,5 +2,5 @@ namespace Beyond.NET.CodeGenerator.Syntax.C;
 
 public class CSyntaxWriterConfiguration: ISyntaxWriterConfiguration
 {
-    
+
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/CTypeOfSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/CTypeOfSyntaxWriter.cs
@@ -20,7 +20,7 @@ public class CTypeOfSyntaxWriter: CMethodSyntaxWriter, ITypeOfSyntaxWriter
         }
 
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedTypeOf(type) ?? throw new Exception("No C# generated typeOf");
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/CTypeSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/CTypeSyntaxWriter.cs
@@ -13,7 +13,7 @@ namespace Beyond.NET.CodeGenerator.Syntax.C;
 public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
 {
     public Settings Settings { get; }
-    
+
     private readonly Dictionary<MemberTypes, ICSyntaxWriter> m_syntaxWriters = new() {
         { MemberTypes.Constructor, new CConstructorSyntaxWriter() },
         { MemberTypes.Property, new CPropertySyntaxWriter() },
@@ -21,15 +21,15 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
         { MemberTypes.Field, new CFieldSyntaxWriter() },
         { MemberTypes.Event, new CEventSyntaxWriter() }
     };
-    
+
     private CDestructorSyntaxWriter m_destructorSyntaxWriter = new();
     private CTypeOfSyntaxWriter m_typeOfSyntaxWriter = new();
-    
+
     public CTypeSyntaxWriter(Settings settings)
     {
         Settings = settings ?? throw new ArgumentNullException(nameof(settings));
     }
-    
+
     public string Write(object @object, State state, ISyntaxWriterConfiguration? configuration)
     {
         return Write((Type)@object, state, configuration);
@@ -38,9 +38,9 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
     public string Write(Type type, State state, ISyntaxWriterConfiguration? configuration)
     {
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         // Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
-        
+
         if (type.IsPointer ||
             type.IsByRef ||
             type.IsNullableValueType(out _)) {
@@ -55,7 +55,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
             return Builder.SingleLineComment($"Type \"{type.Name}\" was skipped. Reason: It has no full name.")
                 .ToString();
         }
-        
+
         string cTypeName = type.CTypeName();
 
         CCodeBuilder sb = new();
@@ -75,14 +75,14 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
                 type,
                 delegateInvokeMethod
             );
-    
+
             sb.AppendLine(delegateTypedefCode);
         } else {
             string typedefCode = WriteTypeDef(cTypeName);
-            
+
             sb.AppendLine(typedefCode);
         }
-        
+
         return sb.ToString();
     }
 
@@ -98,32 +98,32 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
     )
     {
         var nullabilityContext = new NullabilityInfoContext();
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         string? fullTypeName = delegateType.FullName;
 
         if (fullTypeName == null) {
             return Builder.SingleLineComment($"Type \"{delegateType.Name}\" was skipped. Reason: It has no full name.")
                 .ToString();
         }
-        
+
         string cTypeName = delegateType.CTypeName();
-        
+
         Type returnType = delegateInvokeMethod?.ReturnType ?? typeof(void);
         var parameterInfos = delegateInvokeMethod?.GetParameters() ?? Array.Empty<ParameterInfo>();
-        
+
         if (returnType.IsByRef) {
             return Builder.SingleLineComment($"TODO: ({cTypeName}) Unsupported delegate type. Reason: Has by ref return type")
                 .ToString();
         }
-        
+
         foreach (var parameter in parameterInfos) {
             if (parameter.IsOut) {
                 return Builder.SingleLineComment($"TODO: ({cTypeName}) Unsupported delegate type. Reason: Has out parameters")
                     .ToString();
             }
-            
+
             if (parameter.IsIn) {
                 return Builder.SingleLineComment($"TODO: ({cTypeName}) Unsupported delegate type. Reason: Has in parameters")
                     .ToString();
@@ -131,7 +131,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
 
             if (!ExperimentalFeatureFlags.EnableByRefParametersInDelegates) {
                 Type parameterType = parameter.ParameterType;
-                
+
                 if (parameterType.IsByRef) {
                     return Builder.SingleLineComment($"TODO: ({cTypeName}) Unsupported delegate type. Reason: Has by ref parameters")
                         .ToString();
@@ -140,13 +140,13 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
         }
 
         CCodeBuilder sb = new();
-        
+
         sb.AppendLine(WriteTypeDef(cTypeName));
 
         string contextTypeName = "void*";
         string cFunctionTypeName = $"{cTypeName}_CFunction_t";
         string cDestructorFunctionTypeName = $"{cTypeName}_CDestructorFunction_t";
-        
+
         sb.AppendLine($"typedef void (*{cDestructorFunctionTypeName})({contextTypeName} context);");
         sb.AppendLine();
 
@@ -156,7 +156,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
             cReturnTypeName = "void";
         } else {
             TypeDescriptor returnTypeDescriptor = returnType.GetTypeDescriptor(typeDescriptorRegistry);
-            cReturnTypeName = returnTypeDescriptor.GetTypeName(CodeLanguage.C, true);            
+            cReturnTypeName = returnTypeDescriptor.GetTypeName(CodeLanguage.C, true);
         }
 
         sb.AppendLine($"typedef {cReturnTypeName} (*{cFunctionTypeName})(");
@@ -165,20 +165,20 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
 
         foreach (var parameter in parameterInfos) {
             string parameterName = parameter.Name ?? throw new Exception("Delegate parameter has no name");
-        
+
             Type parameterType = parameter.ParameterType;
-            
+
             bool isOutParameter = parameter.IsOut;
             bool isInParameter = parameter.IsIn;
-                
+
             bool isByRefParameter = parameterType.IsByRef;
 
             if (isByRefParameter) {
                 parameterType = parameterType.GetNonByRefType();
             }
-            
+
             TypeDescriptor parameterTypeDescriptor = parameterType.GetTypeDescriptor(typeDescriptorRegistry);
-            
+
             bool isNotNull = false;
 
             if (parameterType.IsReferenceType()) {
@@ -202,7 +202,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
                 isByRefParameter,
                 isInParameter
             );
-                
+
             parameters.Add($"{parameterTypeName} {parameterName}");
         }
 
@@ -215,7 +215,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
         } else {
             parametersString = contextParameter;
         }
-    
+
         sb.Append(parametersString
             .IndentAllLines(1));
 
@@ -241,7 +241,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
         TypeDescriptor underlyingTypeDescriptor = underlyingType.GetTypeDescriptor(typeDescriptorRegistry);
 
         string underlyingTypeName = underlyingTypeDescriptor.GetTypeName(CodeLanguage.C, false);
-        
+
         bool isFlagsEnum = type.IsDefined(typeof(FlagsAttribute), false);
 
         List<string> clangAttributes = new() {
@@ -268,7 +268,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
         for (int i = 0; i < caseNames.Length; i++) {
             string caseName = caseNames[i];
             var value = values.GetValue(i) ?? throw new Exception("No enum value for case");
-            
+
             enumCases.Add($"\t{cTypeName}_{caseName} = {value.ToString()}");
         }
 
@@ -277,18 +277,18 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
         sb.AppendLine(enumCasesString);
 
         string cEnumTypeName = typeDescriptor.GetTypeName(CodeLanguage.C, false);
-        
+
         sb.AppendLine($"}} {cEnumTypeName};");
-        
+
         return sb.ToString();
     }
 
     public string WriteMembers(Type type, State state, ISyntaxWriterConfiguration? configuration)
     {
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
-        
+
         if (type.IsPointer ||
             type.IsByRef ||
             type.IsGenericParameter ||
@@ -299,7 +299,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
 
             return string.Empty;
         }
-        
+
         var cSharpMembers = cSharpUnmanagedResult.GeneratedTypes[type];
 
         CCodeBuilder sb = new();
@@ -319,7 +319,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
             TypeDescriptor typeDescriptor = type.GetTypeDescriptor(typeDescriptorRegistry);
             string cTypeName =  typeDescriptor.GetTypeName(CodeLanguage.C, false);
             string cMemberNamePrefix = type.CTypeName();
-            
+
             WriteDelegateTypeMembers(
                 typeDescriptor,
                 fullTypeName,
@@ -340,7 +340,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
                 generatedMembers.Contains(member)) {
                 continue;
             }
-            
+
             var memberKind = cSharpMember.MemberKind;
             var memberType = member?.MemberType;
 
@@ -348,12 +348,12 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
                 memberKind,
                 memberType ?? MemberTypes.Custom
             );
-            
+
             if (syntaxWriter == null) {
                 if (Settings.EmitUnsupported) {
                     sb.AppendLine(Builder.SingleLineComment($"TODO: Unsupported Member Type \"{memberType}\"").ToString());
                 }
-                    
+
                 continue;
             }
 
@@ -427,7 +427,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
     {
         var parameterInfos = invokeMethod?.GetParameters() ?? Array.Empty<ParameterInfo>();
         var returnType = invokeMethod?.ReturnType ?? typeof(void);
-        
+
         WriteDelegateTypeMembers(
             typeDescriptor,
             fullTypeName,
@@ -440,7 +440,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
             typeDescriptorRegistry
         );
     }
-    
+
     private void WriteDelegateTypeMembers(
         TypeDescriptor typeDescriptor,
         string fullTypeName,
@@ -454,7 +454,7 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
     )
     {
         // TODO: Generics
-        
+
         Type type = typeDescriptor.ManagedType;
         TypeDescriptor returnTypeDescriptor = returnType.GetTypeDescriptor(typeDescriptorRegistry);
 
@@ -463,17 +463,17 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
 
             return;
         }
-        
+
         foreach (var parameter in parameterInfos) {
             if (parameter.IsOut) {
                 sb.AppendLine(Builder.SingleLineComment($"TODO: ({cTypeName}) Unsupported delegate type. Reason: Has out parameters").ToString());
-                
+
                 return;
             }
-            
+
             if (parameter.IsIn) {
                 sb.AppendLine(Builder.SingleLineComment($"TODO: ({cTypeName}) Unsupported delegate type. Reason: Has in parameters").ToString());
-                
+
                 return;
             }
 
@@ -482,26 +482,26 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
             if (!ExperimentalFeatureFlags.EnableByRefParametersInDelegates) {
                 if (parameterType.IsByRef) {
                     sb.AppendLine(Builder.SingleLineComment($"TODO: ({cTypeName}) Unsupported delegate type. Reason: Has by ref parameters").ToString());
-                    
+
                     return;
                 }
             }
-            
+
             if (parameterType.IsGenericParameter ||
                 parameterType.IsGenericMethodParameter) {
                 sb.AppendLine(Builder.SingleLineComment($"TODO: ({cTypeName}) Unsupported delegate type. Reason: Has generic parameters").ToString());
-                
+
                 return;
             }
         }
-        
+
         string contextType = "const void*";
         string functionType = $"{cMemberNamePrefix}_CFunction_t";
         string destrutorFunctionType = $"{cMemberNamePrefix}_CDestructorFunction_t";
 
         #region Create
         var nonNullAttr = Nullability.NonNullable.GetClangAttribute();
-        
+
         sb.AppendLine($"{cTypeName} {nonNullAttr} /* {fullTypeName} */");
         sb.AppendLine($"{cMemberNamePrefix}_Create(");
         sb.AppendLine($"\t{contextType} context,");
@@ -529,21 +529,21 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
             Array.Empty<Type>(),
             typeDescriptorRegistry
         );
-        
+
         if (!string.IsNullOrEmpty(parameters)) {
             parameters = ", " + parameters;
         }
 
         parameters += ", System_Exception_t* /* System.Exception */ outException";
-        
+
         sb.AppendLine($"{returnTypeName}");
         sb.AppendLine($"{cMemberNamePrefix}_Invoke(");
         sb.AppendLine($"\t{cTypeName} /* {fullTypeName} */ self{parameters}");
         sb.AppendLine(");");
         #endregion Invoke
-        
+
         sb.AppendLine();
-        
+
         #region Context Get
         sb.AppendLine($"{contextType}");
         sb.AppendLine($"{cMemberNamePrefix}_Context_Get(");
@@ -552,14 +552,14 @@ public class CTypeSyntaxWriter: ICSyntaxWriter, ITypeSyntaxWriter
         #endregion Context Get
 
         sb.AppendLine();
-        
+
         #region CFunction Get
         sb.AppendLine($"{functionType}");
         sb.AppendLine($"{cMemberNamePrefix}_CFunction_Get(");
         sb.AppendLine($"\t{cTypeName} /* {fullTypeName} */ self");
         sb.AppendLine(");");
         #endregion CFunction Get
-        
+
         sb.AppendLine();
 
         #region CDestructorFunction Get

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/Declaration/CPragmaMarkDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/Declaration/CPragmaMarkDeclaration.cs
@@ -15,7 +15,7 @@ public struct CPragmaMarkDeclaration
         IsSeparator = isSeparator;
         Comment = comment;
     }
-    
+
     public override string ToString()
     {
         var sb = new CCodeBuilder("#pragma mark");
@@ -30,7 +30,7 @@ public struct CPragmaMarkDeclaration
         }
 
         var str = sb.ToString();
-        
+
         return str;
     }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/Declaration/CTypeAliasTypeDefDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/Declaration/CTypeAliasTypeDefDeclaration.cs
@@ -17,7 +17,7 @@ public struct CTypeAliasTypeDefDeclaration
     public override string ToString()
     {
         const string typedef = "typedef";
-        
+
         string[] components = [
             typedef,
             OriginalTypeName,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/C/ICSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/C/ICSyntaxWriter.cs
@@ -2,5 +2,5 @@ namespace Beyond.NET.CodeGenerator.Syntax.C;
 
 public interface ICSyntaxWriter: ISyntaxWriter
 {
-    
+
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedConstructorSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedConstructorSyntaxWriter.cs
@@ -10,11 +10,11 @@ public class CSharpUnmanagedConstructorSyntaxWriter: CSharpUnmanagedMethodSyntax
     {
         return Write((ConstructorInfo)@object, state, configuration);
     }
-    
+
     public string Write(ConstructorInfo constructor, State state, ISyntaxWriterConfiguration? configuration)
     {
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         const bool mayThrow = true;
         const MemberKind methodKind = MemberKind.Constructor;
         const bool addToState = true;
@@ -27,7 +27,7 @@ public class CSharpUnmanagedConstructorSyntaxWriter: CSharpUnmanagedMethodSyntax
         if (declaringType.IsAbstract) {
             return string.Empty;
         }
-        
+
         Type returnType = declaringType;
         IEnumerable<ParameterInfo> parameters = constructor.GetParameters();
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedDestructorSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedDestructorSyntaxWriter.cs
@@ -18,7 +18,7 @@ public class CSharpUnmanagedDestructorSyntaxWriter: CSharpUnmanagedMethodSyntaxW
             type.IsEnum) {
             return string.Empty;
         }
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
 
         const bool mayThrow = false;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedEventSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedEventSyntaxWriter.cs
@@ -10,11 +10,11 @@ public class CSharpUnmanagedEventSyntaxWriter: CSharpUnmanagedMethodSyntaxWriter
     {
         return Write((EventInfo)@object, state, configuration);
     }
-    
+
     public string Write(EventInfo @event, State state, ISyntaxWriterConfiguration? configuration)
     {
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         const bool mayThrow = false;
         const bool addToState = false;
 
@@ -37,7 +37,7 @@ public class CSharpUnmanagedEventSyntaxWriter: CSharpUnmanagedMethodSyntaxWriter
 
         if (addMethod != null) {
             bool isStaticMethod = addMethod.IsStatic;
-            
+
             string adderCode = WriteMethod(
                 addMethod,
                 MemberKind.EventHandlerAdder,
@@ -63,10 +63,10 @@ public class CSharpUnmanagedEventSyntaxWriter: CSharpUnmanagedMethodSyntaxWriter
                 CodeLanguage.CSharpUnmanaged
             );
         }
-        
+
         if (removeMethod != null) {
             bool isStaticMethod = removeMethod.IsStatic;
-            
+
             string removerCode = WriteMethod(
                 removeMethod,
                 MemberKind.EventHandlerRemover,
@@ -83,7 +83,7 @@ public class CSharpUnmanagedEventSyntaxWriter: CSharpUnmanagedMethodSyntaxWriter
             );
 
             sb.AppendLine(removerCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.EventHandlerRemover,
                 @event,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedFieldSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedFieldSyntaxWriter.cs
@@ -10,22 +10,22 @@ public class CSharpUnmanagedFieldSyntaxWriter: CSharpUnmanagedMethodSyntaxWriter
     {
         return Write((FieldInfo)@object, state, configuration);
     }
-    
+
     public string Write(FieldInfo field, State state, ISyntaxWriterConfiguration? configuration)
     {
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
 
         Type declaringType = field.DeclaringType ?? throw new Exception("No declaring type");
         Type fieldType = field.FieldType;
-        
+
         const bool mayThrow = false;
         const bool addToState = false;
-        
+
         bool isStatic = field.IsStatic;
-        
+
         bool canSet = !field.IsLiteral &&
                       !field.IsInitOnly;
-        
+
         string fieldName = field.Name;
 
         CSharpCodeBuilder sb = new();
@@ -72,7 +72,7 @@ public class CSharpUnmanagedFieldSyntaxWriter: CSharpUnmanagedMethodSyntaxWriter
             );
 
             sb.AppendLine(fieldSetterCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.FieldSetter,
                 field,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedMethodSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedMethodSyntaxWriter.cs
@@ -13,11 +13,11 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
     {
         return Write((MethodInfo)@object, state, configuration);
     }
-    
+
     public string Write(MethodInfo method, State state, ISyntaxWriterConfiguration? configuration)
     {
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         const bool mayThrow = true;
         const MemberKind methodKind = MemberKind.Method;
         const bool addToState = true;
@@ -28,7 +28,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
         Type declaringType = method.DeclaringType ?? throw new Exception("No declaring type");;
         Type returnType = method.ReturnType;
         IEnumerable<ParameterInfo> parameters = method.GetParameters();
-        
+
         string methodCode = WriteMethod(
             method,
             methodKind,
@@ -67,12 +67,12 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             memberKind != MemberKind.TypeOf) {
             throw new Exception("memberInfo may only be null when memberKind is Destructor or TypeOf");
         }
-        
+
         MethodBase? methodBase = memberInfo as MethodBase;
 
         bool isGenericType = declaringType.IsGenericType ||
                              declaringType.IsGenericTypeDefinition;
-        
+
         Type[] genericTypeArguments = Array.Empty<Type>();
         int numberOfGenericTypeArguments = 0;
 
@@ -80,7 +80,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             genericTypeArguments = declaringType.GetGenericArguments();
             numberOfGenericTypeArguments = genericTypeArguments.Length;
         }
-        
+
         bool isGeneric = false;
         Type[] genericMethodArguments = Array.Empty<Type>();
         int numberOfGenericMethodArguments = 0;
@@ -98,7 +98,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 } catch {
                     genericMethodArguments = Array.Empty<Type>();
                 }
-                
+
                 numberOfGenericMethodArguments = genericMethodArguments.Length;
             }
         } else if (isGenericType &&
@@ -119,7 +119,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
         }
 
         List<Type> tempCombinedGenericArguments = new();
-        
+
         tempCombinedGenericArguments.AddRange(genericTypeArguments);
         tempCombinedGenericArguments.AddRange(genericMethodArguments);
 
@@ -136,13 +136,13 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 
                     if (nonByRefParameterType.IsArray) {
                         generatedName = string.Empty;
-                        
-                        return "// TODO: Generic Methods with out/ref parameters that are arrays are not supported";    
+
+                        return "// TODO: Generic Methods with out/ref parameters that are arrays are not supported";
                     }
                 }
             }
         }
-        
+
         bool isGenericConstructor = isGenericType &&
                                     memberKind == MemberKind.Constructor;
 
@@ -155,7 +155,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             genericMethodArguments.Length > 0) {
             methodNameWithGenericArity = methodName + "_A" + numberOfGenericMethodArguments;
         }
-        
+
         string methodNameC;
 
         switch (memberKind) {
@@ -273,9 +273,9 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
         if (isReturnOrSetterOrEventHandlerTypeByRef) {
             returnOrSetterOrEventHandlerType = returnOrSetterOrEventHandlerType.GetNonByRefType();
         }
-        
+
         TypeDescriptor returnOrSetterOrEventHandlerTypeDescriptor = returnOrSetterOrEventHandlerType.GetTypeDescriptor(typeDescriptorRegistry);
-        
+
         string unmanagedReturnOrSetterOrEventHandlerTypeName = returnOrSetterOrEventHandlerTypeDescriptor.GetTypeName(
             CodeLanguage.CSharpUnmanaged,
             true,
@@ -285,7 +285,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             isReturnOrSetterOrEventHandlerTypeByRef,
             false
         );
-        
+
         string unmanagedReturnOrSetterOrEventHandlerTypeNameWithComment;
 
         if (memberKind == MemberKind.PropertySetter ||
@@ -296,9 +296,9 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
         } else {
             unmanagedReturnOrSetterOrEventHandlerTypeNameWithComment = $"{unmanagedReturnOrSetterOrEventHandlerTypeName} /* {returnOrSetterOrEventHandlerType.GetFullNameOrName()} */";
         }
-        
+
         CSharpCodeBuilder sb = new();
-        
+
         sb.AppendLine($"[UnmanagedCallersOnly(EntryPoint = \"{methodNameC}\")]");
         sb.AppendLine($"internal static {unmanagedReturnOrSetterOrEventHandlerTypeNameWithComment} {methodNameC}({methodSignatureParameters})");
         sb.AppendLine("{");
@@ -311,7 +311,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             memberKind != MemberKind.Destructor &&
             memberKind != MemberKind.TypeOf) {
             selfType = declaringType;
-            
+
             string selfConversionCode = WriteSelfConversion(
                 declaringType,
                 typeDescriptorRegistry,
@@ -346,8 +346,8 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 """);
         }
 
-        string implPrefix = mayThrow 
-            ? "\t\t" 
+        string implPrefix = mayThrow
+            ? "\t\t"
             : "\t";
 
         string methodTarget;
@@ -391,10 +391,10 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             string callPrefix = isReturnOrSetterOrEventHandlerTypeByRef
                 ? "ref "
                 : string.Empty;
-            
+
             returnValuePrefix = $"{fullReturnTypeName} {returnValueName} = {callPrefix}";
         }
-        
+
         bool isProperty = memberKind == MemberKind.PropertyGetter ||
                           memberKind == MemberKind.PropertySetter;
 
@@ -407,17 +407,17 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             methodNameForInvocation = string.Empty;
         } else if (memberKind == MemberKind.Destructor) {
             bool generateCheckedDestructors = state.Settings?.GenerateTypeCheckedDestroyMethods ?? false;
-            
+
             if (generateCheckedDestructors &&
                 !declaringType.IsAbstract &&
                 !declaringType.IsGenericType &&
                 !declaringType.IsGenericTypeDefinition) {
                 string typeName = fullTypeName;
-                
+
                 if (declaringType.IsDelegate()) {
                     typeName = fullTypeNameC;
                 }
-                
+
                 methodNameForInvocation = $"InteropUtils.CheckedFreeIfAllocated<{typeName}>(__self)";
             } else {
                 methodNameForInvocation = "InteropUtils.FreeIfAllocated(__self)";
@@ -478,7 +478,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
         } else if (memberKind == MemberKind.EventHandlerAdder ||
                    memberKind == MemberKind.EventHandlerRemover) {
             string valueParamterName = "__value";
-            
+
             string? eventHandlerTypeConversion = returnOrSetterOrEventHandlerTypeDescriptor.GetTypeConversion(
                 CodeLanguage.CSharpUnmanaged,
                 CodeLanguage.CSharp
@@ -501,33 +501,33 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
         if (isGeneric) {
             bool isNonConstructedGenericType = isGenericType &&
                                                !declaringType.IsConstructedGenericType;
-            
+
             string declaringTypeName = declaringType.GetFullNameOrName();
-            
+
             if (isGenericConstructor) { // Constructor
                 sb.AppendLine($"{implPrefix}System.Type __targetTypeForGenericCall = typeof({declaringTypeName});");
             } else { // Method, Property, etc.
                 sb.AppendLine($"{implPrefix}System.Type __targetTypeForGenericCall = typeof({declaringTypeName});");
-                
+
                 if (isNonConstructedGenericType) {
                     sb.AppendLine($"{implPrefix}const System.String __memberNameForGenericCall = \"{methodName}\";");
                 } else {
                     sb.AppendLine($"{implPrefix}System.String __memberNameForGenericCall = nameof({declaringTypeName}.{methodName});");
                 }
-                
+
                 if (isStaticMethod) {
                     sb.AppendLine($"{implPrefix}System.Object? __methodTargetForGenericCall = null;");
                 } else {
                     sb.AppendLine($"{implPrefix}System.Object? __methodTargetForGenericCall = {convertedSelfParameterName};");
                 }
-    
+
                 sb.AppendLine();
             }
 
             Type returnType;
             string returnTypeName;
             string typeOfReturnTypeName;
-            
+
             if (isGenericReturnType ||
                 isConstructedGenericReturnType) {
                 returnType = originalReturnOrSetterOrEventHandlerType;
@@ -561,7 +561,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                         typeOfReturnTypeName = "typeof(System.Object)";
                     } else {
                         typeOfReturnTypeName = returnTypeName;
-                        
+
                         if (returnTypeIsGenericParameterType) {
                             returnTypeName = "System.Object";
                         }
@@ -587,7 +587,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 
                     parameterNamesString += $"{fullSetterTypeConversion}";
                 }
-                
+
                 sb.AppendLine($"{implPrefix}System.Object[] __parametersForGenericCall = new System.Object[] {{ {parameterNamesString} }};");
 
                 List<string> parameterTypeNames = new();
@@ -609,7 +609,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 
                     if (isGenericParameterType) {
                         string parameterTypeName;
-                        
+
                         if (isGenericMethodParameter) {
                             parameterTypeName = $"System.Type.MakeGenericMethodParameter({parameterType.GenericParameterPosition})";
                         } else {
@@ -619,7 +619,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                                 parameterTypeName = convertedGenericTypeArgumentNames[parameterType.GenericParameterPosition];
                             }
                         }
-                        
+
                         if (isByRefParameter) {
                             parameterTypeName += ".MakeByRefType()";
                         }
@@ -628,7 +628,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                     } else {
                         bool isGenericArrayParameterType = false;
                         Type? arrayType = parameterType.GetElementType();
-                        
+
                         if (parameterType.IsArray &&
                             arrayType is not null &&
                             (arrayType.IsGenericParameter || arrayType.IsGenericMethodParameter)) {
@@ -639,13 +639,13 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                             arrayType is not null) {
                             // TODO: This is not correct for type generic parameters
                             string parameterTypeName = $"System.Type.MakeGenericMethodParameter({arrayType.GenericParameterPosition}).MakeArrayType()";
-                        
+
                             parameterTypeNames.Add(parameterTypeName);
                         } else {
                             string parameterTypeName = parameterType.GetFullNameOrName();
-                            
+
                             string typeOfCode = $"typeof({parameterTypeName})";
-                            
+
                             if (isByRefParameter) {
                                 typeOfCode += ".MakeByRefType()";
                             }
@@ -660,7 +660,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 }
 
                 string parameterTypeNamesString = string.Join(", ", parameterTypeNames);
-                
+
                 sb.AppendLine($"{implPrefix}System.Type[] __parameterTypesForGenericCall = new System.Type[] {{ {parameterTypeNamesString} }};");
             } else {
                 if (memberKind == MemberKind.PropertySetter) {
@@ -676,25 +676,25 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 
             if (isNonConstructedGenericType) {
                 string convertedGenericTypeArgumentNamesString = string.Join(", ", convertedGenericTypeArgumentNames);
-                
+
                 sb.AppendLine($"{implPrefix}System.Type[] __genericParameterTypesForGenericType = new System.Type[] {{ {convertedGenericTypeArgumentNamesString} }};");
-                sb.AppendLine();    
+                sb.AppendLine();
             }
 
             string convertedGenericMethodArgumentNamesString = string.Join(", ", convertedGenericMethodArgumentNames);
-            
+
             sb.AppendLine($"{implPrefix}System.Type[] __genericParameterTypesForGenericCall = new System.Type[] {{ {convertedGenericMethodArgumentNamesString} }};");
             sb.AppendLine();
 
             if (isNonConstructedGenericType) {
                 sb.AppendLine($"{implPrefix}__targetTypeForGenericCall = __targetTypeForGenericCall.MakeGenericType(__genericParameterTypesForGenericType);");
             }
-            
+
             if (!isGenericConstructor) {
                 // TODO: More member kinds
 
                 bool hasMethodForGenericCall = true;
-                
+
                 if (memberKind == MemberKind.Method) {
                     sb.AppendLine($"{implPrefix}System.Reflection.MethodInfo __methodForGenericCall = __targetTypeForGenericCall.GetMethod(__memberNameForGenericCall, {numberOfGenericMethodArguments}, __parameterTypesForGenericCall) ?? throw new Exception(\"Method {methodName} not found\");");
                 } else if (memberKind == MemberKind.PropertyGetter) {
@@ -704,7 +704,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 } else if (memberKind == MemberKind.FieldGetter ||
                            memberKind == MemberKind.FieldSetter) {
                     hasMethodForGenericCall = false;
-                    
+
                     sb.AppendLine($"{implPrefix}System.Reflection.FieldInfo __fieldForGenericCall = __targetTypeForGenericCall.GetField(__memberNameForGenericCall) ?? throw new Exception(\"Field {methodName} not found\");");
                 } else {
                     throw new Exception($"Unsupported member kind in generic method or type: {memberKind}");
@@ -753,9 +753,9 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 
             if (returnValueTypeConversion != null) {
                 string fullReturnValueTypeConversion = string.Format(returnValueTypeConversion, returnValueName);
-                
+
                 convertedReturnValueName = "__returnValueNative";
-                
+
                 sb.AppendLine($"{implPrefix}{returnOrSetterOrEventHandlerTypeDescriptor.GetTypeName(CodeLanguage.CSharpUnmanaged, true)} {convertedReturnValueName} = {fullReturnValueTypeConversion};");
             } else {
                 convertedReturnValueName = returnValueName;
@@ -763,7 +763,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 
             if (isReturnOrSetterOrEventHandlerTypeByRef) {
                 string boxedReturnValueName = "__returnValueBoxed";
-                
+
                 returnValueBoxing = $"{unmanagedReturnOrSetterOrEventHandlerTypeName} {boxedReturnValueName} = ({unmanagedReturnOrSetterOrEventHandlerTypeName})System.Runtime.InteropServices.Marshal.AllocHGlobal(sizeof({unmanagedReturnOrSetterOrEventHandlerTypeName})); *{boxedReturnValueName} = {convertedReturnValueName};";
 
                 convertedReturnValueName = boxedReturnValueName;
@@ -783,13 +783,13 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 
             foreach (var parameter in parameters) {
                 parameterIdx++;
-                
+
                 Type parameterType = parameter.ParameterType;
 
                 bool isOutParameter = parameter.IsOut;
                 bool isInParameter = parameter.IsIn;
                 bool isByRefParameter = parameterType.IsByRef;
-                
+
                 if (!isOutParameter &&
                     !isInParameter &&
                     !isByRefParameter) {
@@ -802,7 +802,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                     parameterType.IsGenericMethodParameter) {
                     parameterType = typeof(object);
                 }
-                
+
                 string parameterName = parameter.Name ?? throw new Exception("Parameter has no name");
                 string convertedParameterName = $"{parameterName}Converted";
 
@@ -818,11 +818,11 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 if (isGeneric) {
                     parameterPrefix = string.Empty;
                 } else {
-                    parameterPrefix = isOutParameter 
+                    parameterPrefix = isOutParameter
                         ? "out "
-                        : isInParameter 
+                        : isInParameter
                             ? string.Empty
-                            : "ref ";                    
+                            : "ref ";
                 }
 
                 string fullParameterName = $"{parameterPrefix}{convertedParameterName}";
@@ -835,33 +835,33 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                     sb.AppendLine($"\t\t{fullParameterName} = ({parameterType.GetFullNameOrName()})__parametersForGenericCall[{parameterIdx}];");
                     sb.AppendLine();
                 }
-                
+
                 if (string.IsNullOrEmpty(parameterTypeConversion)) {
                     parameterTypeConversion = convertedParameterName;
                 } else {
                     parameterTypeConversion = string.Format(parameterTypeConversion, convertedParameterName);
                 }
-                
+
                 sb.AppendLine($"\t\tif ({parameterName} is not null) {{");
                 sb.AppendLine($"\t\t\t*{parameterName} = {parameterTypeConversion};");
                 sb.AppendLine("\t\t}");
                 sb.AppendLine();
             }
-            
+
             if (isReturning) {
                 if (!string.IsNullOrEmpty(returnValueBoxing)) {
                     sb.AppendLine($"{implPrefix}{returnValueBoxing}");
                     sb.AppendLine();
                 }
-                
+
                 sb.AppendLine($"{implPrefix}return {convertedReturnValueName};");
             }
-            
+
             sb.AppendLine("""
     } catch (Exception __exception) {
         if (__outException is not null) {
             void* __exceptionHandleAddress = __exception.AllocateGCHandleAndGetAddress();
-                
+
             *__outException = __exceptionHandleAddress;
         }
 
@@ -871,13 +871,13 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 if (!parameter.IsOut) {
                     continue;
                 }
-                
+
                 string parameterName = parameter.Name ?? throw new Exception("Parameter has no name");
 
                 Type parameterType = parameter.ParameterType.GetNonByRefType();
                 TypeDescriptor parameterTypeDescriptor = parameterType.GetTypeDescriptor(typeDescriptorRegistry);
 
-                string outValue = parameterTypeDescriptor.GetDefaultValue() 
+                string outValue = parameterTypeDescriptor.GetDefaultValue()
                                   ?? $"default({parameterType.GetFullNameOrName()})";
 
                 sb.AppendLine($"\t\tif ({parameterName} is not null) {{");
@@ -888,7 +888,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 
             if (isReturning) {
                 string returnValue;
-                
+
                 if (isReturnOrSetterOrEventHandlerTypeByRef) {
                     returnValue = "null";
                 } else {
@@ -898,7 +898,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 
                 sb.AppendLine($"{implPrefix}return {returnValue};");
             }
-            
+
             sb.AppendLine("\t} finally {");
 
             string mutableStructInstanceReplacement = WriteMutableStructInstanceReplacement(
@@ -911,7 +911,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 sb.AppendLine(mutableStructInstanceReplacement
                     .IndentAllLines(2));
             }
-            
+
             sb.AppendLine("\t}");
         } else {
             string mutableStructInstanceReplacement = WriteMutableStructInstanceReplacement(
@@ -924,13 +924,13 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 sb.AppendLine(mutableStructInstanceReplacement
                     .IndentAllLines(1));
             }
-            
+
             if (isReturning) {
                 if (!string.IsNullOrEmpty(returnValueBoxing)) {
                     sb.AppendLine($"\t{returnValueBoxing}");
                     sb.AppendLine();
                 }
-                
+
                 sb.AppendLine($"\treturn {convertedReturnValueName};");
             }
         }
@@ -952,7 +952,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             string.IsNullOrEmpty(convertedParameterName)) {
             return string.Empty;
         }
-        
+
         CSharpCodeBuilder sb = new();
 
         sb.AppendLine($"if ({parameterName} is not null) {{");
@@ -971,26 +971,26 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
     {
         bool isNonConstructedGeneric = (type.IsGenericType || type.IsGenericTypeDefinition) &&
                                        !type.IsConstructedGenericType;
-                
+
         if (isNonConstructedGeneric) {
             type = typeof(System.Object);
         }
-        
+
         TypeDescriptor typeDescriptor = type.GetTypeDescriptor(typeDescriptorRegistry);
-        
+
         string parameterName = "__self";
         convertedSelfParameterName = parameterName;
 
         CSharpCodeBuilder sb = new();
-                
+
         string? typeConversion = typeDescriptor.GetTypeConversion(
-            CodeLanguage.CSharpUnmanaged, 
+            CodeLanguage.CSharpUnmanaged,
             CodeLanguage.CSharp
         );
-            
+
         if (typeConversion != null) {
             string convertedParameterName = $"{parameterName}Converted";
-                
+
             string fullTypeConversion = string.Format(typeConversion, parameterName);
 
             bool isSelfPointer = typeDescriptor.RequiresNativePointer;
@@ -1001,7 +1001,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 sb.AppendLine("\t}");
                 sb.AppendLine();
             }
-            
+
             string typeConversionCode = $"{type.GetFullNameOrName()} {convertedParameterName} = {fullTypeConversion};";
 
             sb.AppendLine($"\t{typeConversionCode}");
@@ -1027,12 +1027,12 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
     )
     {
         List<string> parameterList = new();
-        
-        string parameterNamePrefix = onlyWriteParameterTypes 
+
+        string parameterNamePrefix = onlyWriteParameterTypes
             ? "/* "
             : string.Empty;
-        
-        string parameterNameSuffix = onlyWriteParameterTypes 
+
+        string parameterNameSuffix = onlyWriteParameterTypes
             ? " */"
             : string.Empty;
 
@@ -1040,27 +1040,27 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             TypeDescriptor declaringTypeDescriptor = declaringType.GetTypeDescriptor(typeDescriptorRegistry);
             string declaringTypeName = declaringTypeDescriptor.GetTypeName(targetLanguage, true);
             string selfParameterName = "__self";
-            
+
             string parameterString = $"{declaringTypeName} /* {declaringType.GetFullNameOrName()} */ {parameterNamePrefix}{selfParameterName}{parameterNameSuffix}";
-            
+
             parameterList.Add(parameterString);
         }
-        
+
         if (isGeneric) {
             Type typeOfSystemType = typeof(Type);
             TypeDescriptor systemTypeTypeDescriptor = typeOfSystemType.GetTypeDescriptor(typeDescriptorRegistry);
             string systemTypeTypeName = typeOfSystemType.GetFullNameOrName();
             string nativeSystemTypeTypeName = systemTypeTypeDescriptor.GetTypeName(targetLanguage, true);
-            
+
             foreach (var genericArgumentType in genericArguments) {
                 string parameterName = genericArgumentType.Name;
-            
+
                 string parameterString = $"{nativeSystemTypeTypeName} /* {systemTypeTypeName} */ {parameterNamePrefix}{parameterName}{parameterNameSuffix}";
-            
+
                 parameterList.Add(parameterString);
             }
         }
-        
+
         if (memberKind != MemberKind.Destructor) {
             foreach (var parameter in parameters) {
                 Type parameterType = parameter.ParameterType;
@@ -1072,9 +1072,9 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 if (isByRefParameter) {
                     parameterType = parameterType.GetNonByRefType();
                 }
-                
+
                 TypeDescriptor parameterTypeDescriptor = parameterType.GetTypeDescriptor(typeDescriptorRegistry);
-                
+
                 string unmanagedParameterTypeName = parameterTypeDescriptor.GetTypeName(
                     targetLanguage,
                     true,
@@ -1084,7 +1084,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                     isByRefParameter,
                     isInParameter
                 );
-                
+
                 string parameterString = $"{unmanagedParameterTypeName} /* {parameterType.GetFullNameOrName()} */ {parameterNamePrefix}{parameter.Name}{parameterNameSuffix}";
                 parameterList.Add(parameterString);
             }
@@ -1097,10 +1097,10 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             if (setterOrEventHandlerType == null) {
                 throw new Exception("Setter or Event Handler Type may not be null");
             }
-            
+
             TypeDescriptor setterOrEventHandlerTypeDescriptor = setterOrEventHandlerType.GetTypeDescriptor(typeDescriptorRegistry);
             string unmanagedSetterOrEventHandlerTypeName = setterOrEventHandlerTypeDescriptor.GetTypeName(targetLanguage, true);
-    
+
             string parameterString = $"{unmanagedSetterOrEventHandlerTypeName} /* {setterOrEventHandlerType.GetFullNameOrName()} */ {parameterNamePrefix}__value{parameterNameSuffix}";
             parameterList.Add(parameterString);
         }
@@ -1108,7 +1108,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
         if (mayThrow) {
             Type exceptionType = typeof(Exception);
             TypeDescriptor outExceptionTypeDescriptor = exceptionType.GetTypeDescriptor(typeDescriptorRegistry);
-            
+
             string outExceptionTypeName = outExceptionTypeDescriptor.GetTypeName(
                 targetLanguage,
                 true,
@@ -1118,10 +1118,10 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 true,
                 false
             );
-            
+
             string outExceptionParameterName = "__outException";
 
-            string outExceptionParameterString = $"{outExceptionTypeName} /* {exceptionType.GetFullNameOrName()} */ {parameterNamePrefix}{outExceptionParameterName}{parameterNameSuffix}"; 
+            string outExceptionParameterString = $"{outExceptionTypeName} /* {exceptionType.GetFullNameOrName()} */ {parameterNamePrefix}{outExceptionParameterName}{parameterNameSuffix}";
             parameterList.Add(outExceptionParameterString);
         }
 
@@ -1145,7 +1145,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
     )
     {
         CSharpCodeBuilder sb = new();
-        
+
         convertedParameterNames = new();
         convertedGenericTypeArgumentNames = new();
         convertedGenericMethodArgumentNames = new();
@@ -1155,42 +1155,42 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             Type typeOfSystemType = typeof(Type);
             TypeDescriptor systemTypeTypeDescriptor = typeOfSystemType.GetTypeDescriptor(typeDescriptorRegistry);
             string systemTypeTypeName = typeOfSystemType.GetFullNameOrName();
-            
+
             string systemTypeTypeConversion = systemTypeTypeDescriptor.GetTypeConversion(
                 sourceLanguage,
                 targetLanguage
             )!;
-    
+
             foreach (var genericArgumentType in genericTypeArguments) {
                 string name = genericArgumentType.Name;
-                
+
                 string convertedGenericArgumentName = $"{name}Converted";
-                    
+
                 string fullTypeConversion = string.Format(systemTypeTypeConversion, name);
                 string typeConversionCode = $"{systemTypeTypeName} {convertedGenericArgumentName} = {fullTypeConversion};";
-    
+
                 sb.AppendLine($"\t{typeConversionCode}");
-                
+
                 convertedGenericTypeArgumentNames.Add(convertedGenericArgumentName);
             }
-            
+
             foreach (var genericArgumentType in genericMethodArguments) {
                 string name = genericArgumentType.Name;
-                
+
                 string convertedGenericArgumentName = $"{name}Converted";
-                    
+
                 string fullTypeConversion = string.Format(systemTypeTypeConversion, name);
                 string typeConversionCode = $"{systemTypeTypeName} {convertedGenericArgumentName} = {fullTypeConversion};";
-    
+
                 sb.AppendLine($"\t{typeConversionCode}");
-                
+
                 convertedGenericMethodArgumentNames.Add(convertedGenericArgumentName);
             }
         }
 
         foreach (var parameter in parameters) {
             string parameterName = parameter.Name ?? throw new Exception("Parameter has no name");
-            
+
             Type parameterType = parameter.ParameterType;
             bool isOutParameter = parameter.IsOut;
             bool isInParameter = parameter.IsIn;
@@ -1200,7 +1200,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
             if (isByRefParameter) {
                 parameterType = parameterType.GetNonByRefType();
             }
-            
+
             bool isGenericParameterType = parameterType.IsGenericParameter || parameterType.IsGenericMethodParameter;
 
             if (isOutParameter &&
@@ -1218,7 +1218,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                     }
                 }
             }
-            
+
             TypeDescriptor parameterTypeDescriptor = parameterType.GetTypeDescriptor(typeDescriptorRegistry);
 
             string? typeConversion = parameterTypeDescriptor.GetTypeConversion(
@@ -1256,7 +1256,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 if (sourceLanguage == CodeLanguage.CSharpUnmanaged &&
                     targetLanguage == CodeLanguage.CSharp) {
                     string typeConversionCode;
-                
+
                     if (!string.IsNullOrEmpty(typeConversion)) {
                         string fullTypeConversion = string.Format(typeConversion, $"(*{parameterName})");
                         typeConversionCode = $"{convertedParameterName} = {fullTypeConversion};";
@@ -1267,13 +1267,13 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                     sb.AppendLine($"\t{parameterTypeName} {convertedParameterName};");
 
                     sb.AppendLine();
-                
+
                     sb.AppendLine($"\tif ({parameterName} is not null) {{");
                     sb.AppendLine($"\t\t{typeConversionCode}");
                     sb.AppendLine("\t} else {");
-                
+
                     string defaultValue = $"default({parameterType.GetFullNameOrName()})";
-                
+
                     sb.AppendLine($"\t\t{convertedParameterName} = {defaultValue};");
                     sb.AppendLine("\t}");
 
@@ -1287,7 +1287,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 } else if (sourceLanguage == CodeLanguage.CSharp &&
                            targetLanguage == CodeLanguage.CSharpUnmanaged) {
                     // TODO: Delegates
-                
+
                     if (string.IsNullOrEmpty(typeConversion)) {
                         string convertedParameterTypeName = parameterTypeDescriptor.GetTypeName(
                             CodeLanguage.CSharpUnmanaged,
@@ -1298,7 +1298,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                             true,
                             isInParameter
                         );
-                    
+
                         sb.AppendLine($"\t{convertedParameterTypeName} {convertedParameterName} = ({convertedParameterTypeName})System.Runtime.CompilerServices.Unsafe.AsPointer(ref {parameterName});");
                     } else {
                         string convertedParameterTypeName = parameterTypeDescriptor.GetTypeName(
@@ -1327,13 +1327,13 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
 
                         // TODO: I don't know... This kind of looks dangerous
                         var destructorFormat = parameterTypeDescriptor.GetDestructor(CodeLanguage.CSharpUnmanaged);
-                        
+
                         if (!string.IsNullOrEmpty(destructorFormat)) {
                             sbDestructor.AppendLine($"\t{string.Format(destructorFormat, convertedParameterName)};");
                         }
 
                         var destructor = sbDestructor.ToString();
-                        
+
                         convertedTypeDestructors.Add(destructor);
                     }
                 }
@@ -1344,7 +1344,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                     .Replace("&", string.Empty);
 
                 string typeConversionCode;
-                
+
                 if (!string.IsNullOrEmpty(typeConversion)) {
                     string fullTypeConversion = string.Format(typeConversion, $"(*{parameterName})");
                     typeConversionCode = $"{convertedParameterName} = {fullTypeConversion};";
@@ -1355,13 +1355,13 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                 sb.AppendLine($"\t{parameterTypeName} {convertedParameterName};");
 
                 sb.AppendLine();
-                
+
                 sb.AppendLine($"\tif ({parameterName} is not null) {{");
                 sb.AppendLine($"\t\t{typeConversionCode}");
                 sb.AppendLine("\t} else {");
-                
+
                 string defaultValue = $"default({parameterType.GetFullNameOrName()})";
-                
+
                 sb.AppendLine($"\t\t{convertedParameterName} = {defaultValue};");
                 sb.AppendLine("\t}");
 
@@ -1376,9 +1376,9 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                     isByRefParameter,
                     isInParameter
                 );
-                
+
                 convertedParameterName = $"{parameterName}Converted";
-                
+
                 string fullTypeConversion = string.Format(typeConversion, parameterName);
                 string typeConversionCode = $"{parameterTypeName} {convertedParameterName} = {fullTypeConversion};";
 
@@ -1408,7 +1408,7 @@ public class CSharpUnmanagedMethodSyntaxWriter: ICSharpUnmanagedSyntaxWriter, IM
                     convertedParameterName = parameterName;
                 }
             }
-            
+
             convertedParameterNames.Add(convertedParameterName);
         }
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedPropertySyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedPropertySyntaxWriter.cs
@@ -11,11 +11,11 @@ public class CSharpUnmanagedPropertySyntaxWriter: CSharpUnmanagedMethodSyntaxWri
     {
         return Write((PropertyInfo)@object, state, configuration);
     }
-    
+
     public string Write(PropertyInfo property, State state, ISyntaxWriterConfiguration? configuration)
     {
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         const bool mayThrow = true;
         const bool addToState = false;
 
@@ -34,7 +34,7 @@ public class CSharpUnmanagedPropertySyntaxWriter: CSharpUnmanagedMethodSyntaxWri
 
         if (getterMethod is not null) {
             bool isStaticMethod = getterMethod.IsStatic;
-            
+
             string getterCode = WriteMethod(
                 getterMethod,
                 MemberKind.PropertyGetter,
@@ -51,7 +51,7 @@ public class CSharpUnmanagedPropertySyntaxWriter: CSharpUnmanagedMethodSyntaxWri
             );
 
             sb.AppendLine(getterCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.PropertyGetter,
                 property,
@@ -60,10 +60,10 @@ public class CSharpUnmanagedPropertySyntaxWriter: CSharpUnmanagedMethodSyntaxWri
                 CodeLanguage.CSharpUnmanaged
             );
         }
-        
+
         if (setterMethod is not null) {
             bool isStaticMethod = setterMethod.IsStatic;
-            
+
             string setterCode = WriteMethod(
                 setterMethod,
                 MemberKind.PropertySetter,
@@ -80,7 +80,7 @@ public class CSharpUnmanagedPropertySyntaxWriter: CSharpUnmanagedMethodSyntaxWri
             );
 
             sb.AppendLine(setterCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.PropertySetter,
                 property,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedSyntaxWriterConfiguration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedSyntaxWriterConfiguration.cs
@@ -4,5 +4,5 @@ namespace Beyond.NET.CodeGenerator.Syntax.CSharpUnmanaged;
 
 public record class CSharpUnmanagedSyntaxWriterConfiguration(TypeCollectorSettings TypeCollectorSettings): ISyntaxWriterConfiguration
 {
-    
+
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedTypeOfSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedTypeOfSyntaxWriter.cs
@@ -17,7 +17,7 @@ public class CSharpUnmanagedTypeOfSyntaxWriter: CSharpUnmanagedMethodSyntaxWrite
         if (type.IsVoid()) {
             return string.Empty;
         }
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
 
         const bool mayThrow = false;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedTypeSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedTypeSyntaxWriter.cs
@@ -10,7 +10,7 @@ namespace Beyond.NET.CodeGenerator.Syntax.CSharpUnmanaged;
 public partial class CSharpUnmanagedTypeSyntaxWriter: ICSharpUnmanagedSyntaxWriter, ITypeSyntaxWriter
 {
     public Settings Settings { get; }
-    
+
     private readonly Dictionary<MemberTypes, ICSharpUnmanagedSyntaxWriter> m_syntaxWriters = new() {
         { MemberTypes.Constructor, new CSharpUnmanagedConstructorSyntaxWriter() },
         { MemberTypes.Property, new CSharpUnmanagedPropertySyntaxWriter() },
@@ -26,12 +26,12 @@ public partial class CSharpUnmanagedTypeSyntaxWriter: ICSharpUnmanagedSyntaxWrit
     {
         Settings = settings ?? throw new ArgumentNullException(nameof(settings));
     }
-    
+
     public string Write(object @object, State state, ISyntaxWriterConfiguration? configuration)
     {
         return Write((Type)@object, state, configuration);
     }
-    
+
     public string Write(Type type, State state, ISyntaxWriterConfiguration? configuration)
     {
         if (type.IsPointer ||
@@ -42,23 +42,23 @@ public partial class CSharpUnmanagedTypeSyntaxWriter: ICSharpUnmanagedSyntaxWrit
 
             return string.Empty;
         }
-        
+
         string? fullTypeName = type.FullName;
 
         if (fullTypeName == null) {
             return $"// Type \"{type.Name}\" was skipped. Reason: It has no full name.";
         }
-        
+
         string cTypeName = type.CTypeName();
 
         bool isDelegate = type.IsDelegate();
-        
+
         MethodInfo? delegateInvokeMethod = isDelegate
             ? type.GetDelegateInvokeMethod()
             : null;
-        
+
         CSharpCodeBuilder sb = new();
-        
+
         sb.AppendLine($"internal unsafe class {cTypeName}");
         sb.AppendLine("{");
 
@@ -114,7 +114,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter: ICSharpUnmanagedSyntaxWrit
             null,
             typeCollectorSettings
         );
-        
+
         var memberCollector = new MemberCollector(type, typeCollector);
         var members = memberCollector.Collect(out Dictionary<MemberInfo, string> unsupportedMembers);
 
@@ -122,14 +122,14 @@ public partial class CSharpUnmanagedTypeSyntaxWriter: ICSharpUnmanagedSyntaxWrit
             foreach (var kvp in unsupportedMembers) {
                 MemberInfo member = kvp.Key;
                 string reason = kvp.Value;
-    
+
                 string memberName = member.Name;
-    
+
                 sb.AppendLine($"\t// Unsupported Member \"{memberName}\": {reason}");
                 sb.AppendLine();
             }
         }
-        
+
         foreach (var member in members) {
             var memberType = member.MemberType;
 
@@ -142,7 +142,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter: ICSharpUnmanagedSyntaxWrit
                 if (Settings.EmitUnsupported) {
                     sb.AppendLine($"\t// TODO: Unsupported Member Type \"{memberType}\"");
                 }
-                    
+
                 continue;
             }
 
@@ -151,14 +151,14 @@ public partial class CSharpUnmanagedTypeSyntaxWriter: ICSharpUnmanagedSyntaxWrit
 
             sb.AppendLine(memberCode);
         }
-        
+
         WriteTypeOf(
             configuration,
             type,
             sb,
             state
         );
-        
+
         WriteDestructor(
             configuration,
             type,
@@ -218,7 +218,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter: ICSharpUnmanagedSyntaxWrit
 
         sb.AppendLine(code);
     }
-    
+
     private void WriteDestructor(
         ISyntaxWriterConfiguration? configuration,
         Type type,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedTypeSyntaxWriter_Delegates.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/CSharpUnmanagedTypeSyntaxWriter_Delegates.cs
@@ -21,7 +21,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
     {
         var parameterInfos = invokeMethod?.GetParameters() ?? Array.Empty<ParameterInfo>();
         var returnType = invokeMethod?.ReturnType ?? typeof(void);
-        
+
         WriteDelegateType(
             configuration,
             type,
@@ -33,7 +33,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
             state
         );
     }
-    
+
     private void WriteDelegateType(
         ISyntaxWriterConfiguration? configuration,
         Type type,
@@ -49,17 +49,17 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
 
         // TODO: Duh...
         fullTypeName = fullTypeName.Replace("+", ".");
-        
+
         foreach (var parameter in parameterInfos) {
             if (parameter.IsOut) {
                 sb.AppendLine("\t// TODO: Unsupported delegate type. Reason: Has out parameters");
-                
+
                 return;
             }
-            
+
             if (parameter.IsIn) {
                 sb.AppendLine("\t// TODO: Unsupported delegate type. Reason: Has in parameters");
-                
+
                 return;
             }
 
@@ -76,11 +76,11 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
             if (parameterType.IsGenericParameter ||
                 parameterType.IsGenericMethodParameter) {
                 sb.AppendLine("\t// TODO: Unsupported delegate type. Reason: Has generic parameters");
-                
+
                 return;
             }
         }
-        
+
         // TODO: Generics
 
         string managedParmeters = CSharpUnmanagedMethodSyntaxWriter.WriteParameters(
@@ -114,7 +114,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         if (!string.IsNullOrEmpty(unmanagedParameters)) {
             unmanagedParameters += ", ";
         }
-        
+
         string unmanagedParametersForInvocation = CSharpUnmanagedMethodSyntaxWriter.WriteParameters(
             CodeLanguage.CSharpUnmanaged,
             MemberKind.Automatic,
@@ -128,11 +128,11 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
             false,
             typeDescriptorRegistry
         );
-        
+
         if (!string.IsNullOrEmpty(unmanagedParametersForInvocation)) {
             unmanagedParametersForInvocation = ", " + unmanagedParametersForInvocation;
         }
-        
+
         if (returnType.IsByRef) {
             sb.AppendLine("\t// TODO: Unsupported delegate type. Reason: Has by ref return type");
 
@@ -155,7 +155,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         sb.AppendLine($"\tinternal {contextType} Context {{ get; }}");
         sb.AppendLine($"\tinternal {cFunctionSignature} CFunction {{ get; }}");
         sb.AppendLine($"\tinternal {cDestructorFunctionSignature} CDestructorFunction {{ get; }}");
-        
+
         sb.AppendLine();
 
         sb.AppendLine($"\tprivate WeakReference<{fullTypeName}> m_trampoline;");
@@ -179,7 +179,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         sb.AppendLine("\t\t}");
         sb.AppendLine("\t}");
         #endregion Properties
-        
+
         sb.AppendLine();
 
         #region Native Constructor
@@ -194,16 +194,16 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         #endregion Native Constructor
 
         sb.AppendLine();
-        
+
         #region Managed Constructor
         sb.AppendLine($"\tinternal {cTypeName}({fullTypeName} originalDelegate)");
         sb.AppendLine("\t{");
         sb.AppendLine("\t\tm_trampoline = new(originalDelegate);");
         sb.AppendLine("\t}");
         #endregion Managed Constructor
-        
+
         sb.AppendLine();
-        
+
         #region Finalizer
         sb.AppendLine($"\t~{cTypeName}()");
         sb.AppendLine("\t{");
@@ -253,7 +253,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
 
         sb.AppendLine($"\tprivate {managedReturnTypeName} __InvokeByCallingCFunction({managedParmeters})");
         sb.AppendLine("\t{");
-        
+
         // TODO: Generics
 
         string parameterConversions = CSharpUnmanagedMethodSyntaxWriter.WriteParameterConversions(
@@ -284,7 +284,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
 
         bool hasReturnType = !returnType.IsVoid();
 
-        string returnValueName = "__returnValue"; 
+        string returnValueName = "__returnValue";
 
         string invocationPrefix = hasReturnType
             ? $"var {returnValueName} = "
@@ -297,11 +297,11 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         if (managedToNativeConvertedTypeDestructors.Count > 0) {
             sb.AppendLine();
         }
-        
+
         foreach (var typeDestructor in managedToNativeConvertedTypeDestructors) {
             var indentedTypeDestructor = typeDestructor
                 .IndentAllLines(1);
-            
+
             sb.AppendLine(indentedTypeDestructor);
         }
 
@@ -321,7 +321,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
             } else {
                 returnValueDestructor = null;
             }
-    
+
             if (!string.IsNullOrEmpty(returnTypeConversion)) {
                 returnTypeConversion = string.Format(returnTypeConversion, "__returnValue");
                 returnTypeConversion = $"var {convertedReturnValueName} = {returnTypeConversion}";
@@ -340,7 +340,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
                     sb.AppendLine($"\t\t{returnValueDestructor}");
                     sb.AppendLine();
                 }
-                
+
                 sb.AppendLine($"\t\treturn {returnValueName};");
             }
         }
@@ -369,7 +369,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         sb.AppendLine($"\t[UnmanagedCallersOnly(EntryPoint = \"{cTypeName}_Invoke\")]");
         sb.AppendLine($"\tpublic static {unmanagedReturnTypeNameWithComment} Invoke(void* self{unmanagedParametersForInvocation}, void** __outException)");
         sb.AppendLine("\t{");
-        
+
         sb.AppendLine("\t\tif (self is null) {");
         sb.AppendLine("\t\t\tthrow new ArgumentNullException(nameof(self));");
         sb.AppendLine("\t\t}");
@@ -377,7 +377,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         sb.AppendLine("\t\ttry {");
         sb.AppendLine($"\t\t\tvar selfConverted = InteropUtils.GetInstance<{cTypeName}>(self);");
         sb.AppendLine();
-        
+
         string parameterConversionsForInvocation = CSharpUnmanagedMethodSyntaxWriter.WriteParameterConversions(
             CodeLanguage.CSharpUnmanaged,
             CodeLanguage.CSharp,
@@ -408,7 +408,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         } else {
             trampolineInvocationSuffix = string.Empty;
         }
-        
+
         string managedInvocation = $"selfConverted.Trampoline{trampolineInvocationSuffix}({parameterNamesStringForInvocation})";
 
         sb.AppendLine($"\t\t\t{invocationPrefix}{managedInvocation};");
@@ -418,13 +418,13 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
                 CodeLanguage.CSharp,
                 CodeLanguage.CSharpUnmanaged
             );
-        
+
             string convertedReturnValueName = "__returnValueConverted";
-        
+
             if (!string.IsNullOrEmpty(returnTypeConversion)) {
                 returnTypeConversion = string.Format(returnTypeConversion, "__returnValue");
                 returnTypeConversion = $"var {convertedReturnValueName} = {returnTypeConversion}";
-        
+
                 sb.AppendLine($"\t\t\t{returnTypeConversion};");
                 sb.AppendLine();
 
@@ -441,7 +441,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         sb.AppendLine("\t\t\t\t*__outException = __exceptionHandleAddress;");
         sb.AppendLine("\t\t\t}");
         sb.AppendLine();
-        
+
         if (hasReturnType) {
             string returnValue = returnTypeDescriptor.GetDefaultValue()
                                  ?? $"default({returnType.GetFullNameOrName()})";
@@ -452,7 +452,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         sb.AppendLine("\t\t}");
         sb.AppendLine("\t}");
         #endregion Invoke
-        
+
         sb.AppendLine();
 
         #region Context Get
@@ -468,7 +468,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         sb.AppendLine("\t\treturn selfConverted.Context;");
         sb.AppendLine("\t}");
         #endregion Context Get
-        
+
         sb.AppendLine();
 
         #region CFunction Get
@@ -484,7 +484,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         sb.AppendLine("\t\treturn selfConverted.CFunction;");
         sb.AppendLine("\t}");
         #endregion CFunction Get
-        
+
         sb.AppendLine();
 
         #region CDestructorFunction Get
@@ -514,7 +514,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
         #endregion TypeOf
 
         sb.AppendLine();
-        
+
         #region Destructor
         WriteDestructor(
             configuration,
@@ -523,7 +523,7 @@ public partial class CSharpUnmanagedTypeSyntaxWriter
             state
         );
         #endregion Destructor
-        
+
         // TODO: Add to State
     }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/ICSharpUnmanagedSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/CSharpUnmanaged/ICSharpUnmanagedSyntaxWriter.cs
@@ -2,5 +2,5 @@ namespace Beyond.NET.CodeGenerator.Syntax.CSharpUnmanaged;
 
 public interface ICSharpUnmanagedSyntaxWriter: ISyntaxWriter
 {
-    
+
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/GeneratedMember.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/GeneratedMember.cs
@@ -5,7 +5,7 @@ namespace Beyond.NET.CodeGenerator.Syntax;
 public class GeneratedMember
 {
     private Dictionary<CodeLanguage, string> m_generatedNames = new();
-    
+
     public MemberKind MemberKind { get; }
     public MemberInfo? Member { get; }
     public bool MayThrow { get; }
@@ -20,7 +20,7 @@ public class GeneratedMember
             memberKind == MemberKind.Automatic) {
             throw new Exception("Either member must be not null or memberKind must be something other than Automatic");
         }
-        
+
         MemberKind = memberKind;
         Member = member;
         MayThrow = mayThrow;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Interfaces/ISyntaxWriterConfiguration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Interfaces/ISyntaxWriterConfiguration.cs
@@ -2,5 +2,5 @@ namespace Beyond.NET.CodeGenerator.Syntax;
 
 public interface ISyntaxWriterConfiguration
 {
-    
+
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builder.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builder.cs
@@ -37,7 +37,7 @@ public struct Builder
             comment
         );
     }
-    
+
     // public static Builders.Class Class
     // (
     //     string name
@@ -87,7 +87,7 @@ public struct Builder
     //         name
     //     );
     // }
-    
+
     public static Builders.Fun Fun
     (
         string name
@@ -97,7 +97,7 @@ public struct Builder
             name
         );
     }
-    
+
     // public static Builders.Initializer Initializer()
     // {
     //     return new();
@@ -107,7 +107,7 @@ public struct Builder
     // {
     //     return new();
     // }
-    
+
     public static Builders.FunSignatureParameter FunSignatureParameter
     (
         string label,
@@ -119,12 +119,12 @@ public struct Builder
             typeName
         );
     }
-    
+
     public static Builders.FunSignatureParameters FunSignatureParameters()
     {
         return new();
     }
-    
+
     public static Builders.Variable Variable
     (
         KotlinVariableKinds variableKind,
@@ -136,7 +136,7 @@ public struct Builder
             name
         );
     }
-    
+
     public static Builders.Variable Val
     (
         string name
@@ -147,7 +147,7 @@ public struct Builder
             name
         );
     }
-    
+
     public static Builders.Variable Var
     (
         string name

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builders/Fun.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builders/Fun.cs
@@ -24,15 +24,15 @@ public struct Fun
     {
         m_name = name;
     }
-    
+
     #region Visibility
     public Fun Visibility(KotlinVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public Fun Open()
     {
         return Visibility(KotlinVisibilities.Open);
@@ -42,19 +42,19 @@ public struct Fun
     {
         return Visibility(KotlinVisibilities.Public);
     }
-    
+
     // TODO
     // public Fun Internal()
     // {
     //     return Visibility(KotlinVisibilities.Internal);
     // }
-    
+
     public Fun Private()
     {
         return Visibility(KotlinVisibilities.Private);
     }
     #endregion Visibility
-    
+
     #region External
     public Fun External(bool isExternal = true)
     {
@@ -63,7 +63,7 @@ public struct Fun
         return this;
     }
     #endregion External
-    
+
     #region Override
     public Fun Override(bool isOverride = true)
     {
@@ -99,7 +99,7 @@ public struct Fun
         return this;
     }
     #endregion Parameters
-    
+
     #region ReturnTypeName
     public Fun ReturnTypeName(string? returnTypeName = null)
     {
@@ -117,7 +117,7 @@ public struct Fun
         return this;
     }
     #endregion Attribute
-    
+
     #region Implementation
     public Fun Implementation(string? implementation = null)
     {
@@ -126,7 +126,7 @@ public struct Fun
         return this;
     }
     #endregion Implementation
-    
+
     #region Build
     public KotlinFunDeclaration Build()
     {
@@ -149,7 +149,7 @@ public struct Fun
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builders/FunSignatureParameter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builders/FunSignatureParameter.cs
@@ -6,7 +6,7 @@ public struct FunSignatureParameter
 {
     private readonly string m_name;
     private readonly string m_typeName;
-    
+
     public FunSignatureParameter
     (
         string name,
@@ -16,7 +16,7 @@ public struct FunSignatureParameter
         m_name = name;
         m_typeName = typeName;
     }
-    
+
     #region Build
     public KotlinFunSignatureParameter Build()
     {

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builders/FunSignatureParameters.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builders/FunSignatureParameters.cs
@@ -16,7 +16,7 @@ public struct FunSignatureParameters
 
         return this;
     }
-    
+
     public FunSignatureParameters AddParameter(
         string name,
         [StringSyntax("Kt")] string typeName
@@ -28,7 +28,7 @@ public struct FunSignatureParameters
         ));
     }
     #endregion Add Parameter
-    
+
     #region Build
     public KotlinFunSignatureParameters Build()
     {
@@ -36,10 +36,10 @@ public struct FunSignatureParameters
 
         foreach (var parameter in m_parameters) {
             var convertedParameter = parameter.Build();
-            
+
             parameters.Add(convertedParameter);
         }
-        
+
         return new(parameters);
     }
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builders/SingleLineComment.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builders/SingleLineComment.cs
@@ -6,14 +6,14 @@ namespace Beyond.NET.CodeGenerator.Syntax.Kotlin.Builders;
 public struct SingleLineComment
 {
     private readonly string m_comment;
-    
+
     public SingleLineComment(
         string comment
     )
     {
         m_comment = comment;
     }
-    
+
     #region Build
     public KotlinSingleLineComment Build()
     {
@@ -27,7 +27,7 @@ public struct SingleLineComment
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builders/Variable.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Builders/Variable.cs
@@ -30,7 +30,7 @@ public struct Variable
         return this;
     }
     #endregion TypeName
-    
+
     #region Value
     public Variable Value([StringSyntax("Kt")]string? value)
     {
@@ -39,15 +39,15 @@ public struct Variable
         return this;
     }
     #endregion Value
-    
+
     #region Visibility
     public Variable Visibility(KotlinVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public Variable Open()
     {
         return Visibility(KotlinVisibilities.Open);
@@ -57,18 +57,18 @@ public struct Variable
     {
         return Visibility(KotlinVisibilities.Public);
     }
-    
+
     // public Variable Internal()
     // {
     //     return Visibility(KotlinVisibilities.Internal);
     // }
-    
+
     public Variable Private()
     {
         return Visibility(KotlinVisibilities.Private);
     }
     #endregion Visibility
-    
+
     #region Build
     public KotlinVariableDeclaration Build()
     {
@@ -86,7 +86,7 @@ public struct Variable
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinClassDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinClassDeclaration.cs
@@ -11,7 +11,7 @@ public class KotlinClassDeclaration
     public KotlinFunSignatureParameters? PrimaryConstructorParameters { get; }
     public IEnumerable<string> BaseTypePrimaryConstructorParameterNames { get; }
     public string? Implementation { get; }
-    
+
     public KotlinClassDeclaration(
         string name,
         string? baseTypeName,
@@ -34,9 +34,9 @@ public class KotlinClassDeclaration
     public override string ToString()
     {
         const string @class = "class";
-        
+
         string visibilityString = Visibility.ToKotlinSyntaxString();
-        
+
         var primaryConstructorParametersStr = PrimaryConstructorParameters?.ToString();
         string primaryConstructorStr;
 
@@ -70,7 +70,7 @@ public class KotlinClassDeclaration
                 ? $", {InterfaceConformance}"
                 : $": {InterfaceConformance}";
         }
-        
+
         string[] signatureComponents = [
             visibilityString,
             @class,
@@ -80,10 +80,10 @@ public class KotlinClassDeclaration
         string signature = KotlinFunSignatureComponents.ComponentsToString(signatureComponents);
 
         string fullDecl;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImpl = Implementation.IndentAllLines(1);
-            
+
             fullDecl = $"{signature} {{\n{indentedImpl}\n}}";
         } else {
             fullDecl = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinEnumClassCase.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinEnumClassCase.cs
@@ -11,14 +11,14 @@ public struct KotlinEnumClassCase
     )
     {
         Name = !string.IsNullOrEmpty(name)
-            ? name 
+            ? name
             : throw new ArgumentOutOfRangeException(nameof(name));
-        
+
         UnderlyingValue = !string.IsNullOrEmpty(underlyingValue)
-            ? underlyingValue 
+            ? underlyingValue
             : throw new ArgumentOutOfRangeException(nameof(underlyingValue));
     }
-    
+
     public override string ToString()
     {
         var str = $"{Name}({UnderlyingValue})";

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinEnumClassDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinEnumClassDeclaration.cs
@@ -17,22 +17,22 @@ public struct KotlinEnumClassDeclaration
     )
     {
         Name = !string.IsNullOrEmpty(name)
-            ? name 
+            ? name
             : throw new ArgumentOutOfRangeException(nameof(name));
-        
+
         Visibility = visibility;
-        
+
         UnderlyingTypeName = !string.IsNullOrEmpty(underlyingTypeName)
-            ? underlyingTypeName 
+            ? underlyingTypeName
             : throw new ArgumentOutOfRangeException(nameof(underlyingTypeName));
 
         Implementation = implementation;
     }
-    
+
     public override string ToString()
     {
         const string enumClass = "enum class";
-        
+
         var visibilityString = Visibility.ToKotlinSyntaxString();
         var underlyingTypeString = $"(val rawValue: {UnderlyingTypeName})";
         var nameAndUnderlyingTypeString = $"{Name}{underlyingTypeString}";
@@ -46,10 +46,10 @@ public struct KotlinEnumClassDeclaration
         string signature = KotlinFunSignatureComponents.ComponentsToString(signatureComponents);
 
         string fullFunc;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImplementation = Implementation.IndentAllLines(1);
-            
+
             fullFunc = $"{signature} {{\n{indentedImplementation}\n}}";
         } else {
             fullFunc = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinFunDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinFunDeclaration.cs
@@ -14,7 +14,7 @@ public struct KotlinFunDeclaration
     public string? ReturnTypeName { get; }
     public HashSet<string>? Attributes { get; }
     public string? Implementation { get; }
-    
+
     public KotlinFunDeclaration(
         string name,
         KotlinVisibilities visibility,
@@ -29,18 +29,18 @@ public struct KotlinFunDeclaration
     )
     {
         Name = !string.IsNullOrEmpty(name)
-            ? name 
+            ? name
             : throw new ArgumentOutOfRangeException(nameof(name));
-        
+
         Visibility = visibility;
         IsExternal = isExternal;
         IsOverride = isOverride;
         IsOperator = isOperator;
-        
+
         ExtendedTypeName = !string.IsNullOrEmpty(extendedTypeName)
             ? extendedTypeName
             : null;
-        
+
         Parameters = parameters;
 
         ReturnTypeName = !string.IsNullOrEmpty(returnTypeName)
@@ -48,7 +48,7 @@ public struct KotlinFunDeclaration
             : null;
 
         Attributes = attributes;
-        
+
         Implementation = !string.IsNullOrEmpty(implementation)
             ? implementation
             : null;
@@ -57,17 +57,17 @@ public struct KotlinFunDeclaration
     public override string ToString()
     {
         const string fun = "fun";
-        
+
         string visibilityString = Visibility.ToKotlinSyntaxString();
 
         string externalString = IsExternal
             ? "external"
             : string.Empty;
-        
+
         string overrideString = IsOverride
             ? "override"
             : string.Empty;
-        
+
         string operatorString = IsOperator
             ? "operator"
             : string.Empty;
@@ -75,7 +75,7 @@ public struct KotlinFunDeclaration
         string extendedTypeNameString = !string.IsNullOrEmpty(ExtendedTypeName)
             ? $"{ExtendedTypeName}."
             : string.Empty;
-        
+
         string returnString = !string.IsNullOrEmpty(ReturnTypeName)
             ? $": {ReturnTypeName}"
             : string.Empty;
@@ -102,10 +102,10 @@ public struct KotlinFunDeclaration
         string signature = KotlinFunSignatureComponents.ComponentsToString(signatureComponents);
 
         string fullFunc;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImpl = Implementation.IndentAllLines(1);
-            
+
             fullFunc = $"{signature} {{\n{indentedImpl}\n}}";
         } else {
             fullFunc = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinFunSignatureParameter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinFunSignatureParameter.cs
@@ -4,7 +4,7 @@ public struct KotlinFunSignatureParameter
 {
     public string Name { get; }
     public string TypeName { get; }
-    
+
     public KotlinFunSignatureParameter(
         string name,
         string typeName
@@ -19,13 +19,13 @@ public struct KotlinFunSignatureParameter
         if (string.IsNullOrEmpty(TypeName)) {
             throw new ArgumentOutOfRangeException(nameof(TypeName));
         }
-        
+
         if (string.IsNullOrEmpty(Name)) {
             throw new ArgumentOutOfRangeException(nameof(Name));
         }
 
         string nameAndColon = $"{Name}:";
-        
+
         string parameter = KotlinFunSignatureComponents.ComponentsToString(new[] {
             nameAndColon,
             TypeName

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinFunSignatureParameters.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinFunSignatureParameters.cs
@@ -8,7 +8,7 @@ public struct KotlinFunSignatureParameters
     {
         Parameters = Array.Empty<KotlinFunSignatureParameter>();
     }
-    
+
     public KotlinFunSignatureParameters(IEnumerable<KotlinFunSignatureParameter> parameters)
     {
         Parameters = parameters;
@@ -21,7 +21,7 @@ public struct KotlinFunSignatureParameters
         foreach (var parameter in Parameters) {
             parameterStrings.Add(parameter.ToString());
         }
-        
+
         string parametersString = string.Join(", ", parameterStrings);
 
         return parametersString;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinInterfaceDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinInterfaceDeclaration.cs
@@ -9,7 +9,7 @@ public class KotlinInterfaceDeclaration
     public string? InterfaceConformance { get; }
     public KotlinVisibilities Visibility { get; }
     public string? Implementation { get; }
-    
+
     public KotlinInterfaceDeclaration(
         string name,
         string? baseTypeName,
@@ -24,7 +24,7 @@ public class KotlinInterfaceDeclaration
         Visibility = visibility;
         Implementation = implementation;
     }
-    
+
     public override string ToString()
     {
         const string interfaceKeyword = "interface";
@@ -39,8 +39,8 @@ public class KotlinInterfaceDeclaration
             baseTypeAndInterfaceConformanceDecl += !string.IsNullOrEmpty(baseTypeAndInterfaceConformanceDecl)
                 ? $", {InterfaceConformance}"
                 : $": {InterfaceConformance}";
-        } 
-        
+        }
+
         string[] signatureComponents = [
             visibilityString,
             interfaceKeyword,
@@ -50,10 +50,10 @@ public class KotlinInterfaceDeclaration
         string signature = KotlinFunSignatureComponents.ComponentsToString(signatureComponents);
 
         string fullDecl;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImpl = Implementation.IndentAllLines(1);
-            
+
             fullDecl = $"{signature} {{\n{indentedImpl}\n}}";
         } else {
             fullDecl = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinVariableDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/Declaration/KotlinVariableDeclaration.cs
@@ -42,7 +42,7 @@ public struct KotlinVariableDeclaration
             default:
                 throw new Exception("Unknown Variable Kind");
         }
-        
+
         string visibilityString = Visibility.ToKotlinSyntaxString();
 
         string nameAndTypeName = Name;
@@ -54,7 +54,7 @@ public struct KotlinVariableDeclaration
         string valueAssignment = !string.IsNullOrEmpty(Value)
             ? $"= {Value}"
             : string.Empty;
-        
+
         string[] signatureComponents = [
             visibilityString,
             variableKindString,
@@ -63,7 +63,7 @@ public struct KotlinVariableDeclaration
         ];
 
         string decl = KotlinFunSignatureComponents.ComponentsToString(signatureComponents);
-        
+
         return decl;
     }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/IKotlinSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/IKotlinSyntaxWriter.cs
@@ -2,5 +2,5 @@ namespace Beyond.NET.CodeGenerator.Syntax.Kotlin;
 
 public interface IKotlinSyntaxWriter: ISyntaxWriter
 {
-    
+
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinConstructorSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinConstructorSyntaxWriter.cs
@@ -16,12 +16,12 @@ public class KotlinConstructorSyntaxWriter: KotlinMethodSyntaxWriter, IConstruct
     {
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
-        
+
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedMember(constructor) ?? throw new Exception("No C# generated member");
         GeneratedMember cGeneratedMember = cResult.GetGeneratedMember(constructor) ?? throw new Exception("No C generated member");
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         bool mayThrow = cSharpGeneratedMember.MayThrow;
         const MemberKind methodKind = MemberKind.Constructor;
 
@@ -32,7 +32,7 @@ public class KotlinConstructorSyntaxWriter: KotlinMethodSyntaxWriter, IConstruct
         if (declaringType.IsAbstract) {
             return string.Empty;
         }
-        
+
         Type returnType = declaringType;
         IEnumerable<ParameterInfo> parameters = constructor.GetParameters();
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinDestructorSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinDestructorSyntaxWriter.cs
@@ -21,10 +21,10 @@ public class KotlinDestructorSyntaxWriter: KotlinMethodSyntaxWriter, IDestructor
         }
 
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
-        
+
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedDestructor(type) ?? throw new Exception("No C# generated destructor");
         GeneratedMember cGeneratedMember = cResult.GetGeneratedDestructor(type) ?? throw new Exception("No C generated destructor");
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinEventSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinEventSyntaxWriter.cs
@@ -16,15 +16,15 @@ public class KotlinEventSyntaxWriter: KotlinMethodSyntaxWriter, IEventSyntaxWrit
     public string Write(EventInfo @event, State state, ISyntaxWriterConfiguration? configuration)
     {
         const bool addToState = false;
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
 
         GeneratedMember? cSharpGeneratedAdderMember = cSharpUnmanagedResult.GetGeneratedMember(@event, MemberKind.EventHandlerAdder);
         GeneratedMember? cGeneratedAdderMember = cResult.GetGeneratedMember(@event, MemberKind.EventHandlerAdder);
-        
+
         GeneratedMember? cSharpGeneratedRemoverMember = cSharpUnmanagedResult.GetGeneratedMember(@event, MemberKind.EventHandlerRemover);
         GeneratedMember? cGeneratedRemoverMember = cResult.GetGeneratedMember(@event, MemberKind.EventHandlerRemover);
 
@@ -32,7 +32,7 @@ public class KotlinEventSyntaxWriter: KotlinMethodSyntaxWriter, IEventSyntaxWrit
             cSharpGeneratedRemoverMember is null) {
             throw new Exception("No generated C# Unmanaged Member");
         }
-        
+
         if (cGeneratedAdderMember is null &&
             cGeneratedRemoverMember is null) {
             throw new Exception("No generated C Member");
@@ -40,9 +40,9 @@ public class KotlinEventSyntaxWriter: KotlinMethodSyntaxWriter, IEventSyntaxWrit
 
         bool adderMayThrow = cSharpGeneratedAdderMember?.MayThrow ?? true;
         bool removerMayThrow = cSharpGeneratedRemoverMember?.MayThrow ?? true;
-        
+
         string eventName = @event.Name;
-        
+
         Type declaringType = @event.DeclaringType ?? throw new Exception("No declaring type");;
 
         IEnumerable<ParameterInfo> parameters = Array.Empty<ParameterInfo>();
@@ -50,7 +50,7 @@ public class KotlinEventSyntaxWriter: KotlinMethodSyntaxWriter, IEventSyntaxWrit
         KotlinCodeBuilder sb = new();
 
         Type? eventHandlerType = @event.EventHandlerType;
-        
+
         if (eventHandlerType is null) {
             return $"// TODO: {eventName} - Event without Event Handler Type";
         }
@@ -62,7 +62,7 @@ public class KotlinEventSyntaxWriter: KotlinMethodSyntaxWriter, IEventSyntaxWrit
             cSharpGeneratedAdderMember is not null &&
             cGeneratedAdderMember is not null) {
             bool isStaticMethod = adderMethod.IsStatic;
-            
+
             string adderCode = WriteMethod(
                 cSharpGeneratedAdderMember,
                 cGeneratedAdderMember,
@@ -82,7 +82,7 @@ public class KotlinEventSyntaxWriter: KotlinMethodSyntaxWriter, IEventSyntaxWrit
             );
 
             sb.AppendLine(adderCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.EventHandlerAdder,
                 @event,
@@ -91,12 +91,12 @@ public class KotlinEventSyntaxWriter: KotlinMethodSyntaxWriter, IEventSyntaxWrit
                 CodeLanguage.Kotlin
             );
         }
-        
+
         if (removerMethod is not null &&
             cSharpGeneratedRemoverMember is not null &&
             cGeneratedRemoverMember is not null) {
             bool isStaticMethod = removerMethod.IsStatic;
-            
+
             string removerCode = WriteMethod(
                 cSharpGeneratedRemoverMember,
                 cGeneratedRemoverMember,
@@ -116,7 +116,7 @@ public class KotlinEventSyntaxWriter: KotlinMethodSyntaxWriter, IEventSyntaxWrit
             );
 
             sb.AppendLine(removerCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.EventHandlerRemover,
                 @event,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinFieldSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinFieldSyntaxWriter.cs
@@ -16,15 +16,15 @@ public class KotlinFieldSyntaxWriter: KotlinMethodSyntaxWriter, IFieldSyntaxWrit
     public string Write(FieldInfo field, State state, ISyntaxWriterConfiguration? configuration)
     {
         const bool addToState = false;
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
-        
+
         GeneratedMember? cSharpGeneratedGetterMember = cSharpUnmanagedResult.GetGeneratedMember(field, MemberKind.FieldGetter);
         GeneratedMember? cGeneratedGetterMember = cResult.GetGeneratedMember(field, MemberKind.FieldGetter);
-        
+
         GeneratedMember? cSharpGeneratedSetterMember = cSharpUnmanagedResult.GetGeneratedMember(field, MemberKind.FieldSetter);
         GeneratedMember? cGeneratedSetterMember = cResult.GetGeneratedMember(field, MemberKind.FieldSetter);
 
@@ -32,7 +32,7 @@ public class KotlinFieldSyntaxWriter: KotlinMethodSyntaxWriter, IFieldSyntaxWrit
             cSharpGeneratedSetterMember is null) {
             throw new Exception("No C# generated member");
         }
-        
+
         if (cGeneratedGetterMember is null &&
             cGeneratedSetterMember is null) {
             throw new Exception("No C generated member");
@@ -48,7 +48,7 @@ public class KotlinFieldSyntaxWriter: KotlinMethodSyntaxWriter, IFieldSyntaxWrit
         if (cSharpGeneratedGetterMember is not null &&
             cGeneratedGetterMember is not null) {
             bool mayThrow = cSharpGeneratedGetterMember.MayThrow;
-                
+
             string code = WriteMethod(
                 cSharpGeneratedGetterMember,
                 cGeneratedGetterMember,
@@ -68,7 +68,7 @@ public class KotlinFieldSyntaxWriter: KotlinMethodSyntaxWriter, IFieldSyntaxWrit
             );
 
             sb.AppendLine(code);
-            
+
             state.AddGeneratedMember(
                 MemberKind.FieldGetter,
                 field,
@@ -81,7 +81,7 @@ public class KotlinFieldSyntaxWriter: KotlinMethodSyntaxWriter, IFieldSyntaxWrit
         if (cSharpGeneratedSetterMember is not null &&
             cGeneratedSetterMember is not null) {
             bool mayThrow = cSharpGeneratedSetterMember.MayThrow;
-            
+
             string code = WriteMethod(
                 cSharpGeneratedSetterMember,
                 cGeneratedSetterMember,
@@ -101,7 +101,7 @@ public class KotlinFieldSyntaxWriter: KotlinMethodSyntaxWriter, IFieldSyntaxWrit
             );
 
             sb.AppendLine(code);
-            
+
             state.AddGeneratedMember(
                 MemberKind.FieldSetter,
                 field,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinMethodSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinMethodSyntaxWriter.cs
@@ -19,10 +19,10 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
     public string Write(MethodInfo method, State state, ISyntaxWriterConfiguration? configuration)
     {
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
-        
+
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedMember(method) ?? throw new Exception("No C# generated member");
         GeneratedMember cGeneratedMember = cResult.GetGeneratedMember(method) ?? throw new Exception("No C generated member");
 
@@ -142,12 +142,12 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             memberKind != MemberKind.TypeOf) {
             throw new Exception("memberInfo may only be null when memberKind is Destructor");
         }
-        
+
         MethodBase? methodBase = memberInfo as MethodBase;
 
         bool isGenericType = declaringType.IsGenericType ||
                              declaringType.IsGenericTypeDefinition;
-        
+
         Type[] genericTypeArguments = Array.Empty<Type>();
         int numberOfGenericTypeArguments = 0;
 
@@ -155,7 +155,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             genericTypeArguments = declaringType.GetGenericArguments();
             numberOfGenericTypeArguments = genericTypeArguments.Length;
         }
-        
+
         bool isGeneric = false;
         Type[] genericMethodArguments = Array.Empty<Type>();
         int numberOfGenericMethodArguments = 0;
@@ -173,7 +173,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 } catch {
                     genericMethodArguments = Array.Empty<Type>();
                 }
-                
+
                 numberOfGenericMethodArguments = genericMethodArguments.Length;
             }
         } else if (isGenericType &&
@@ -192,9 +192,9 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             numberOfGenericMethodArguments <= 0) {
             throw new Exception("Generic Method without generic arguments");
         }
-        
+
         List<Type> tempCombinedGenericArguments = new();
-        
+
         tempCombinedGenericArguments.AddRange(genericTypeArguments);
         tempCombinedGenericArguments.AddRange(genericMethodArguments);
 
@@ -211,13 +211,13 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
 
                     if (nonByRefParameterType.IsArray) {
                         generatedName = string.Empty;
-                        
-                        return Builder.SingleLineComment("TODO: Generic Methods with out/in/ref parameters that are arrays are not supported").ToString();    
+
+                        return Builder.SingleLineComment("TODO: Generic Methods with out/in/ref parameters that are arrays are not supported").ToString();
                     }
                 }
             }
         }
-        
+
         string methodNameC = cSharpGeneratedMember.GetGeneratedName(CodeLanguage.CSharpUnmanaged) ?? throw new Exception("No native name");
 
         if (addToState) {
@@ -231,7 +231,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         }
 
         bool isNullableValueTypeReturnType = returnOrSetterOrEventHandlerType.IsNullableValueType(out Type? nullableValueReturnType);
-        
+
         bool isGenericReturnType = !isNullableValueTypeReturnType &&
                                    (
                                        returnOrSetterOrEventHandlerType.IsGenericParameter ||
@@ -244,7 +244,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
 
         bool isConstructedGenericReturnType = !isNullableValueTypeReturnType &&
                                               returnOrSetterOrEventHandlerType.IsConstructedGenericType;
-        
+
         bool isGenericArrayReturnType = false;
 
         if (!isGenericReturnType &&
@@ -396,9 +396,9 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
 
             if (returnOrSetterOrEventHandlerTypeIsByRef) {
                 returnOrSetterOrEventHandlerType = returnOrSetterOrEventHandlerType.GetNonByRefType();
-            }   
+            }
         }
-        
+
         TypeDescriptor returnOrSetterTypeDescriptor = returnOrSetterOrEventHandlerType.GetTypeDescriptor(typeDescriptorRegistry);
 
         string? kotlinJNAReturnOrSetterTypeName;
@@ -407,19 +407,19 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             kotlinJNAReturnOrSetterTypeName = null;
         } else {
             kotlinJNAReturnOrSetterTypeName = returnOrSetterTypeDescriptor.GetTypeName(
-                CodeLanguage.KotlinJNA, 
+                CodeLanguage.KotlinJNA,
                 true,
                 returnOrSetterTypeNullability,
                 returnOrSetterTypeArrayElementNullability,
                 false,
                 returnOrSetterOrEventHandlerTypeIsByRef,
                 false
-            );   
+            );
         }
-        
+
         string? kotlinJNAReturnOrSetterTypeNameWithComment;
         Type? setterType;
-        
+
         if (memberKind == MemberKind.PropertySetter ||
             memberKind == MemberKind.FieldSetter ||
             memberKind == MemberKind.EventHandlerAdder ||
@@ -432,7 +432,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             } else {
                 kotlinJNAReturnOrSetterTypeNameWithComment = null;
             }
-            
+
             setterType = null;
         }
 
@@ -459,7 +459,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             typeDescriptorRegistry,
             CodeLanguage.KotlinJNA
         );
-        
+
         KotlinCodeBuilder sb = new();
 
         // if (string.IsNullOrEmpty(methodSignatureParameters)) {
@@ -474,10 +474,10 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         sb.AppendLine(fun.ToString());
 
         generatedName = methodNameC;
-        
+
         return sb.ToString();
     }
-    
+
     internal static string WriteJNAParameters(
         MemberKind memberKind,
         Type? setterOrEventHandlerType,
@@ -493,57 +493,57 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
     )
     {
         var nullabilityContext = new NullabilityInfoContext();
-        
+
         List<KotlinFunSignatureParameter> parameterList = new();
 
         if (!isStatic) {
             TypeDescriptor declaringTypeDescriptor = declaringType.GetTypeDescriptor(typeDescriptorRegistry);
-            
+
             string declaringTypeName = declaringTypeDescriptor.GetTypeName(targetLanguage, true);
-            
+
             string selfParameterName = "self";
             var selfParameter = new KotlinFunSignatureParameter(selfParameterName, $"{declaringTypeName} /* {declaringType.GetFullNameOrName()} */");
 
             parameterList.Add(selfParameter);
         }
-        
+
         if (isGeneric) {
             Type typeOfSystemType = typeof(Type);
             TypeDescriptor systemTypeTypeDescriptor = typeOfSystemType.GetTypeDescriptor(typeDescriptorRegistry);
             string systemTypeTypeName = typeOfSystemType.GetFullNameOrName();
             string nativeSystemTypeTypeName = systemTypeTypeDescriptor.GetTypeName(targetLanguage, true);
-            
+
             foreach (var genericArgumentType in genericArguments) {
                 string parameterName = genericArgumentType.Name
                     .EscapedKotlinName();
-            
+
                 var kotlinParameter = new KotlinFunSignatureParameter(parameterName, $"{nativeSystemTypeTypeName} /* {systemTypeTypeName} */");
-            
+
                 parameterList.Add(kotlinParameter);
             }
         }
-        
+
         foreach (var parameter in parameters) {
             bool isOutParameter = parameter.IsOut;
             bool isInParameter = parameter.IsIn;
-                
+
             Type parameterType = parameter.ParameterType;
-                
+
             bool isByRefParameter = parameterType.IsByRef;
 
             if (isByRefParameter) {
                 parameterType = parameterType.GetNonByRefType();
             }
-                
+
             bool isGenericParameterType = parameterType.IsGenericParameter || parameterType.IsGenericMethodParameter;
-                
+
             if (isGenericParameterType) {
                 parameterType = typeof(object);
             }
-                
+
             bool isGenericArrayParameterType = false;
             Type? arrayType = parameterType.GetElementType();
-                        
+
             if (parameterType.IsArray &&
                 arrayType is not null &&
                 (arrayType.IsGenericParameter || arrayType.IsGenericMethodParameter)) {
@@ -566,13 +566,13 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                     isNotNull = parameterNullabilityInfo.ReadState == NullabilityState.NotNull;
                 }
             }
-            
+
             Nullability parameterNullability = isNotNull
                 ? Nullability.NonNullable
                 : Nullability.NotSpecified;
-            
+
             TypeDescriptor parameterTypeDescriptor = parameterType.GetTypeDescriptor(typeDescriptorRegistry);
-                
+
             string unmanagedParameterTypeName = parameterTypeDescriptor.GetTypeName(
                 targetLanguage,
                 true,
@@ -582,12 +582,12 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 isByRefParameter,
                 isInParameter
             );
-            
+
             var parameterName = parameter.Name
                 ?.EscapedKotlinName() ?? throw new Exception("Parameter without a name");
 
             var kotlinParameter = new KotlinFunSignatureParameter(parameterName, $"{unmanagedParameterTypeName} /* {parameterType.GetFullNameOrName()} */");
-            
+
             parameterList.Add(kotlinParameter);
         }
 
@@ -598,24 +598,24 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             if (setterOrEventHandlerType == null) {
                 throw new Exception("Setter or Event Handler Type may not be null");
             }
-            
+
             TypeDescriptor setterOrEventHandlerTypeDescriptor = setterOrEventHandlerType.GetTypeDescriptor(typeDescriptorRegistry);
-            
+
             string cSetterOrEventHandlerTypeName = setterOrEventHandlerTypeDescriptor.GetTypeName(
                 targetLanguage,
                 true,
                 setterOrEventHandlerTypeNullability
             );
-    
+
             var kotlinParameter = new KotlinFunSignatureParameter("value", $"{cSetterOrEventHandlerTypeName} /* {setterOrEventHandlerType.GetFullNameOrName()} */");
-            
+
             parameterList.Add(kotlinParameter);
         }
 
         if (mayThrow) {
             Type exceptionType = typeof(Exception);
             TypeDescriptor outExceptionTypeDescriptor = exceptionType.GetTypeDescriptor(typeDescriptorRegistry);
-            
+
             string outExceptionTypeName = outExceptionTypeDescriptor.GetTypeName(
                 targetLanguage,
                 true,
@@ -625,10 +625,10 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 true,
                 false
             );
-            
+
             string outExceptionParameterName = "outException";
             var outExceptionParameter = new KotlinFunSignatureParameter(outExceptionParameterName, $"{outExceptionTypeName} /* {exceptionType.GetFullNameOrName()} */");
- 
+
             parameterList.Add(outExceptionParameter);
         }
 
@@ -665,7 +665,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             memberKind != MemberKind.TypeOf) {
             throw new Exception("memberInfo may only be null when memberKind is Destructor");
         }
-        
+
         MethodBase? methodBase = memberInfo as MethodBase;
         MethodInfo? methodInfo = methodBase as MethodInfo;
 
@@ -674,35 +674,35 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             methodBase is not null &&
             methodBase.Name == "get_Current") {
             generatedName = string.Empty;
-            
+
             return "// TODO: System.CharEnumerator.Current getter causes issues in Kotlin's type system because it overrides the method with the same name in System.Collections.IEnumerator which has a return value of System.Object. But this one here has a return value of char which is a primitive and not an System.Object as far as Kotlin is concerned.";
         }
-        
+
         if (returnOrSetterOrEventHandlerType.IsByRef) {
             generatedName = string.Empty;
-            
+
             return $"// TODO: Method with by ref return or setter or event handler type ({cMember.GetGeneratedName(CodeLanguage.C)})";
         }
-        
+
         if (returnOrSetterOrEventHandlerType.IsGenericInAnyWay(true) &&
             !returnOrSetterOrEventHandlerType.IsNullableValueType(out _)) {
             generatedName = string.Empty;
-            
+
             return $"// TODO: Method with generic return or setter or event handler type ({cMember.GetGeneratedName(CodeLanguage.C)})";
         }
 
         if (methodInfo?.ContainsGenericParameters ?? false) {
             generatedName = string.Empty;
-            
+
             return $"// TODO: Method with generic parameters ({cMember.GetGeneratedName(CodeLanguage.C)})";
         }
 
         foreach (var parameter in parameters) {
             var parameterType = parameter.ParameterType;
-            
+
             if (parameterType.IsGenericInAnyWay(true)) {
                 generatedName = string.Empty;
-                
+
                 return $"// TODO: Method with generic parameter ({cMember.GetGeneratedName(CodeLanguage.C)})";
             }
 
@@ -710,20 +710,20 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                                    parameter.IsIn ||
                                    parameterType.IsByRef ||
                                    parameterType.IsByRefLike ||
-                                   parameterType.IsByRefValueType(out _); 
-            
+                                   parameterType.IsByRefValueType(out _);
+
             if (isByRefParameter) {
                 var nonByRefType = parameterType.GetNonByRefType();
-                
+
                 if (nonByRefType.IsEnum ||
                     nonByRefType.IsPointer ||
                     nonByRefType == typeof(IntPtr) ||
                     nonByRefType == typeof(UIntPtr)) {
                     generatedName = string.Empty;
-                    
+
                     return $"// TODO: Method with out or in or by ref enum/IntPtr/UIntPtr/Pointer type parameter ({cMember.GetGeneratedName(CodeLanguage.C)})";
                 }
-                
+
                 bool isNullableValueType = nonByRefType.IsNullableValueType(out Type? nullableValueType);
 
                 // Only nullable structs, not primitives or enums are currently supported
@@ -733,7 +733,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 if (nonByRefType.IsGenericInAnyWay(true) &&
                     !isNullableStruct) {
                     generatedName = string.Empty;
-                    
+
                     return $"// TODO: Method with out or in or by ref generic type parameter ({cMember.GetGeneratedName(CodeLanguage.C)})";
                 }
 
@@ -748,7 +748,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
 
         bool isGenericType = declaringType.IsGenericType ||
                              declaringType.IsGenericTypeDefinition;
-        
+
         Type[] genericTypeArguments = Array.Empty<Type>();
         int numberOfGenericTypeArguments = 0;
 
@@ -756,7 +756,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             genericTypeArguments = declaringType.GetGenericArguments();
             numberOfGenericTypeArguments = genericTypeArguments.Length;
         }
-        
+
         bool isGeneric = false;
         Type[] genericMethodArguments = Array.Empty<Type>();
         int numberOfGenericMethodArguments = 0;
@@ -774,7 +774,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 } catch {
                     genericMethodArguments = Array.Empty<Type>();
                 }
-                
+
                 numberOfGenericMethodArguments = genericMethodArguments.Length;
             }
         } else if (isGenericType &&
@@ -795,7 +795,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         }
 
         List<Type> tempCombinedGenericArguments = new();
-        
+
         tempCombinedGenericArguments.AddRange(genericTypeArguments);
         tempCombinedGenericArguments.AddRange(genericMethodArguments);
 
@@ -812,15 +812,15 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
 
                     if (nonByRefParameterType.IsArray) {
                         generatedName = string.Empty;
-                        
-                        return "// TODO: Generic Methods with out/in/ref parameters that are arrays are not supported";    
+
+                        return "// TODO: Generic Methods with out/in/ref parameters that are arrays are not supported";
                     }
                 }
             }
         }
-        
+
         const string jnaClassName = KotlinTypeSyntaxWriter.JNA_CLASS_NAME;
-        
+
         string cMethodName = $"{jnaClassName}.{cSharpGeneratedMember.GetGeneratedName(CodeLanguage.CSharpUnmanaged)}" ?? throw new Exception("No native name");
 
         // string methodNameKotlin = state.UniqueGeneratedName(
@@ -886,7 +886,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 CodeLanguage.Kotlin
             );
         }
-        
+
         bool isGenericReturnType = returnOrSetterOrEventHandlerType.IsGenericParameter ||
                                    returnOrSetterOrEventHandlerType.IsGenericMethodParameter ||
                                    returnOrSetterOrEventHandlerType.IsGenericType ||
@@ -895,7 +895,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                                    returnOrSetterOrEventHandlerType.IsConstructedGenericType;
 
         bool isConstructedGenericReturnType = returnOrSetterOrEventHandlerType.IsConstructedGenericType;
-        
+
         bool isGenericArrayReturnType = false;
 
         if (!isGenericReturnType &&
@@ -934,13 +934,13 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
 
             return "// TODO: Unsupported because of unsupported return type or derived by unsupported type";
         }
-        
+
         TypeDescriptor returnOrSetterTypeDescriptor = returnOrSetterOrEventHandlerType.GetTypeDescriptor(typeDescriptorRegistry);
-        
+
         var nullabilityInfoContext = new NullabilityInfoContext();
         var returnOrSetterTypeNullability = Nullability.NotSpecified;
-        var returnOrSetterTypeArrayElementNullability = Nullability.NotSpecified; 
-        
+        var returnOrSetterTypeArrayElementNullability = Nullability.NotSpecified;
+
         if (memberKind == MemberKind.TypeOf) {
             returnOrSetterTypeNullability = Nullability.NonNullable;
         } else if (returnOrSetterOrEventHandlerType.IsNullableValueType(out _)) {
@@ -958,7 +958,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 } else {
                     returnOrSetterValueParameter = methodInfo.ReturnParameter;
                 }
-                
+
                 var nullabilityInfo = nullabilityInfoContext.Create(returnOrSetterValueParameter);
 
                 if (memberKind == MemberKind.PropertyGetter) {
@@ -973,7 +973,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                     returnOrSetterTypeNullability = nullabilityInfo.WriteState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
-                    
+
                     returnOrSetterTypeArrayElementNullability = nullabilityInfo.ElementType?.WriteState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
@@ -1010,7 +1010,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                     returnOrSetterTypeNullability = nullabilityInfo.ReadState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
-                    
+
                     returnOrSetterTypeArrayElementNullability = nullabilityInfo.ElementType?.ReadState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
@@ -1018,7 +1018,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                     returnOrSetterTypeNullability = nullabilityInfo.WriteState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
-                    
+
                     returnOrSetterTypeArrayElementNullability = nullabilityInfo.ElementType?.WriteState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
@@ -1028,7 +1028,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                             ? Nullability.NonNullable
                             : Nullability.NotSpecified;
                     }
-                    
+
                     var elementTypeNullabilityInfo = nullabilityInfo.ElementType;
 
                     if (elementTypeNullabilityInfo is not null &&
@@ -1040,7 +1040,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 }
             }
         }
-        
+
         // TODO: This generates inout TypeName if the return type is by ref
         string kotlinReturnOrSetterTypeName = returnOrSetterTypeDescriptor.GetTypeName(
             CodeLanguage.Kotlin,
@@ -1051,10 +1051,10 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             returnOrSetterOrEventHandlerTypeIsByRef,
             false
         );
-        
+
         string kotlinReturnOrSetterTypeNameWithComment;
         Type? setterType;
-        
+
         if (memberKind == MemberKind.PropertySetter ||
             memberKind == MemberKind.FieldSetter ||
             memberKind == MemberKind.EventHandlerAdder ||
@@ -1065,7 +1065,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             kotlinReturnOrSetterTypeNameWithComment = $"{kotlinReturnOrSetterTypeName} /* {returnOrSetterOrEventHandlerType.GetFullNameOrName()} */";
             setterType = null;
         }
-        
+
         generatedName = methodNameKotlin;
         #endregion Preparation
 
@@ -1091,8 +1091,8 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             genericMethodArguments,
             syntaxWriterConfiguration,
             typeDescriptorRegistry
-        );   
-        
+        );
+
         string methodSignatureParameters = WriteParameters(
             memberKind,
             setterType,
@@ -1148,7 +1148,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             if (isEnum) {
                 return "// TODO: typeOf for enums";
             }
-            
+
             string typeOfTypeName = !returnOrSetterOrEventHandlerType.IsVoid()
                 ? kotlinReturnOrSetterTypeNameWithComment
                 : throw new Exception("A typeof declaration must have a return type");
@@ -1161,7 +1161,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 .ReturnTypeName(typeOfTypeName)
                 .Implementation(memberImpl)
                 .ToString();
-            
+
             // TODO: Properties
             /* } else if (CanBeGeneratedAsGetOnlyProperty(memberKind, isGeneric, parameters.Any())) {
                 // string propTypeName = !returnOrSetterOrEventHandlerType.IsVoid()
@@ -1185,7 +1185,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         } else {
             // TODO: Static?
             // TODO: Throws?
-            
+
             var extensionMethodType = syntaxWriterConfiguration.ExtensionMethodType;
             string? extensionMethodTypeName;
 
@@ -1202,10 +1202,10 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             }else {
                 extensionMethodTypeName = null;
             }
-            
+
             declaration = Builder.Fun(methodNameKotlin)
                 .Visibility(memberVisibility)
-                // .TypeAttachmentKind(isStaticMethod 
+                // .TypeAttachmentKind(isStaticMethod
                 //     ? interfaceGenerationPhase == SwiftSyntaxWriterConfiguration.InterfaceGenerationPhases.Protocol || interfaceGenerationPhase == SwiftSyntaxWriterConfiguration.InterfaceGenerationPhases.ProtocolExtensionForDefaultImplementations ? SwiftTypeAttachmentKinds.Static : SwiftTypeAttachmentKinds.Class
                 //     : SwiftTypeAttachmentKinds.Instance)
                 .Override(treatAsOverridden)
@@ -1221,7 +1221,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         #endregion Func Declaration
 
         XmlDocumentationMember? xmlDocumentationContent;
-        
+
         if (originatingMemberInfo is FieldInfo originatingFieldInfo) {
             xmlDocumentationContent = originatingFieldInfo.GetDocumentation();
         } else if (originatingMemberInfo is PropertyInfo originatingPropertyInfo) {
@@ -1237,7 +1237,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         } else {
             xmlDocumentationContent = null;
         }
-        
+
         var declarationComment = xmlDocumentationContent
             ?.GetFormattedDocumentationComment();
 
@@ -1253,10 +1253,10 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         } else {
             declarationWithComment = declaration;
         }
-        
+
         return declarationWithComment;
     }
-    
+
     private static bool CanBeGeneratedAsGetOnlyProperty(
         MemberKind memberKind,
         bool isGeneric,
@@ -1268,7 +1268,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             !isGeneric &&
             !hasParameters;
     }
-    
+
     private static string WriteMethodImplementation(
         GeneratedMember cSharpGeneratedMember,
         GeneratedMember cMember,
@@ -1291,18 +1291,18 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
     )
     {
         // TODO: This was copied from the Swift version of the same method and modified
-        
+
         KotlinCodeBuilder sbImpl = new();
 
         bool needsRegularImpl = true;
 
         if (memberKind == MemberKind.Destructor) {
             needsRegularImpl = false;
-            
+
             sbImpl.AppendLine($"{cMethodName}(this.__handle)");
         } else if (memberKind == MemberKind.TypeOf) {
             needsRegularImpl = false;
-            
+
             string returnTypeConversion = returnOrSetterTypeDescriptor.GetTypeConversion(
                 CodeLanguage.KotlinJNA,
                 CodeLanguage.Kotlin,
@@ -1339,14 +1339,14 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
 
             if (mayThrow) {
                 string cExceptionVarName = "__exceptionC";
-                
+
                 // TODO
                 convertedParameterNames.Add(cExceptionVarName);
-                
+
                 sbImpl.AppendLine(Builder.Val(cExceptionVarName)
                     .Value("PointerByReference()")
                     .ToString());
-                
+
                 sbImpl.AppendLine();
             }
 
@@ -1358,7 +1358,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 !returnOrSetterTypeDescriptor.IsVoid;
 
             string returnValueName = "__returnValueC";
-            
+
             string returnValueCStorage = isReturning
                 ? $"val {returnValueName} = "
                 : string.Empty;
@@ -1368,22 +1368,22 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             if (!isStaticMethod) {
                 allParameterNames.Add("this.__handle");
             }
-            
+
             allParameterNames.AddRange(convertedGenericTypeArgumentNames);
             allParameterNames.AddRange(convertedGenericMethodArgumentNames);
             allParameterNames.AddRange(convertedParameterNames);
-            
+
             string allParameterNamesString = string.Join(", ", allParameterNames);
-            
+
             string invocation = $"{returnValueCStorage}{cMethodName}({allParameterNamesString})";
-            
+
             sbImpl.AppendLine(invocation);
             sbImpl.AppendLine();
-            
+
             if (mayThrow) {
                 sbImpl.AppendLine("""
                                   val __exceptionCHandle = __exceptionC.value
-                                   
+
                                   if (__exceptionCHandle != null) {
                                       throw System_Exception(__exceptionCHandle).toKException()
                                   }
@@ -1398,7 +1398,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 if (memberKind == MemberKind.Constructor) {
                     TypeDescriptor declaringTypeDescriptor = declaringType.GetTypeDescriptor(typeDescriptorRegistry);
                     string declaringTypeName = declaringTypeDescriptor.GetTypeName(CodeLanguage.Kotlin, false);
-                    
+
                     returnCode = $"return {declaringTypeName}({returnValueName})";
                 } else {
                     string? returnTypeConversion = returnOrSetterTypeDescriptor.GetTypeConversion(
@@ -1406,7 +1406,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                         CodeLanguage.Kotlin,
                         returnOrSetterOrEventHandlerArrayElementNullability
                     );
-    
+
                     if (!string.IsNullOrEmpty(returnTypeConversion)) {
                         string newReturnValueName = "__returnValue";
                         var conv = string.Format(returnTypeConversion, returnValueName);
@@ -1417,7 +1417,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                         Nullability actualNullability = returnOrSetterOrEventHandlerNullability != Nullability.NotSpecified
                                 ? returnOrSetterOrEventHandlerNullability
                                 : returnOrSetterTypeDescriptor.Nullability;
-                        
+
                         if (returnOrSetterTypeDescriptor.RequiresNativePointer &&
                             actualNullability != Nullability.NonNullable) {
                             prefix = $"if ({returnValueName} != null) ";
@@ -1430,13 +1430,13 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                         string fullReturnTypeConversion = Builder.Val(newReturnValueName)
                             .Value($"{prefix}{conv}{suffix}")
                             .ToString();
-    
+
                         sbImpl.AppendLine(fullReturnTypeConversion);
                         sbImpl.AppendLine();
-                        
+
                         returnValueName = newReturnValueName;
                     }
-    
+
                     returnCode = $"return {returnValueName}";
                 }
             }
@@ -1451,19 +1451,19 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 bool isByRefParameter = parameterType.IsByRef;
 
                 var isInOutParameter = isOutParameter || isInParameter || isByRefParameter;
-                
+
                 if (!isInOutParameter) {
                     continue;
                 }
 
                 bool isGenericParameterType = parameterType.IsGenericParameter || parameterType.IsGenericMethodParameter;
-                
+
                 parameterType = parameterType.GetNonByRefType();
 
                 if (isGenericParameterType) {
                     parameterType = typeof(object);
                 }
-                
+
                 string parameterName = parameter.Name ?? throw new Exception("Parameter has no name");
                 string convertedParameterName = $"__{parameterName}JNAByRef";
 
@@ -1483,28 +1483,28 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                     parameterArrayElementNullability = Nullability.NotSpecified;
                 }
 
-                Nullability parameterNullability = Nullability.NotSpecified; 
-                
+                Nullability parameterNullability = Nullability.NotSpecified;
+
                 if (!isGeneric &&
                     !isGenericParameterType &&
                     parameterType.IsReferenceType()) {
                     bool isNotNull = false;
-                        
+
                     var parameterNullabilityInfo = nullabilityInfoContext.Create(parameter);
-                        
+
                     if (parameterNullabilityInfo.ReadState == parameterNullabilityInfo.WriteState) {
                         isNotNull = parameterNullabilityInfo.ReadState == NullabilityState.NotNull;
                     }
-                        
+
                     parameterNullability = isNotNull
                         ? Nullability.NonNullable
                         : parameterTypeDescriptor.Nullability;
                 }
-    
+
                 if (parameterNullability == Nullability.NotSpecified) {
                     parameterNullability = parameterTypeDescriptor.Nullability;
                 }
-                
+
                 string? parameterTypeConversion = parameterTypeDescriptor.GetTypeConversion(
                     CodeLanguage.KotlinJNA,
                     CodeLanguage.Kotlin,
@@ -1528,7 +1528,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                         // TODO: This is a bad hack
                         parameterNullability = Nullability.NonNullable;
                     }
-                    
+
                     if (parameterNullability == Nullability.NonNullable) {
                         parameterTypeConversion = resolvedConversion;
                     } else {
@@ -1555,7 +1555,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
 
         return funcImpl;
     }
-    
+
     internal static string WriteParameters(
         MemberKind memberKind,
         Type? setterOrEventHandlerType,
@@ -1573,65 +1573,65 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
     )
     {
         // TODO: This was copied from the Swift version of the same method and modified
-        
+
         var nullabilityContext = new NullabilityInfoContext();
-        
+
         List<string> parameterList = new();
 
         if (isGeneric) {
             Type typeOfSystemType = typeof(Type);
             TypeDescriptor systemTypeTypeDescriptor = typeOfSystemType.GetTypeDescriptor(typeDescriptorRegistry);
             string systemTypeTypeName = typeOfSystemType.GetFullNameOrName();
-            
+
             string nativeSystemTypeTypeName = systemTypeTypeDescriptor.GetTypeName(
-                CodeLanguage.Kotlin, 
+                CodeLanguage.Kotlin,
                 true,
                 Nullability.NonNullable
             );
-            
+
             foreach (var genericArgumentType in genericArguments) {
                 string parameterName = genericArgumentType.Name.EscapedKotlinName();
 
-                string parameterString = onlyWriteParameterNames 
-                    ? parameterName 
+                string parameterString = onlyWriteParameterNames
+                    ? parameterName
                     : $"{parameterName}: {nativeSystemTypeTypeName} /* {systemTypeTypeName} */";
-            
+
                 parameterList.Add(parameterString);
             }
         }
 
         var isExtensionMethod = syntaxWriterConfiguration?.IsExtensionMethod ?? false;
         var firstParameter = true;
-        
+
         foreach (var parameter in parameters) {
             if (firstParameter) {
                 firstParameter = false;
-            
+
                 if (isExtensionMethod) {
                     continue;
                 }
             }
-            
+
             bool isOutParameter = parameter.IsOut;
             bool isInParameter = parameter.IsIn;
-            
+
             Type parameterType = parameter.ParameterType;
-            
+
             bool isByRefParameter = parameterType.IsByRef;
 
             if (isByRefParameter) {
                 parameterType = parameterType.GetNonByRefType();
             }
-            
+
             bool isGenericParameterType = parameterType.IsGenericParameter || parameterType.IsGenericMethodParameter;
-            
+
             if (isGenericParameterType) {
                 parameterType = typeof(object);
             }
-            
+
             bool isGenericArrayParameterType = false;
             Type? arrayType = parameterType.GetElementType();
-                    
+
             if (parameterType.IsArray &&
                 arrayType is not null &&
                 (arrayType.IsGenericParameter || arrayType.IsGenericMethodParameter)) {
@@ -1641,7 +1641,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             if (isGenericArrayParameterType) {
                 parameterType = typeof(Array);
             }
-            
+
             bool isNotNull = false;
             bool isArrayElementNotNull = false;
 
@@ -1662,7 +1662,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                     isArrayElementNotNull = parameterElementTypeNullability.ReadState == NullabilityState.NotNull;
                 }
             }
-            
+
             TypeDescriptor parameterTypeDescriptor = parameterType.GetTypeDescriptor(typeDescriptorRegistry);
 
             string unmanagedParameterTypeName = parameterTypeDescriptor.GetTypeName(
@@ -1684,7 +1684,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             }
 
             string parameterString;
-            
+
             if (onlyWriteParameterNames) {
                 if (writeModifiersForInvocation) {
                     // TODO
@@ -1694,9 +1694,9 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                     parameterString = parameterName;
                 }
             } else {
-                parameterString = $"{parameterName}: {unmanagedParameterTypeName} /* {parameterType.GetFullNameOrName()} */";    
+                parameterString = $"{parameterName}: {unmanagedParameterTypeName} /* {parameterType.GetFullNameOrName()} */";
             }
-            
+
             parameterList.Add(parameterString);
         }
 
@@ -1707,9 +1707,9 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             if (setterOrEventHandlerType == null) {
                 throw new Exception("Setter or Event Handler Type may not be null");
             }
-            
+
             TypeDescriptor setterOrEventHandlerTypeDescriptor = setterOrEventHandlerType.GetTypeDescriptor(typeDescriptorRegistry);
-            
+
             string cSetterOrEventHandlerTypeName = setterOrEventHandlerTypeDescriptor.GetTypeName(
                 CodeLanguage.Kotlin,
                 true,
@@ -1722,7 +1722,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             string parameterString = onlyWriteParameterNames
                 ? parameterName
                 : $"{parameterName}: {cSetterOrEventHandlerTypeName} /* {setterOrEventHandlerType.GetFullNameOrName()} */";
-            
+
             parameterList.Add(parameterString);
         }
 
@@ -1730,7 +1730,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
 
         return parametersString;
     }
-    
+
     internal static string WriteParameterConversions(
         CodeLanguage sourceLanguage,
         CodeLanguage targetLanguage,
@@ -1751,7 +1751,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
     )
     {
         // TODO: This was copied from the Swift version of the same method and modified
-        
+
         string convertedParameterNameSuffix;
 
         if (sourceLanguage == CodeLanguage.Kotlin &&
@@ -1763,9 +1763,9 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         } else {
             throw new Exception("Unknown language pair");
         }
-        
+
         KotlinCodeBuilder sb = new();
-        
+
         convertedParameterNames = new();
         convertedGenericTypeArgumentNames = new();
         convertedGenericMethodArgumentNames = new();
@@ -1775,52 +1775,52 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             Type typeOfSystemType = typeof(Type);
             TypeDescriptor systemTypeTypeDescriptor = typeOfSystemType.GetTypeDescriptor(typeDescriptorRegistry);
             string systemTypeTypeName = typeOfSystemType.GetFullNameOrName();
-            
+
             string systemTypeTypeConversion = systemTypeTypeDescriptor.GetTypeConversion(
                 sourceLanguage,
                 targetLanguage,
                 Nullability.NotSpecified
             )!;
-    
+
             foreach (var genericArgumentType in genericTypeArguments) {
                 string name = genericArgumentType.Name;
-                
+
                 string convertedGenericArgumentName = $"{name}{convertedParameterNameSuffix}";
-                    
+
                 string fullTypeConversion = string.Format(systemTypeTypeConversion, name);
 
                 string typeConversionCode = Builder.Val(convertedGenericArgumentName)
                     .Value(fullTypeConversion)
                     .ToString();
-    
+
                 sb.AppendLine(typeConversionCode);
-                
+
                 convertedGenericTypeArgumentNames.Add(convertedGenericArgumentName);
             }
-            
+
             foreach (var genericArgumentType in genericMethodArguments) {
                 string name = genericArgumentType.Name;
-                
+
                 string convertedGenericArgumentName = $"{name}{convertedParameterNameSuffix}";
-                    
+
                 string fullTypeConversion = string.Format(systemTypeTypeConversion, name);
 
                 string typeConversionCode = Builder.Val(convertedGenericArgumentName)
                     .Value(fullTypeConversion)
                     .ToString();
-    
+
                 sb.AppendLine(typeConversionCode);
-                
+
                 convertedGenericMethodArgumentNames.Add(convertedGenericArgumentName);
             }
         }
-        
+
         var isExtensionMethod = syntaxWriterConfiguration?.IsExtensionMethod ?? false;
         var isFirstParameter = true;
 
         foreach (var parameter in parameters) {
             string extensionMethodTargetParameter = string.Empty;
-            
+
             if (isFirstParameter) {
                 isFirstParameter = false;
 
@@ -1828,19 +1828,19 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                     extensionMethodTargetParameter = "this";
                 }
             }
-            
-            string? parameterName = !string.IsNullOrEmpty(extensionMethodTargetParameter) 
-                ? extensionMethodTargetParameter 
+
+            string? parameterName = !string.IsNullOrEmpty(extensionMethodTargetParameter)
+                ? extensionMethodTargetParameter
                 : parameter.Name?.EscapedKotlinName();
-            
+
             if (parameterName is null) {
                 throw new Exception("Parameter without a name");
             }
-            
+
             Type parameterType = parameter.ParameterType;
             bool isOutParameter = parameter.IsOut;
             bool isInParameter = parameter.IsIn;
-            
+
             WriteParameterConversion(
                 sourceLanguage,
                 targetLanguage,
@@ -1860,7 +1860,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             if (!string.IsNullOrEmpty(typeConversionCode)) {
                 sb.AppendLine(typeConversionCode);
             }
-            
+
             convertedParameterNames.Add(convertedParameterName);
 
             if (!string.IsNullOrEmpty(typeBackConversionCode)) {
@@ -1876,7 +1876,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             Type parameterType = setterOrEventHandlerType ?? throw new Exception("No setter or event handler type");
             const bool isOutParameter = false;
             const bool isInParameter = false;
-            
+
             WriteParameterConversion(
                 sourceLanguage,
                 targetLanguage,
@@ -1896,9 +1896,9 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
             if (!string.IsNullOrEmpty(typeConversionCode)) {
                 sb.AppendLine(typeConversionCode);
             }
-            
+
             convertedParameterNames.Add(convertedParameterName);
-            
+
             if (!string.IsNullOrEmpty(typeBackConversionCode)) {
                 parameterTypeBackConversionCodes.Add(typeBackConversionCode);
             }
@@ -1906,7 +1906,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
 
         return sb.ToString();
     }
-    
+
     private static void WriteParameterConversion(
         CodeLanguage sourceLanguage,
         CodeLanguage targetLanguage,
@@ -1924,13 +1924,13 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
     )
     {
         // TODO: This was copied from the Swift version of the same method and modified
-        
+
         if (string.IsNullOrEmpty(parameterName)) {
-            throw new Exception("Parameter has no name");   
+            throw new Exception("Parameter has no name");
         }
-        
+
         var nullabilityContext = new NullabilityInfoContext();
-        
+
         string convertedParameterNameSuffix;
 
         if (sourceLanguage == CodeLanguage.Kotlin &&
@@ -1942,7 +1942,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         } else {
             throw new Exception("Unknown language pair");
         }
-        
+
         bool isByRefParameter = parameterType.IsByRef;
         bool isArrayType = parameterType.IsArray;
         bool isInOut = isOutParameter || isInParameter || isByRefParameter;
@@ -1950,7 +1950,7 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         if (isByRefParameter) {
             parameterType = parameterType.GetNonByRefType();
         }
-        
+
         bool isGenericParameterType = parameterType.IsGenericParameter || parameterType.IsGenericMethodParameter;
 
         if (!isByRefParameter &&
@@ -1968,11 +1968,11 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
                 }
             }
         }
-        
+
         TypeDescriptor parameterTypeDescriptor = parameterType.GetTypeDescriptor(typeDescriptorRegistry);
 
         Nullability parameterArrayElementNullability;
-        
+
         if (parameterInfo is not null) {
             var nullabilityInfoContext = new NullabilityInfoContext();
             var parameterNullabilityA = nullabilityInfoContext.Create(parameterInfo);
@@ -1989,51 +1989,51 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         } else {
             parameterArrayElementNullability = Nullability.NotSpecified;
         }
-        
+
         string parameterNameForConversion = parameterName;
-            
+
         if (parameterName.StartsWith("`") &&
             parameterName.EndsWith("`")) {
             parameterNameForConversion = parameterName.Trim('`');
         }
-        
+
         string? typeConversion = parameterTypeDescriptor.GetTypeConversion(
             sourceLanguage,
             targetLanguage,
             parameterArrayElementNullability
         );
-        
+
         string optionalString;
-                
+
         if (sourceLanguage == CodeLanguage.Kotlin &&
             targetLanguage == CodeLanguage.KotlinJNA) {
             // bool isNotNull = false;
-    
+
             if ((typeDescriptorRegistry.GetTypeDescriptor(parameterType)?.RequiresNativePointer ?? false)) {
                 parameterNullability = Nullability.NonNullable;
             }
-    
+
             if (parameterInfo is not null &&
                 !isGeneric &&
                 !isGenericParameterType &&
                 parameterType.IsReferenceType()) {
                 bool isNotNull = false;
-                        
+
                 var parameterNullabilityInfo = nullabilityContext.Create(parameterInfo);
-                        
+
                 if (parameterNullabilityInfo.ReadState == parameterNullabilityInfo.WriteState) {
                     isNotNull = parameterNullabilityInfo.ReadState == NullabilityState.NotNull;
                 }
-                        
+
                 parameterNullability = isNotNull
                     ? Nullability.NonNullable
                     : parameterTypeDescriptor.Nullability;
             }
-    
+
             if (parameterNullability == Nullability.NotSpecified) {
                 parameterNullability = parameterTypeDescriptor.Nullability;
             }
-                    
+
             optionalString = parameterNullability.GetKotlinOptionalitySpecifier();
         } else {
             optionalString = string.Empty;
@@ -2046,13 +2046,13 @@ public class KotlinMethodSyntaxWriter: IKotlinSyntaxWriter, IMethodSyntaxWriter
         } else {
             if (typeConversion != null) {
                 convertedParameterName = $"{parameterNameForConversion}{convertedParameterNameSuffix}";
-    
+
                 string fullTypeConversion = string.Format(typeConversion, $"{parameterName}{optionalString}");
-    
+
                 typeConversionCode = Builder.Val(convertedParameterName)
                     .Value(fullTypeConversion)
                     .ToString();
-                
+
                 typeBackConversionCode = null;
             } else {
                 typeConversionCode = null;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinPropertySyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinPropertySyntaxWriter.cs
@@ -12,19 +12,19 @@ public class KotlinPropertySyntaxWriter: KotlinMethodSyntaxWriter, IPropertySynt
     {
         return Write((PropertyInfo)@object, state, configuration);
     }
-    
+
     public string Write(PropertyInfo property, State state, ISyntaxWriterConfiguration? configuration)
     {
         const bool addToState = false;
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
 
         GeneratedMember? cSharpGeneratedMemberGetter = cSharpUnmanagedResult.GetGeneratedMember(property, MemberKind.PropertyGetter);
         GeneratedMember? cGeneratedMemberGetter = cResult.GetGeneratedMember(property, MemberKind.PropertyGetter);
-        
+
         GeneratedMember? cSharpGeneratedMemberSetter = cSharpUnmanagedResult.GetGeneratedMember(property, MemberKind.PropertySetter);
         GeneratedMember? cGeneratedMemberSetter = cResult.GetGeneratedMember(property, MemberKind.PropertySetter);
 
@@ -32,15 +32,15 @@ public class KotlinPropertySyntaxWriter: KotlinMethodSyntaxWriter, IPropertySynt
             cSharpGeneratedMemberSetter is null) {
             throw new Exception("No generated C# Unmanaged Member");
         }
-        
+
         if (cGeneratedMemberGetter is null &&
             cGeneratedMemberSetter is null) {
             throw new Exception("No generated C Member");
         }
 
         bool getterMayThrow = cSharpGeneratedMemberGetter?.MayThrow ?? true;
-        bool setterMayThrow = cSharpGeneratedMemberSetter?.MayThrow ?? true; 
-        
+        bool setterMayThrow = cSharpGeneratedMemberSetter?.MayThrow ?? true;
+
         Type declaringType = property.DeclaringType ?? throw new Exception("No declaring type");
 
         IEnumerable<ParameterInfo> parameters = property.GetIndexParameters();
@@ -56,7 +56,7 @@ public class KotlinPropertySyntaxWriter: KotlinMethodSyntaxWriter, IPropertySynt
             cSharpGeneratedMemberGetter is not null &&
             cGeneratedMemberGetter is not null) {
             bool isStaticMethod = getterMethod.IsStatic;
-            
+
             string getterCode = WriteMethod(
                 cSharpGeneratedMemberGetter,
                 cGeneratedMemberGetter,
@@ -76,7 +76,7 @@ public class KotlinPropertySyntaxWriter: KotlinMethodSyntaxWriter, IPropertySynt
             );
 
             sb.AppendLine(getterCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.PropertyGetter,
                 property,
@@ -85,12 +85,12 @@ public class KotlinPropertySyntaxWriter: KotlinMethodSyntaxWriter, IPropertySynt
                 CodeLanguage.Kotlin
             );
         }
-        
+
         if (setterMethod is not null &&
             cSharpGeneratedMemberSetter is not null &&
             cGeneratedMemberSetter is not null) {
             bool isStaticMethod = setterMethod.IsStatic;
-            
+
             string setterCode = WriteMethod(
                 cSharpGeneratedMemberSetter,
                 cGeneratedMemberSetter,
@@ -110,7 +110,7 @@ public class KotlinPropertySyntaxWriter: KotlinMethodSyntaxWriter, IPropertySynt
             );
 
             sb.AppendLine(setterCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.PropertySetter,
                 property,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinSharedSettings.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinSharedSettings.cs
@@ -7,7 +7,7 @@ static class KotlinSharedSettings
         typeof(System.Net.ICredentials), // Unsupported because some implementations of this use different nullability
         typeof(System.ICloneable), // Unsupported because some implementations of this use different nullability
     ];
-    
+
     private static readonly List<Type> UnsupportedTypes = [
         typeof(System.Xml.XmlDocument), // Unsupported because some implementations of this use different nullability
         typeof(System.Xml.XmlProcessingInstruction), // Unsupported because some implementations of this use different nullability
@@ -21,7 +21,7 @@ static class KotlinSharedSettings
 
         return isIt;
     }
-    
+
     internal static bool IsUnsupportedTypeOrDerivedByUnsupportedType(this Type type)
     {
         bool isIt = UnsupportedTypes.Contains(type);
@@ -29,7 +29,7 @@ static class KotlinSharedSettings
         if (isIt) {
             return true;
         }
-        
+
         var baseType = type.BaseType;
 
         if (baseType is not null &&

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinSyntaxWriterConfiguration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinSyntaxWriterConfiguration.cs
@@ -7,7 +7,7 @@ public class KotlinSyntaxWriterConfiguration: ISyntaxWriterConfiguration
         KotlinBindings,
         JNA
     }
-    
+
     public enum ExtensionMethodKinds
     {
         None,
@@ -16,10 +16,10 @@ public class KotlinSyntaxWriterConfiguration: ISyntaxWriterConfiguration
     }
 
     public GenerationPhases GenerationPhase { get; set; } = GenerationPhases.KotlinBindings;
-    
+
     public ExtensionMethodKinds ExtensionMethodKind { get; set; } = ExtensionMethodKinds.None;
     public Type? ExtensionMethodType { get; set; } = null;
-    
-    public bool IsExtensionMethod => 
+
+    public bool IsExtensionMethod =>
         ExtensionMethodKind != ExtensionMethodKinds.None && ExtensionMethodType is not null;
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinTypeOfSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinTypeOfSyntaxWriter.cs
@@ -20,10 +20,10 @@ public class KotlinTypeOfSyntaxWriter: KotlinMethodSyntaxWriter, ITypeOfSyntaxWr
         }
 
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
-        
+
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedTypeOf(type) ?? throw new Exception("No C# generated typeOf");
         GeneratedMember cGeneratedMember = cResult.GetGeneratedTypeOf(type) ?? throw new Exception("No C generated typeOf");
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/MemberKind.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/MemberKind.cs
@@ -3,20 +3,20 @@ namespace Beyond.NET.CodeGenerator.Syntax;
 public enum MemberKind
 {
     Automatic,
-    
+
     Method,
-    
+
     Constructor,
     Destructor,
-    
+
     TypeOf,
-    
+
     PropertyGetter,
     PropertySetter,
-    
+
     FieldGetter,
     FieldSetter,
-    
+
     EventHandlerAdder,
     EventHandlerRemover
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/NamespaceNode.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/NamespaceNode.cs
@@ -64,14 +64,14 @@ public class NamespaceNode
                 if (parent.IsTreeRoot) {
                     break;
                 }
-                
+
                 names.Add(parent.Name);
 
                 target = parent;
             }
-            
+
             names.Reverse();
-            
+
             string joined = string.Join('.', names);
 
             return joined;
@@ -87,10 +87,10 @@ public class NamespaceNode
     private void AddChild(NamespaceNode childNode)
     {
         childNode.m_parent = new(this);
-        
+
         m_children.Add(childNode);
     }
-    
+
     public static NamespaceNode FromTypes(IEnumerable<Type> types)
     {
         var rootNode = new NamespaceNode(string.Empty);
@@ -106,7 +106,7 @@ public class NamespaceNode
                     currentNode = existingNode;
                 } else {
                     var newNode = new NamespaceNode(part);
-                    
+
                     currentNode.AddChild(newNode);
                     currentNode = newNode;
                 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/State.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/State.cs
@@ -7,10 +7,10 @@ namespace Beyond.NET.CodeGenerator.Syntax;
 public class State
 {
     public Settings? Settings { get; init; }
-    
+
     private List<GeneratedMember> m_generatedMembers = new();
     public IEnumerable<GeneratedMember> GeneratedMembers => m_generatedMembers;
-    
+
     private List<Type> m_skippedTypes = new();
     public IEnumerable<Type> SkippedTypes => m_skippedTypes;
 
@@ -23,7 +23,7 @@ public class State
     {
         CSharpUnmanagedResult = cSharpUnmanagedResult ?? throw new ArgumentNullException(nameof(cSharpUnmanagedResult));
     }
-    
+
     public State(
         Result cSharpUnmanagedResult,
         Result cResult
@@ -44,7 +44,7 @@ public class State
             member,
             mayThrow
         );
-        
+
         m_generatedMembers.Add(generatedMember);
 
         return generatedMember;
@@ -63,9 +63,9 @@ public class State
             member,
             mayThrow
         );
-        
+
         generatedMember.SetGeneratedName(generatedName, generatedNameLanguage);
-        
+
         return generatedMember;
     }
 
@@ -122,10 +122,10 @@ public class State
     public IEnumerable<GeneratedMember> GetGeneratedMembersThatAreExtensions()
     {
         List<GeneratedMember> extensionMembers = new();
-        
+
         foreach (var generatedMember in GeneratedMembers) {
             MethodBase? methodBase = generatedMember.Member as MethodBase;
-            
+
             if (methodBase is null) {
                 continue;
             }
@@ -135,7 +135,7 @@ public class State
             if (declaringType is null) {
                 continue;
             }
-            
+
             if (declaringType.IsGenericType ||
                 declaringType.IsNested ||
                 !declaringType.IsSealed ||
@@ -148,7 +148,7 @@ public class State
             if (parameters.Length < 1) {
                 continue;
             }
-            
+
             extensionMembers.Add(generatedMember);
         }
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builder.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builder.cs
@@ -37,7 +37,7 @@ public struct Builder
             comment
         );
     }
-    
+
     public static Builders.Class Class
     (
         string name
@@ -47,7 +47,7 @@ public struct Builder
             name
         );
     }
-    
+
     public static Builders.Struct Struct
     (
         string name
@@ -57,7 +57,7 @@ public struct Builder
             name
         );
     }
-    
+
     public static Builders.Enum Enum
     (
         string name
@@ -67,7 +67,7 @@ public struct Builder
             name
         );
     }
-    
+
     public static Builders.Extension Extension
     (
         string name
@@ -77,7 +77,7 @@ public struct Builder
             name
         );
     }
-    
+
     public static Builders.Protocol Protocol
     (
         string name
@@ -87,7 +87,7 @@ public struct Builder
             name
         );
     }
-    
+
     public static Builders.Func Func
     (
         string name
@@ -97,17 +97,17 @@ public struct Builder
             name
         );
     }
-    
+
     public static Builders.Initializer Initializer()
     {
         return new();
     }
-    
+
     public static Builders.Closure Closure()
     {
         return new();
     }
-    
+
     public static Builders.FuncSignatureParameter FuncSignatureParameter
     (
         string label,
@@ -121,7 +121,7 @@ public struct Builder
             typeName
         );
     }
-    
+
     public static Builders.FuncSignatureParameter FuncSignatureParameter
     (
         string label,
@@ -133,12 +133,12 @@ public struct Builder
             typeName
         );
     }
-    
+
     public static Builders.FuncSignatureParameters FuncSignatureParameters()
     {
         return new();
     }
-    
+
     public static Builders.Variable Variable
     (
         SwiftVariableKinds variableKind,
@@ -150,7 +150,7 @@ public struct Builder
             name
         );
     }
-    
+
     public static Builders.Variable Let
     (
         string name
@@ -161,7 +161,7 @@ public struct Builder
             name
         );
     }
-    
+
     public static Builders.Variable Var
     (
         string name

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Class.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Class.cs
@@ -11,22 +11,22 @@ public struct Class
     private string? m_protocolConformance = null;
     private SwiftVisibilities m_visibility = SwiftVisibilities.None;
     private string? m_implementation = null;
-    
+
     public Class(
         string name
     )
     {
         m_name = name;
     }
-    
+
     #region Visibility
     public Class Visibility(SwiftVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public Class Open()
     {
         return Visibility(SwiftVisibilities.Open);
@@ -36,17 +36,17 @@ public struct Class
     {
         return Visibility(SwiftVisibilities.Public);
     }
-    
+
     public Class Internal()
     {
         return Visibility(SwiftVisibilities.Internal);
     }
-    
+
     public Class Private()
     {
         return Visibility(SwiftVisibilities.Private);
     }
-    
+
     public Class FilePrivate()
     {
         return Visibility(SwiftVisibilities.FilePrivate);
@@ -61,7 +61,7 @@ public struct Class
         return this;
     }
     #endregion BaseTypeName
-    
+
     #region ProtocolConformance
     public Class ProtocolConformance(string? protocolConformance = null)
     {
@@ -70,7 +70,7 @@ public struct Class
         return this;
     }
     #endregion ProtocolConformance
-    
+
     #region Implementation
     public Class Implementation(string? implementation = null)
     {
@@ -79,7 +79,7 @@ public struct Class
         return this;
     }
     #endregion Implementation
-    
+
     #region Build
     public SwiftClassDeclaration Build()
     {
@@ -97,7 +97,7 @@ public struct Class
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Closure.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Closure.cs
@@ -8,9 +8,9 @@ public struct Closure
     private string? m_parameters = null;
     private bool m_throws = false;
     private string? m_returnTypeName = null;
-    
+
     public Closure() { }
-    
+
     #region Parameters
     public Closure Parameters(string? parameters = null)
     {
@@ -19,7 +19,7 @@ public struct Closure
         return this;
     }
     #endregion Parameters
-    
+
     #region Throws
     public Closure Throws(bool throws = true)
     {
@@ -37,7 +37,7 @@ public struct Closure
         return this;
     }
     #endregion ReturnTypeName
-    
+
     #region Build
     public SwiftClosureDeclaration Build()
     {
@@ -53,7 +53,7 @@ public struct Closure
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Enum.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Enum.cs
@@ -27,15 +27,15 @@ public struct Enum
         return this;
     }
     #endregion RawTypeName
-    
+
     #region Visibility
     public Enum Visibility(SwiftVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public Enum Open()
     {
         return Visibility(SwiftVisibilities.Open);
@@ -45,23 +45,23 @@ public struct Enum
     {
         return Visibility(SwiftVisibilities.Public);
     }
-    
+
     public Enum Internal()
     {
         return Visibility(SwiftVisibilities.Internal);
     }
-    
+
     public Enum Private()
     {
         return Visibility(SwiftVisibilities.Private);
     }
-    
+
     public Enum FilePrivate()
     {
         return Visibility(SwiftVisibilities.FilePrivate);
     }
     #endregion Visibility
-    
+
     #region Implementation
     public Enum Implementation(string? implementation = null)
     {
@@ -70,7 +70,7 @@ public struct Enum
         return this;
     }
     #endregion Implementation
-    
+
     #region Build
     public SwiftEnumDeclaration Build()
     {
@@ -87,7 +87,7 @@ public struct Enum
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Extension.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Extension.cs
@@ -10,7 +10,7 @@ public struct Extension
     private string? m_protocolConformance = null;
     private SwiftVisibilities m_visibility = SwiftVisibilities.None;
     private string? m_implementation = null;
-    
+
     public Extension(
         string name
     )
@@ -26,15 +26,15 @@ public struct Extension
         return this;
     }
     #endregion ProtocolConformance
-    
+
     #region Visibility
     public Extension Visibility(SwiftVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public Extension Open()
     {
         return Visibility(SwiftVisibilities.Open);
@@ -44,23 +44,23 @@ public struct Extension
     {
         return Visibility(SwiftVisibilities.Public);
     }
-    
+
     public Extension Internal()
     {
         return Visibility(SwiftVisibilities.Internal);
     }
-    
+
     public Extension Private()
     {
         return Visibility(SwiftVisibilities.Private);
     }
-    
+
     public Extension FilePrivate()
     {
         return Visibility(SwiftVisibilities.FilePrivate);
     }
     #endregion Visibility
-    
+
     #region Implementation
     public Extension Implementation(string? implementation = null)
     {
@@ -69,7 +69,7 @@ public struct Extension
         return this;
     }
     #endregion Implementation
-    
+
     #region Build
     public SwiftExtensionDeclaration Build()
     {
@@ -86,7 +86,7 @@ public struct Extension
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Func.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Func.cs
@@ -22,15 +22,15 @@ public struct Func
     {
         m_name = name;
     }
-    
+
     #region Visibility
     public Func Visibility(SwiftVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public Func Open()
     {
         return Visibility(SwiftVisibilities.Open);
@@ -40,23 +40,23 @@ public struct Func
     {
         return Visibility(SwiftVisibilities.Public);
     }
-    
+
     public Func Internal()
     {
         return Visibility(SwiftVisibilities.Internal);
     }
-    
+
     public Func Private()
     {
         return Visibility(SwiftVisibilities.Private);
     }
-    
+
     public Func FilePrivate()
     {
         return Visibility(SwiftVisibilities.FilePrivate);
     }
     #endregion Visibility
-    
+
     #region TypeAttachmentKind
     public Func TypeAttachmentKind(SwiftTypeAttachmentKinds typeAttachmentKind)
     {
@@ -69,13 +69,13 @@ public struct Func
     {
         return TypeAttachmentKind(SwiftTypeAttachmentKinds.Static);
     }
-    
+
     public Func Class()
     {
         return TypeAttachmentKind(SwiftTypeAttachmentKinds.Class);
     }
     #endregion TypeAttachmentKind
-    
+
     #region Override
     public Func Override(bool isOverride = true)
     {
@@ -102,7 +102,7 @@ public struct Func
         return this;
     }
     #endregion Parameters
-    
+
     #region ReturnTypeName
     public Func ReturnTypeName(string? returnTypeName = null)
     {
@@ -111,7 +111,7 @@ public struct Func
         return this;
     }
     #endregion ReturnTypeName
-    
+
     #region Implementation
     public Func Implementation(string? implementation = null)
     {
@@ -120,7 +120,7 @@ public struct Func
         return this;
     }
     #endregion Implementation
-    
+
     #region Build
     public SwiftFuncDeclaration Build()
     {
@@ -141,7 +141,7 @@ public struct Func
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/FuncSignatureParameter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/FuncSignatureParameter.cs
@@ -7,7 +7,7 @@ public struct FuncSignatureParameter
     private readonly string m_label;
     private readonly string? m_name;
     private readonly string m_typeName;
-    
+
     public FuncSignatureParameter
     (
         string label,
@@ -19,7 +19,7 @@ public struct FuncSignatureParameter
         m_name = name;
         m_typeName = typeName;
     }
-    
+
     public FuncSignatureParameter
     (
         string label,
@@ -30,7 +30,7 @@ public struct FuncSignatureParameter
         m_name = null;
         m_typeName = typeName;
     }
-    
+
     #region Build
     public SwiftFuncSignatureParameter Build()
     {

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/FuncSignatureParameters.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/FuncSignatureParameters.cs
@@ -15,7 +15,7 @@ public struct FuncSignatureParameters
 
         return this;
     }
-    
+
     public FuncSignatureParameters AddParameter(
         string label,
         string? name,
@@ -28,7 +28,7 @@ public struct FuncSignatureParameters
             typeName
         ));
     }
-    
+
     public FuncSignatureParameters AddParameter(
         string label,
         string typeName
@@ -40,7 +40,7 @@ public struct FuncSignatureParameters
         ));
     }
     #endregion Add Parameter
-    
+
     #region Build
     public SwiftFuncSignatureParameters Build()
     {
@@ -48,10 +48,10 @@ public struct FuncSignatureParameters
 
         foreach (var parameter in m_parameters) {
             var convertedParameter = parameter.Build();
-            
+
             parameters.Add(convertedParameter);
         }
-        
+
         return new(parameters);
     }
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/GetOnlyProperty.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/GetOnlyProperty.cs
@@ -7,13 +7,13 @@ public struct GetOnlyProperty
 {
     private readonly string m_name;
     private readonly string m_typeName;
-    
+
     private SwiftVisibilities m_visibility = SwiftVisibilities.None;
     private SwiftTypeAttachmentKinds m_typeAttachmentKind = SwiftTypeAttachmentKinds.Instance;
     private bool m_override = false;
     private bool m_throws = false;
     private string? m_implementation = null;
-    
+
     public GetOnlyProperty(
         string name,
         string typeName
@@ -27,10 +27,10 @@ public struct GetOnlyProperty
     public GetOnlyProperty Visibility(SwiftVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public GetOnlyProperty Open()
     {
         return Visibility(SwiftVisibilities.Open);
@@ -40,17 +40,17 @@ public struct GetOnlyProperty
     {
         return Visibility(SwiftVisibilities.Public);
     }
-    
+
     public GetOnlyProperty Internal()
     {
         return Visibility(SwiftVisibilities.Internal);
     }
-    
+
     public GetOnlyProperty Private()
     {
         return Visibility(SwiftVisibilities.Private);
     }
-    
+
     public GetOnlyProperty FilePrivate()
     {
         return Visibility(SwiftVisibilities.FilePrivate);
@@ -69,7 +69,7 @@ public struct GetOnlyProperty
     {
         return TypeAttachmentKind(SwiftTypeAttachmentKinds.Static);
     }
-    
+
     public GetOnlyProperty Class()
     {
         return TypeAttachmentKind(SwiftTypeAttachmentKinds.Class);
@@ -122,7 +122,7 @@ public struct GetOnlyProperty
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Initializer.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Initializer.cs
@@ -12,7 +12,7 @@ public struct Initializer
     private string? m_parameters = null;
     private bool m_throws = false;
     private string? m_implementation = null;
-    
+
     public Initializer() { }
 
     #region Convenience
@@ -23,7 +23,7 @@ public struct Initializer
         return this;
     }
     #endregion Convenience
-    
+
     #region Failable
     public Initializer Failable(bool failable = true)
     {
@@ -32,15 +32,15 @@ public struct Initializer
         return this;
     }
     #endregion Failable
-    
+
     #region Visibility
     public Initializer Visibility(SwiftVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public Initializer Open()
     {
         return Visibility(SwiftVisibilities.Open);
@@ -50,17 +50,17 @@ public struct Initializer
     {
         return Visibility(SwiftVisibilities.Public);
     }
-    
+
     public Initializer Internal()
     {
         return Visibility(SwiftVisibilities.Internal);
     }
-    
+
     public Initializer Private()
     {
         return Visibility(SwiftVisibilities.Private);
     }
-    
+
     public Initializer FilePrivate()
     {
         return Visibility(SwiftVisibilities.FilePrivate);
@@ -75,7 +75,7 @@ public struct Initializer
         return this;
     }
     #endregion Parameters
-    
+
     #region Throws
     public Initializer Throws(bool throws = true)
     {
@@ -84,7 +84,7 @@ public struct Initializer
         return this;
     }
     #endregion Throws
-    
+
     #region Implementation
     public Initializer Implementation([StringSyntax("Swift")] string? implementation = null)
     {
@@ -93,7 +93,7 @@ public struct Initializer
         return this;
     }
     #endregion Implementation
-    
+
     #region Build
     public SwiftInitDeclaration Build()
     {
@@ -112,7 +112,7 @@ public struct Initializer
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Protocol.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Protocol.cs
@@ -11,14 +11,14 @@ public struct Protocol
     private string? m_protocolConformance = null;
     private SwiftVisibilities m_visibility = SwiftVisibilities.None;
     private string? m_implementation = null;
-    
+
     public Protocol(
         string name
     )
     {
         m_name = name;
     }
-    
+
     #region BaseTypeName
     public Protocol BaseTypeName(string? baseTypeName = null)
     {
@@ -36,15 +36,15 @@ public struct Protocol
         return this;
     }
     #endregion ProtocolConformance
-    
+
     #region Visibility
     public Protocol Visibility(SwiftVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public Protocol Open()
     {
         return Visibility(SwiftVisibilities.Open);
@@ -54,23 +54,23 @@ public struct Protocol
     {
         return Visibility(SwiftVisibilities.Public);
     }
-    
+
     public Protocol Internal()
     {
         return Visibility(SwiftVisibilities.Internal);
     }
-    
+
     public Protocol Private()
     {
         return Visibility(SwiftVisibilities.Private);
     }
-    
+
     public Protocol FilePrivate()
     {
         return Visibility(SwiftVisibilities.FilePrivate);
     }
     #endregion Visibility
-    
+
     #region Implementation
     public Protocol Implementation(string? implementation = null)
     {
@@ -79,7 +79,7 @@ public struct Protocol
         return this;
     }
     #endregion Implementation
-    
+
     #region Build
     public SwiftProtocolDeclaration Build()
     {
@@ -97,7 +97,7 @@ public struct Protocol
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/SingleLineComment.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/SingleLineComment.cs
@@ -6,14 +6,14 @@ namespace Beyond.NET.CodeGenerator.Syntax.Swift.Builders;
 public struct SingleLineComment
 {
     private readonly string m_comment;
-    
+
     public SingleLineComment(
         string comment
     )
     {
         m_comment = comment;
     }
-    
+
     #region Build
     public SwiftSingleLineComment Build()
     {
@@ -27,7 +27,7 @@ public struct SingleLineComment
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Struct.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Struct.cs
@@ -10,7 +10,7 @@ public struct Struct
     private string? m_protocolConformance = null;
     private SwiftVisibilities m_visibility = SwiftVisibilities.None;
     private string? m_implementation = null;
-    
+
     public Struct(
         string name
     )
@@ -26,15 +26,15 @@ public struct Struct
         return this;
     }
     #endregion ProtocolConformance
-    
+
     #region Visibility
     public Struct Visibility(SwiftVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public Struct Open()
     {
         return Visibility(SwiftVisibilities.Open);
@@ -44,23 +44,23 @@ public struct Struct
     {
         return Visibility(SwiftVisibilities.Public);
     }
-    
+
     public Struct Internal()
     {
         return Visibility(SwiftVisibilities.Internal);
     }
-    
+
     public Struct Private()
     {
         return Visibility(SwiftVisibilities.Private);
     }
-    
+
     public Struct FilePrivate()
     {
         return Visibility(SwiftVisibilities.FilePrivate);
     }
     #endregion Visibility
-    
+
     #region Implementation
     public Struct Implementation(string? implementation = null)
     {
@@ -69,7 +69,7 @@ public struct Struct
         return this;
     }
     #endregion Implementation
-    
+
     #region Build
     public SwiftStructDeclaration Build()
     {
@@ -86,7 +86,7 @@ public struct Struct
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/TypeAlias.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/TypeAlias.cs
@@ -7,9 +7,9 @@ public struct TypeAlias
 {
     private readonly string m_aliasTypeName;
     private readonly string m_originalTypeName;
-    
+
     private SwiftVisibilities m_visibility = SwiftVisibilities.None;
-    
+
     public TypeAlias(
         string aliasTypeName,
         string originalTypeName
@@ -18,15 +18,15 @@ public struct TypeAlias
         m_aliasTypeName = aliasTypeName;
         m_originalTypeName = originalTypeName;
     }
-    
+
     #region Visibility
     public TypeAlias Visibility(SwiftVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public TypeAlias Open()
     {
         return Visibility(SwiftVisibilities.Open);
@@ -36,23 +36,23 @@ public struct TypeAlias
     {
         return Visibility(SwiftVisibilities.Public);
     }
-    
+
     public TypeAlias Internal()
     {
         return Visibility(SwiftVisibilities.Internal);
     }
-    
+
     public TypeAlias Private()
     {
         return Visibility(SwiftVisibilities.Private);
     }
-    
+
     public TypeAlias FilePrivate()
     {
         return Visibility(SwiftVisibilities.FilePrivate);
     }
     #endregion Visibility
-    
+
     #region Build
     public SwiftTypeAliasDeclaration Build()
     {
@@ -68,7 +68,7 @@ public struct TypeAlias
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Variable.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Builders/Variable.cs
@@ -31,7 +31,7 @@ public struct Variable
         return this;
     }
     #endregion TypeName
-    
+
     #region Value
     public Variable Value([StringSyntax("Swift")]string? value)
     {
@@ -40,15 +40,15 @@ public struct Variable
         return this;
     }
     #endregion Value
-    
+
     #region Visibility
     public Variable Visibility(SwiftVisibilities visibility)
     {
         m_visibility = visibility;
-        
+
         return this;
     }
-    
+
     public Variable Open()
     {
         return Visibility(SwiftVisibilities.Open);
@@ -58,23 +58,23 @@ public struct Variable
     {
         return Visibility(SwiftVisibilities.Public);
     }
-    
+
     public Variable Internal()
     {
         return Visibility(SwiftVisibilities.Internal);
     }
-    
+
     public Variable Private()
     {
         return Visibility(SwiftVisibilities.Private);
     }
-    
+
     public Variable FilePrivate()
     {
         return Visibility(SwiftVisibilities.FilePrivate);
     }
     #endregion Visibility
-    
+
     #region TypeAttachmentKind
     public Variable TypeAttachmentKind(SwiftTypeAttachmentKinds typeAttachmentKind)
     {
@@ -87,13 +87,13 @@ public struct Variable
     {
         return TypeAttachmentKind(SwiftTypeAttachmentKinds.Static);
     }
-    
+
     public Variable Class()
     {
         return TypeAttachmentKind(SwiftTypeAttachmentKinds.Class);
     }
     #endregion TypeAttachmentKind
-    
+
     #region Build
     public SwiftVariableDeclaration Build()
     {
@@ -112,7 +112,7 @@ public struct Variable
         return Build()
             .ToString();
     }
-    
+
     public string ToIndentedString(int indentationLevel)
     {
         return Build()

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftClassDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftClassDeclaration.cs
@@ -28,7 +28,7 @@ public struct SwiftClassDeclaration
     public override string ToString()
     {
         const string @class = "class";
-        
+
         string visibilityString = Visibility.ToSwiftSyntaxString();
 
         string baseTypeAndProtocolConformanceDecl = !string.IsNullOrEmpty(BaseTypeName)
@@ -40,7 +40,7 @@ public struct SwiftClassDeclaration
                 ? $", {ProtocolConformance}"
                 : $": {ProtocolConformance}";
         }
-        
+
         string[] signatureComponents = {
             visibilityString,
             @class,
@@ -50,10 +50,10 @@ public struct SwiftClassDeclaration
         string signature = SwiftFuncSignatureComponents.ComponentsToString(signatureComponents);
 
         string fullDecl;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImpl = Implementation.IndentAllLines(1);
-            
+
             fullDecl = $"{signature} {{\n{indentedImpl}\n}}";
         } else {
             fullDecl = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftClosureDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftClosureDeclaration.cs
@@ -5,7 +5,7 @@ public struct SwiftClosureDeclaration
     public string Parameters { get; }
     public bool Throws { get; }
     public string? ReturnTypeName { get; }
-    
+
     public SwiftClosureDeclaration(
         string parameters,
         bool throws,
@@ -16,7 +16,7 @@ public struct SwiftClosureDeclaration
         Throws = throws;
 
         ReturnTypeName = !string.IsNullOrEmpty(returnTypeName)
-            ? returnTypeName 
+            ? returnTypeName
             : null;
     }
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftEnumDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftEnumDeclaration.cs
@@ -25,13 +25,13 @@ public struct SwiftEnumDeclaration
     public override string ToString()
     {
         const string @enum = "enum";
-        
+
         string visibilityString = Visibility.ToSwiftSyntaxString();
 
         string rawTypeDecl = !string.IsNullOrEmpty(RawTypeName)
             ? $": {RawTypeName}"
-            : string.Empty; 
-        
+            : string.Empty;
+
         string[] signatureComponents = new[] {
             visibilityString,
             @enum,
@@ -41,10 +41,10 @@ public struct SwiftEnumDeclaration
         string signature = SwiftFuncSignatureComponents.ComponentsToString(signatureComponents);
 
         string fullDecl;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImpl = Implementation.IndentAllLines(1);
-            
+
             fullDecl = $"{signature} {{\n{indentedImpl}\n}}";
         } else {
             fullDecl = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftExtensionDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftExtensionDeclaration.cs
@@ -21,17 +21,17 @@ public struct SwiftExtensionDeclaration
         Visibility = visibility;
         Implementation = implementation;
     }
-    
+
     public override string ToString()
     {
         const string extension = "extension";
-        
+
         string visibilityString = Visibility.ToSwiftSyntaxString();
 
         string protocolConformanceDecl = !string.IsNullOrEmpty(ProtocolConformance)
             ? $": {ProtocolConformance}"
-            : string.Empty; 
-        
+            : string.Empty;
+
         string[] signatureComponents = new[] {
             visibilityString,
             extension,
@@ -41,10 +41,10 @@ public struct SwiftExtensionDeclaration
         string signature = SwiftFuncSignatureComponents.ComponentsToString(signatureComponents);
 
         string fullDecl;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImpl = Implementation.IndentAllLines(1);
-            
+
             fullDecl = $"{signature} {{\n{indentedImpl}\n}}";
         } else {
             fullDecl = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftFuncDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftFuncDeclaration.cs
@@ -12,7 +12,7 @@ public struct SwiftFuncDeclaration
     public bool Throws { get; }
     public string? ReturnTypeName { get; }
     public string? Implementation { get; }
-    
+
     public SwiftFuncDeclaration(
         string name,
         SwiftVisibilities visibility,
@@ -25,9 +25,9 @@ public struct SwiftFuncDeclaration
     )
     {
         Name = !string.IsNullOrEmpty(name)
-            ? name 
+            ? name
             : throw new ArgumentOutOfRangeException(nameof(name));
-        
+
         Visibility = visibility;
         TypeAttachmentKind = typeAttachmentKind;
         IsOverride = isOverride;
@@ -37,7 +37,7 @@ public struct SwiftFuncDeclaration
         ReturnTypeName = !string.IsNullOrEmpty(returnTypeName)
             ? returnTypeName
             : null;
-        
+
         Implementation = !string.IsNullOrEmpty(implementation)
             ? implementation
             : null;
@@ -46,7 +46,7 @@ public struct SwiftFuncDeclaration
     public override string ToString()
     {
         const string func = "func";
-        
+
         string visibilityString = Visibility.ToSwiftSyntaxString();
         string typeAttachmentKindString = TypeAttachmentKind.ToSwiftSyntaxString();
 
@@ -75,10 +75,10 @@ public struct SwiftFuncDeclaration
         string signature = SwiftFuncSignatureComponents.ComponentsToString(signatureComponents);
 
         string fullFunc;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImpl = Implementation.IndentAllLines(1);
-            
+
             fullFunc = $"{signature} {{\n{indentedImpl}\n}}";
         } else {
             fullFunc = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftFuncSignatureParameter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftFuncSignatureParameter.cs
@@ -5,7 +5,7 @@ public struct SwiftFuncSignatureParameter
     public string Label { get; }
     public string? Name { get; }
     public string TypeName { get; }
-    
+
     public SwiftFuncSignatureParameter(
         string label,
         string? name,
@@ -16,7 +16,7 @@ public struct SwiftFuncSignatureParameter
         Name = name;
         TypeName = typeName;
     }
-    
+
     public SwiftFuncSignatureParameter(
         string label,
         string typeName
@@ -32,7 +32,7 @@ public struct SwiftFuncSignatureParameter
         if (string.IsNullOrEmpty(TypeName)) {
             throw new ArgumentOutOfRangeException(nameof(TypeName));
         }
-        
+
         string label = !string.IsNullOrEmpty(Label)
             ? Label
             : "_";
@@ -45,7 +45,7 @@ public struct SwiftFuncSignatureParameter
             label == "_") {
             throw new Exception("Either Label or Name or both must be supplied");
         }
-        
+
         string labelAndName;
 
         if (!string.IsNullOrEmpty(name) &&
@@ -56,7 +56,7 @@ public struct SwiftFuncSignatureParameter
         }
 
         string labelAndNameAndColon = $"{labelAndName}:";
-        
+
         string parameter = SwiftFuncSignatureComponents.ComponentsToString(new[] {
             labelAndNameAndColon,
             TypeName

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftFuncSignatureParameters.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftFuncSignatureParameters.cs
@@ -8,7 +8,7 @@ public struct SwiftFuncSignatureParameters
     {
         Parameters = Array.Empty<SwiftFuncSignatureParameter>();
     }
-    
+
     public SwiftFuncSignatureParameters(IEnumerable<SwiftFuncSignatureParameter> parameters)
     {
         Parameters = parameters;
@@ -21,7 +21,7 @@ public struct SwiftFuncSignatureParameters
         foreach (var parameter in Parameters) {
             parameterStrings.Add(parameter.ToString());
         }
-        
+
         string parametersString = string.Join(", ", parameterStrings);
 
         return parametersString;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftGetOnlyPropertyDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftGetOnlyPropertyDeclaration.cs
@@ -11,7 +11,7 @@ public struct SwiftGetOnlyPropertyDeclaration
     public bool Throws { get; }
     public string TypeName { get; }
     public string? Implementation { get; }
-    
+
     public SwiftGetOnlyPropertyDeclaration(
         string name,
         SwiftVisibilities visibility,
@@ -23,9 +23,9 @@ public struct SwiftGetOnlyPropertyDeclaration
     )
     {
         Name = !string.IsNullOrEmpty(name)
-            ? name 
+            ? name
             : throw new ArgumentOutOfRangeException(nameof(name));
-        
+
         Visibility = visibility;
         TypeAttachmentKind = typeAttachmentKind;
         IsOverride = isOverride;
@@ -33,13 +33,13 @@ public struct SwiftGetOnlyPropertyDeclaration
         TypeName = typeName;
         Implementation = implementation;
     }
-    
+
     public override string ToString()
     {
         const string var = "var";
         const string get = "get";
         string newLine = Environment.NewLine;
-        
+
         string visibilityString = Visibility.ToSwiftSyntaxString();
         string typeAttachmentKindString = TypeAttachmentKind.ToSwiftSyntaxString();
 
@@ -60,7 +60,7 @@ public struct SwiftGetOnlyPropertyDeclaration
 
         const string openingBrace = "{";
         const string closingBrace = "}";
-        
+
         string[] signatureComponents = new[] {
             visibilityString,
             overrideString,
@@ -70,18 +70,18 @@ public struct SwiftGetOnlyPropertyDeclaration
             openingBrace,
             get,
             throwsString,
-            hasImplementation 
+            hasImplementation
                 ? openingBrace
                 : closingBrace
         };
 
         string signature = SwiftFuncSignatureComponents.ComponentsToString(signatureComponents);
         string decl = signature;
-        
+
         if (hasImplementation) {
             decl += $"{newLine}{implementation}{newLine}{closingBrace}{closingBrace}";
         }
-        
+
         return decl;
     }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftInitDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftInitDeclaration.cs
@@ -10,7 +10,7 @@ public struct SwiftInitDeclaration
     public string Parameters { get; }
     public bool Throws { get; }
     public string? Implementation { get; }
-    
+
     public SwiftInitDeclaration(
         bool isConvenience,
         bool isFailable,
@@ -25,30 +25,30 @@ public struct SwiftInitDeclaration
         Visibility = visibility;
         Parameters = parameters;
         Throws = throws;
-        
+
         Implementation = !string.IsNullOrEmpty(implementation)
             ? implementation
             : null;
     }
-    
+
     public override string ToString()
     {
         string convenienceString = IsConvenience
             ? "convenience"
             : string.Empty;
-        
+
         const string name = "init";
-        
+
         string isFailableString = IsFailable
             ? "?"
             : string.Empty;
-        
+
         string visibilityString = Visibility.ToSwiftSyntaxString();
-        
+
         string throwsString = Throws
             ? "throws"
             : string.Empty;
-        
+
         string[] signatureComponents = new[] {
             visibilityString,
             convenienceString,
@@ -57,12 +57,12 @@ public struct SwiftInitDeclaration
         };
 
         string signature = SwiftFuncSignatureComponents.ComponentsToString(signatureComponents);
-        
+
         string fullInit;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImpl = Implementation.IndentAllLines(1);
-            
+
             fullInit = $"{signature} {{\n{indentedImpl}\n}}";
         } else {
             fullInit = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftProtocolDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftProtocolDeclaration.cs
@@ -28,7 +28,7 @@ public struct SwiftProtocolDeclaration
     public override string ToString()
     {
         const string protocol = "protocol";
-        
+
         string visibilityString = Visibility.ToSwiftSyntaxString();
 
         string baseTypeAndProtocolConformanceDecl = !string.IsNullOrEmpty(BaseTypeName)
@@ -39,8 +39,8 @@ public struct SwiftProtocolDeclaration
             baseTypeAndProtocolConformanceDecl += !string.IsNullOrEmpty(baseTypeAndProtocolConformanceDecl)
                 ? $", {ProtocolConformance}"
                 : $": {ProtocolConformance}";
-        } 
-        
+        }
+
         string[] signatureComponents = [
             visibilityString,
             protocol,
@@ -50,10 +50,10 @@ public struct SwiftProtocolDeclaration
         string signature = SwiftFuncSignatureComponents.ComponentsToString(signatureComponents);
 
         string fullDecl;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImpl = Implementation.IndentAllLines(1);
-            
+
             fullDecl = $"{signature} {{\n{indentedImpl}\n}}";
         } else {
             fullDecl = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftStructDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftStructDeclaration.cs
@@ -25,13 +25,13 @@ public struct SwiftStructDeclaration
     public override string ToString()
     {
         const string @struct = "struct";
-        
+
         string visibilityString = Visibility.ToSwiftSyntaxString();
 
         string protocolConformanceDecl = !string.IsNullOrEmpty(ProtocolConformance)
             ? $": {ProtocolConformance}"
-            : string.Empty; 
-        
+            : string.Empty;
+
         string[] signatureComponents = new[] {
             visibilityString,
             @struct,
@@ -41,10 +41,10 @@ public struct SwiftStructDeclaration
         string signature = SwiftFuncSignatureComponents.ComponentsToString(signatureComponents);
 
         string fullDecl;
-        
+
         if (!string.IsNullOrEmpty(Implementation)) {
             string indentedImpl = Implementation.IndentAllLines(1);
-            
+
             fullDecl = $"{signature} {{\n{indentedImpl}\n}}";
         } else {
             fullDecl = signature;

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftTypeAliasDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftTypeAliasDeclaration.cs
@@ -21,7 +21,7 @@ public struct SwiftTypeAliasDeclaration
     {
         const string typealias = "typealias";
         const string equals = "=";
-        
+
         string visibilityString = Visibility.ToSwiftSyntaxString();
 
         string[] signatureComponents = new[] {

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftVariableDeclaration.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/Declaration/SwiftVariableDeclaration.cs
@@ -45,7 +45,7 @@ public struct SwiftVariableDeclaration
             default:
                 throw new Exception("Unknown Variable Kind");
         }
-        
+
         string visibilityString = Visibility.ToSwiftSyntaxString();
         string typeAttachmentKindString = TypeAttachmentKind.ToSwiftSyntaxString();
 
@@ -58,7 +58,7 @@ public struct SwiftVariableDeclaration
         string valueAssignment = !string.IsNullOrEmpty(Value)
             ? $"= {Value}"
             : string.Empty;
-        
+
         string[] signatureComponents = [
             visibilityString,
             typeAttachmentKindString,
@@ -68,7 +68,7 @@ public struct SwiftVariableDeclaration
         ];
 
         string decl = SwiftFuncSignatureComponents.ComponentsToString(signatureComponents);
-        
+
         return decl;
     }
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/ISwiftSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/ISwiftSyntaxWriter.cs
@@ -2,5 +2,5 @@ namespace Beyond.NET.CodeGenerator.Syntax.Swift;
 
 public interface ISwiftSyntaxWriter: ISyntaxWriter
 {
-    
+
 }

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftConstructorSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftConstructorSyntaxWriter.cs
@@ -16,12 +16,12 @@ public class SwiftConstructorSyntaxWriter: SwiftMethodSyntaxWriter, IConstructor
     {
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
-        
+
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedMember(constructor) ?? throw new Exception("No C# generated member");
         GeneratedMember cGeneratedMember = cResult.GetGeneratedMember(constructor) ?? throw new Exception("No C generated member");
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         bool mayThrow = cSharpGeneratedMember.MayThrow;
         const MemberKind methodKind = MemberKind.Constructor;
 
@@ -32,7 +32,7 @@ public class SwiftConstructorSyntaxWriter: SwiftMethodSyntaxWriter, IConstructor
         if (declaringType.IsAbstract) {
             return string.Empty;
         }
-        
+
         Type returnType = declaringType;
         IEnumerable<ParameterInfo> parameters = constructor.GetParameters();
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftDestructorSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftDestructorSyntaxWriter.cs
@@ -21,10 +21,10 @@ public class SwiftDestructorSyntaxWriter: SwiftMethodSyntaxWriter, IDestructorSy
         }
 
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
-        
+
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedDestructor(type) ?? throw new Exception("No C# generated destructor");
         GeneratedMember cGeneratedMember = cResult.GetGeneratedDestructor(type) ?? throw new Exception("No C generated destructor");
 

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftEventSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftEventSyntaxWriter.cs
@@ -16,15 +16,15 @@ public class SwiftEventSyntaxWriter: SwiftMethodSyntaxWriter, IEventSyntaxWriter
     public string Write(EventInfo @event, State state, ISyntaxWriterConfiguration? configuration)
     {
         const bool addToState = false;
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
 
         GeneratedMember? cSharpGeneratedAdderMember = cSharpUnmanagedResult.GetGeneratedMember(@event, MemberKind.EventHandlerAdder);
         GeneratedMember? cGeneratedAdderMember = cResult.GetGeneratedMember(@event, MemberKind.EventHandlerAdder);
-        
+
         GeneratedMember? cSharpGeneratedRemoverMember = cSharpUnmanagedResult.GetGeneratedMember(@event, MemberKind.EventHandlerRemover);
         GeneratedMember? cGeneratedRemoverMember = cResult.GetGeneratedMember(@event, MemberKind.EventHandlerRemover);
 
@@ -32,7 +32,7 @@ public class SwiftEventSyntaxWriter: SwiftMethodSyntaxWriter, IEventSyntaxWriter
             cSharpGeneratedRemoverMember is null) {
             throw new Exception("No generated C# Unmanaged Member");
         }
-        
+
         if (cGeneratedAdderMember is null &&
             cGeneratedRemoverMember is null) {
             throw new Exception("No generated C Member");
@@ -40,9 +40,9 @@ public class SwiftEventSyntaxWriter: SwiftMethodSyntaxWriter, IEventSyntaxWriter
 
         bool adderMayThrow = cSharpGeneratedAdderMember?.MayThrow ?? true;
         bool removerMayThrow = cSharpGeneratedRemoverMember?.MayThrow ?? true;
-        
+
         string eventName = @event.Name;
-        
+
         Type declaringType = @event.DeclaringType ?? throw new Exception("No declaring type");;
 
         IEnumerable<ParameterInfo> parameters = Array.Empty<ParameterInfo>();
@@ -50,7 +50,7 @@ public class SwiftEventSyntaxWriter: SwiftMethodSyntaxWriter, IEventSyntaxWriter
         SwiftCodeBuilder sb = new();
 
         Type? eventHandlerType = @event.EventHandlerType;
-        
+
         if (eventHandlerType is null) {
             return $"// TODO: {eventName} - Event without Event Handler Type";
         }
@@ -62,7 +62,7 @@ public class SwiftEventSyntaxWriter: SwiftMethodSyntaxWriter, IEventSyntaxWriter
             cSharpGeneratedAdderMember is not null &&
             cGeneratedAdderMember is not null) {
             bool isStaticMethod = adderMethod.IsStatic;
-            
+
             string adderCode = WriteMethod(
                 cSharpGeneratedAdderMember,
                 cGeneratedAdderMember,
@@ -82,7 +82,7 @@ public class SwiftEventSyntaxWriter: SwiftMethodSyntaxWriter, IEventSyntaxWriter
             );
 
             sb.AppendLine(adderCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.EventHandlerAdder,
                 @event,
@@ -91,12 +91,12 @@ public class SwiftEventSyntaxWriter: SwiftMethodSyntaxWriter, IEventSyntaxWriter
                 CodeLanguage.Swift
             );
         }
-        
+
         if (removerMethod is not null &&
             cSharpGeneratedRemoverMember is not null &&
             cGeneratedRemoverMember is not null) {
             bool isStaticMethod = removerMethod.IsStatic;
-            
+
             string removerCode = WriteMethod(
                 cSharpGeneratedRemoverMember,
                 cGeneratedRemoverMember,
@@ -116,7 +116,7 @@ public class SwiftEventSyntaxWriter: SwiftMethodSyntaxWriter, IEventSyntaxWriter
             );
 
             sb.AppendLine(removerCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.EventHandlerRemover,
                 @event,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftFieldSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftFieldSyntaxWriter.cs
@@ -16,15 +16,15 @@ public class SwiftFieldSyntaxWriter: SwiftMethodSyntaxWriter, IFieldSyntaxWriter
     public string Write(FieldInfo field, State state, ISyntaxWriterConfiguration? configuration)
     {
         const bool addToState = false;
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
-        
+
         GeneratedMember? cSharpGeneratedGetterMember = cSharpUnmanagedResult.GetGeneratedMember(field, MemberKind.FieldGetter);
         GeneratedMember? cGeneratedGetterMember = cResult.GetGeneratedMember(field, MemberKind.FieldGetter);
-        
+
         GeneratedMember? cSharpGeneratedSetterMember = cSharpUnmanagedResult.GetGeneratedMember(field, MemberKind.FieldSetter);
         GeneratedMember? cGeneratedSetterMember = cResult.GetGeneratedMember(field, MemberKind.FieldSetter);
 
@@ -32,7 +32,7 @@ public class SwiftFieldSyntaxWriter: SwiftMethodSyntaxWriter, IFieldSyntaxWriter
             cSharpGeneratedSetterMember is null) {
             throw new Exception("No C# generated member");
         }
-        
+
         if (cGeneratedGetterMember is null &&
             cGeneratedSetterMember is null) {
             throw new Exception("No C generated member");
@@ -48,7 +48,7 @@ public class SwiftFieldSyntaxWriter: SwiftMethodSyntaxWriter, IFieldSyntaxWriter
         if (cSharpGeneratedGetterMember is not null &&
             cGeneratedGetterMember is not null) {
             bool mayThrow = cSharpGeneratedGetterMember.MayThrow;
-                
+
             string code = WriteMethod(
                 cSharpGeneratedGetterMember,
                 cGeneratedGetterMember,
@@ -68,7 +68,7 @@ public class SwiftFieldSyntaxWriter: SwiftMethodSyntaxWriter, IFieldSyntaxWriter
             );
 
             sb.AppendLine(code);
-            
+
             state.AddGeneratedMember(
                 MemberKind.FieldGetter,
                 field,
@@ -81,7 +81,7 @@ public class SwiftFieldSyntaxWriter: SwiftMethodSyntaxWriter, IFieldSyntaxWriter
         if (cSharpGeneratedSetterMember is not null &&
             cGeneratedSetterMember is not null) {
             bool mayThrow = cSharpGeneratedSetterMember.MayThrow;
-            
+
             string code = WriteMethod(
                 cSharpGeneratedSetterMember,
                 cGeneratedSetterMember,
@@ -101,7 +101,7 @@ public class SwiftFieldSyntaxWriter: SwiftMethodSyntaxWriter, IFieldSyntaxWriter
             );
 
             sb.AppendLine(code);
-            
+
             state.AddGeneratedMember(
                 MemberKind.FieldSetter,
                 field,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftMethodSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftMethodSyntaxWriter.cs
@@ -19,10 +19,10 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
     public string Write(MethodInfo method, State state, ISyntaxWriterConfiguration? configuration)
     {
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
-        
+
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedMember(method) ?? throw new Exception("No C# generated member");
         GeneratedMember cGeneratedMember = cResult.GetGeneratedMember(method) ?? throw new Exception("No C generated member");
 
@@ -84,19 +84,19 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
         #region TODO: Unsupported Stuff
         if (returnOrSetterOrEventHandlerType.IsByRef) {
             generatedName = string.Empty;
-            
+
             return $"// TODO: Method with by ref return or setter or event handler type ({cMember.GetGeneratedName(CodeLanguage.C)})";
         }
         #endregion TODO: Unsupported Stuff
 
         var interfaceGenerationPhase = (syntaxWriterConfiguration as SwiftSyntaxWriterConfiguration)?.InterfaceGenerationPhase ?? SwiftSyntaxWriterConfiguration.InterfaceGenerationPhases.NoInterface;
-        
+
         MethodBase? methodBase = memberInfo as MethodBase;
         MethodInfo? methodInfo = methodBase as MethodInfo;
 
         bool isGenericType = declaringType.IsGenericType ||
                              declaringType.IsGenericTypeDefinition;
-        
+
         Type[] genericTypeArguments = Array.Empty<Type>();
         int numberOfGenericTypeArguments = 0;
 
@@ -104,7 +104,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
             genericTypeArguments = declaringType.GetGenericArguments();
             numberOfGenericTypeArguments = genericTypeArguments.Length;
         }
-        
+
         bool isGeneric = false;
         Type[] genericMethodArguments = Array.Empty<Type>();
         int numberOfGenericMethodArguments = 0;
@@ -122,7 +122,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                 } catch {
                     genericMethodArguments = Array.Empty<Type>();
                 }
-                
+
                 numberOfGenericMethodArguments = genericMethodArguments.Length;
             }
         } else if (isGenericType &&
@@ -143,7 +143,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
         }
 
         List<Type> tempCombinedGenericArguments = new();
-        
+
         tempCombinedGenericArguments.AddRange(genericTypeArguments);
         tempCombinedGenericArguments.AddRange(genericMethodArguments);
 
@@ -160,15 +160,15 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
 
                     if (nonByRefParameterType.IsArray) {
                         generatedName = string.Empty;
-                        
+
                         return "// TODO: Generic Methods with out/in/ref parameters that are arrays are not supported";
                     }
                 }
             }
         }
-        
+
         string cMethodName = cSharpGeneratedMember.GetGeneratedName(CodeLanguage.CSharpUnmanaged) ?? throw new Exception("No native name");
-        
+
         // string methodNameSwift = state.UniqueGeneratedName(
         //     memberKind.SwiftName(memberInfo),
         //     CodeLanguage.Swift
@@ -190,7 +190,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                         treatAsOverridden = true;
                     } else {
                         generatedName = string.Empty;
-                        
+
                         return "// TODO: Overridden property or field with incompatible nullability";
                     }
                 } else { // Method
@@ -225,7 +225,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                 CodeLanguage.Swift
             );
         }
-        
+
         bool isGenericReturnType = returnOrSetterOrEventHandlerType.IsGenericParameter ||
                                    returnOrSetterOrEventHandlerType.IsGenericMethodParameter ||
                                    returnOrSetterOrEventHandlerType.IsGenericType ||
@@ -234,7 +234,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                                    returnOrSetterOrEventHandlerType.IsConstructedGenericType;
 
         bool isConstructedGenericReturnType = returnOrSetterOrEventHandlerType.IsConstructedGenericType;
-        
+
         bool isGenericArrayReturnType = false;
 
         if (!isGenericReturnType &&
@@ -267,13 +267,13 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
         if (returnOrSetterOrEventHandlerTypeIsByRef) {
             returnOrSetterOrEventHandlerType = returnOrSetterOrEventHandlerType.GetNonByRefType();
         }
-        
+
         TypeDescriptor returnOrSetterTypeDescriptor = returnOrSetterOrEventHandlerType.GetTypeDescriptor(typeDescriptorRegistry);
-        
+
         var nullabilityInfoContext = new NullabilityInfoContext();
         var returnOrSetterTypeNullability = Nullability.NotSpecified;
-        var returnOrSetterTypeArrayElementNullability = Nullability.NotSpecified; 
-        
+        var returnOrSetterTypeArrayElementNullability = Nullability.NotSpecified;
+
         if (memberKind == MemberKind.TypeOf) {
             returnOrSetterTypeNullability = Nullability.NonNullable;
         } else if (returnOrSetterOrEventHandlerType.IsNullableValueType(out _)) {
@@ -291,7 +291,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                 } else {
                     returnOrSetterValueParameter = methodInfo.ReturnParameter;
                 }
-                
+
                 var nullabilityInfo = nullabilityInfoContext.Create(returnOrSetterValueParameter);
 
                 if (memberKind == MemberKind.PropertyGetter) {
@@ -306,7 +306,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                     returnOrSetterTypeNullability = nullabilityInfo.WriteState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
-                    
+
                     returnOrSetterTypeArrayElementNullability = nullabilityInfo.ElementType?.WriteState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
@@ -343,7 +343,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                     returnOrSetterTypeNullability = nullabilityInfo.ReadState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
-                    
+
                     returnOrSetterTypeArrayElementNullability = nullabilityInfo.ElementType?.ReadState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
@@ -351,7 +351,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                     returnOrSetterTypeNullability = nullabilityInfo.WriteState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
-                    
+
                     returnOrSetterTypeArrayElementNullability = nullabilityInfo.ElementType?.WriteState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
@@ -361,7 +361,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                             ? Nullability.NonNullable
                             : Nullability.NotSpecified;
                     }
-                    
+
                     var elementTypeNullabilityInfo = nullabilityInfo.ElementType;
 
                     if (elementTypeNullabilityInfo is not null &&
@@ -373,7 +373,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                 }
             }
         }
-        
+
         // TODO: This generates inout TypeName if the return type is by ref
         string swiftReturnOrSetterTypeName = returnOrSetterTypeDescriptor.GetTypeName(
             CodeLanguage.Swift,
@@ -384,10 +384,10 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
             returnOrSetterOrEventHandlerTypeIsByRef,
             false
         );
-        
+
         string swiftReturnOrSetterTypeNameWithComment;
         Type? setterType;
-        
+
         if (memberKind == MemberKind.PropertySetter ||
             memberKind == MemberKind.FieldSetter ||
             memberKind == MemberKind.EventHandlerAdder ||
@@ -398,7 +398,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
             swiftReturnOrSetterTypeNameWithComment = $"{swiftReturnOrSetterTypeName} /* {returnOrSetterOrEventHandlerType.GetFullNameOrName()} */";
             setterType = null;
         }
-        
+
         generatedName = methodNameSwift;
         #endregion Preparation
 
@@ -414,7 +414,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
         } else {
             needImpl = true;
         }
-        
+
         if (!needImpl) {
             memberImpl = null;
         } else {
@@ -437,9 +437,9 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                 genericMethodArguments,
                 syntaxWriterConfiguration,
                 typeDescriptorRegistry
-            );   
+            );
         }
-        
+
         string methodSignatureParameters = WriteParameters(
             memberKind,
             setterType,
@@ -487,14 +487,14 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                 .ToString();
         } else if (memberKind == MemberKind.TypeOf) {
             bool isEnum = declaringType.IsEnum;
-            
+
             string propTypeName = !returnOrSetterOrEventHandlerType.IsVoid()
                 ? swiftReturnOrSetterTypeNameWithComment
                 : throw new Exception("A property must have a return type");
 
             declaration = Builder.GetOnlyProperty(methodNameSwift, propTypeName)
                 .Visibility(memberVisibility)
-                .TypeAttachmentKind(isEnum 
+                .TypeAttachmentKind(isEnum
                     ? SwiftTypeAttachmentKinds.Static
                     : SwiftTypeAttachmentKinds.Class)
                 .Override(!isEnum)
@@ -518,7 +518,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
         } else {
             declaration = Builder.Func(methodNameSwift)
                 .Visibility(memberVisibility)
-                .TypeAttachmentKind(isStaticMethod 
+                .TypeAttachmentKind(isStaticMethod
                     ? interfaceGenerationPhase == SwiftSyntaxWriterConfiguration.InterfaceGenerationPhases.Protocol || interfaceGenerationPhase == SwiftSyntaxWriterConfiguration.InterfaceGenerationPhases.ProtocolExtensionForDefaultImplementations ? SwiftTypeAttachmentKinds.Static : SwiftTypeAttachmentKinds.Class
                     : SwiftTypeAttachmentKinds.Instance)
                 .Override(treatAsOverridden)
@@ -533,7 +533,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
         #endregion Func Declaration
 
         XmlDocumentationMember? xmlDocumentationContent;
-        
+
         if (originatingMemberInfo is FieldInfo originatingFieldInfo) {
             xmlDocumentationContent = originatingFieldInfo.GetDocumentation();
         } else if (originatingMemberInfo is PropertyInfo originatingPropertyInfo) {
@@ -549,7 +549,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
         } else {
             xmlDocumentationContent = null;
         }
-        
+
         var declarationComment = xmlDocumentationContent
             ?.GetFormattedDocumentationComment();
 
@@ -565,7 +565,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
         } else {
             declarationWithComment = declaration;
         }
-        
+
         return declarationWithComment;
     }
 
@@ -580,7 +580,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
             !isGeneric &&
             !hasParameters;
     }
-    
+
     private static string WriteMethodImplementation(
         GeneratedMember cSharpGeneratedMember,
         GeneratedMember cMember,
@@ -608,13 +608,13 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
 
         if (memberKind == MemberKind.Destructor) {
             needsRegularImpl = false;
-            
+
             sbImpl.AppendLine($"{cMethodName}(self.__handle)");
         } else if (memberKind == MemberKind.TypeOf) {
             needsRegularImpl = false;
-            
+
             string returnTypeConversion = returnOrSetterTypeDescriptor.GetTypeConversion(
-                CodeLanguage.C, 
+                CodeLanguage.C,
                 CodeLanguage.Swift,
                 returnOrSetterOrEventHandlerArrayElementNullability
             ) ?? "{0}";
@@ -648,13 +648,13 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
 
             if (mayThrow) {
                 string cExceptionVarName = "__exceptionC";
-                
+
                 convertedParameterNames.Add($"&{cExceptionVarName}");
-                
+
                 sbImpl.AppendLine(Builder.Var(cExceptionVarName)
                     .TypeName("System_Exception_t?")
                     .ToString());
-                
+
                 sbImpl.AppendLine();
             }
 
@@ -666,7 +666,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                 !returnOrSetterTypeDescriptor.IsVoid;
 
             string returnValueName = "__returnValueC";
-            
+
             string returnValueCStorage = isReturning
                 ? $"let {returnValueName} = "
                 : string.Empty;
@@ -676,15 +676,15 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
             if (!isStaticMethod) {
                 allParameterNames.Add("self.__handle");
             }
-            
+
             allParameterNames.AddRange(convertedGenericTypeArgumentNames);
             allParameterNames.AddRange(convertedGenericMethodArgumentNames);
             allParameterNames.AddRange(convertedParameterNames);
-            
+
             string allParameterNamesString = string.Join(", ", allParameterNames);
-            
+
             string invocation = $"{returnValueCStorage}{cMethodName}({allParameterNamesString})";
-            
+
             sbImpl.AppendLine(invocation);
             sbImpl.AppendLine();
 
@@ -699,20 +699,20 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                         CodeLanguage.Swift,
                         returnOrSetterOrEventHandlerArrayElementNullability
                     );
-    
+
                     if (!string.IsNullOrEmpty(returnTypeConversion)) {
                         string newReturnValueName = "__returnValue";
 
                         string fullReturnTypeConversion = Builder.Let(newReturnValueName)
                             .Value(string.Format(returnTypeConversion, returnValueName))
                             .ToString();
-    
+
                         sbImpl.AppendLine(fullReturnTypeConversion);
                         sbImpl.AppendLine();
-                        
+
                         returnValueName = newReturnValueName;
                     }
-    
+
                     returnCode = $"return {returnValueName}";
                 }
             }
@@ -725,7 +725,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                 bool isOutParameter = parameter.IsOut;
                 bool isInParameter = parameter.IsIn;
                 bool isByRefParameter = parameterType.IsByRef;
-                
+
                 if (!isOutParameter &&
                     !isInParameter &&
                     !isByRefParameter) {
@@ -738,7 +738,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                     parameterType.IsGenericMethodParameter) {
                     parameterType = typeof(object);
                 }
-                
+
                 string parameterName = parameter.Name ?? throw new Exception("Parameter has no name");
                 string convertedParameterName = $"{parameterName}C";
 
@@ -777,7 +777,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
                 } else {
                     parameterTypeConversion = string.Format(parameterTypeConversion, convertedParameterName);
                 }
-                
+
                 sbByRefParameters.AppendLine($"{parameterName} = {parameterTypeConversion}");
                 sbByRefParameters.AppendLine();
             }
@@ -793,7 +793,7 @@ public class SwiftMethodSyntaxWriter: ISwiftSyntaxWriter, IMethodSyntaxWriter
 if let __exceptionC {
     let __exception = System_Exception(handle: __exceptionC)
     let __error = __exception.swiftError
-    
+
     throw __error
 }
 """);
@@ -828,25 +828,25 @@ if let __exceptionC {
         if (typeWhereExtensionIsDeclared is null) {
             return string.Empty;
         }
-        
+
         MemberKind memberKind = swiftGeneratedMember.MemberKind;
 
         TypeDescriptor typeDescriptorWhereExtensionIsDeclared = typeWhereExtensionIsDeclared.GetTypeDescriptor(typeDescriptorRegistry);
         string swiftTypeNameWhereExtensionIsDeclared = typeDescriptorWhereExtensionIsDeclared.GetTypeName(CodeLanguage.Swift, false);
-        
+
         string? generatedName = swiftGeneratedMember.GetGeneratedName(CodeLanguage.Swift);
 
         if (string.IsNullOrEmpty(generatedName)) {
             return string.Empty;
         }
-        
+
         // TODO: This is likely wrong
         bool isGeneric = false;
         IEnumerable<Type> genericParameters = Array.Empty<Type>();
-        
+
         List<ParameterInfo> parameters = methodBase.GetParameters().ToList();
         var extendedTypeParameter = parameters[0];
-        
+
         if (isExtendedTypeOptional) {
             if (!isGeneric &&
                 extendedTypeParameter.ParameterType.IsReferenceType()) {
@@ -862,7 +862,7 @@ if let __exceptionC {
                 }
             }
         }
-        
+
         parameters.RemoveAt(0);
 
         string parametersString = WriteParameters(
@@ -881,25 +881,25 @@ if let __exceptionC {
         );
 
         Type returnType = typeof(void);
-        
+
         MethodInfo? methodInfo = methodBase as MethodInfo;
 
         if (methodInfo is not null) {
             returnType = methodInfo.ReturnType;
         }
-        
+
         bool returnTypeIsByRef = returnType.IsByRef;
 
         if (returnTypeIsByRef) {
             returnType = returnType.GetNonByRefType();
         }
-        
+
         TypeDescriptor returnTypeDescriptor = returnType.GetTypeDescriptor(typeDescriptorRegistry);
-        
+
         var nullabilityInfoContext = new NullabilityInfoContext();
         var returnTypeNullability = Nullability.NotSpecified;
-        var returnTypeArrayElementNullability = Nullability.NotSpecified; 
-        
+        var returnTypeArrayElementNullability = Nullability.NotSpecified;
+
         if (returnType.IsNullableValueType(out _)) {
             returnTypeNullability = Nullability.Nullable;
         } else if (returnType.IsReferenceType() &&
@@ -915,7 +915,7 @@ if let __exceptionC {
                 } else {
                     returnOrSetterValueParameter = methodInfo.ReturnParameter;
                 }
-                
+
                 var nullabilityInfo = nullabilityInfoContext.Create(returnOrSetterValueParameter);
 
                 if (memberKind == MemberKind.PropertyGetter) {
@@ -930,7 +930,7 @@ if let __exceptionC {
                     returnTypeNullability = nullabilityInfo.WriteState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
-                    
+
                     returnTypeArrayElementNullability = nullabilityInfo.ElementType?.WriteState == NullabilityState.NotNull
                         ? Nullability.NonNullable
                         : Nullability.NotSpecified;
@@ -959,7 +959,7 @@ if let __exceptionC {
                 }
             }
         }
-        
+
         // TODO: This generates inout TypeName if the return type is by ref
         string swiftReturnTypeName = returnTypeDescriptor.GetTypeName(
             CodeLanguage.Swift,
@@ -977,7 +977,7 @@ if let __exceptionC {
         string toReturnOrNotToReturn = !returnType.IsVoid()
             ? "return "
             : string.Empty;
-        
+
         string toTryOrNotToTry = mayThrow
             ? "try "
             : string.Empty;
@@ -1012,7 +1012,7 @@ if let __exceptionC {
             string propTypeName = !returnType.IsVoid()
                 ? swiftReturnTypeName
                 : throw new Exception("A property must have a return type");
-            
+
             fullDecl = Builder.GetOnlyProperty(generatedName, propTypeName)
                 .Public()
                 .Throws(mayThrow)
@@ -1027,12 +1027,12 @@ if let __exceptionC {
                     ? swiftReturnTypeName
                     : null)
                 .Implementation(invocation)
-                .ToString();   
+                .ToString();
         }
 
         return fullDecl;
     }
-    
+
     internal static string WriteParameters(
         MemberKind memberKind,
         Type? setterOrEventHandlerType,
@@ -1049,52 +1049,52 @@ if let __exceptionC {
     )
     {
         var nullabilityContext = new NullabilityInfoContext();
-        
+
         List<string> parameterList = new();
 
         if (isGeneric) {
             Type typeOfSystemType = typeof(Type);
             TypeDescriptor systemTypeTypeDescriptor = typeOfSystemType.GetTypeDescriptor(typeDescriptorRegistry);
             string systemTypeTypeName = typeOfSystemType.GetFullNameOrName();
-            
+
             string nativeSystemTypeTypeName = systemTypeTypeDescriptor.GetTypeName(
-                CodeLanguage.Swift, 
+                CodeLanguage.Swift,
                 true,
                 Nullability.NonNullable
             );
-            
+
             foreach (var genericArgumentType in genericArguments) {
                 string parameterName = genericArgumentType.Name.EscapedSwiftName();
 
-                string parameterString = onlyWriteParameterNames 
-                    ? parameterName 
+                string parameterString = onlyWriteParameterNames
+                    ? parameterName
                     : $"{parameterName}: {nativeSystemTypeTypeName} /* {systemTypeTypeName} */";
-            
+
                 parameterList.Add(parameterString);
             }
         }
-        
+
         foreach (var parameter in parameters) {
             bool isOutParameter = parameter.IsOut;
             bool isInParameter = parameter.IsIn;
-            
+
             Type parameterType = parameter.ParameterType;
-            
+
             bool isByRefParameter = parameterType.IsByRef;
 
             if (isByRefParameter) {
                 parameterType = parameterType.GetNonByRefType();
             }
-            
+
             bool isGenericParameterType = parameterType.IsGenericParameter || parameterType.IsGenericMethodParameter;
-            
+
             if (isGenericParameterType) {
                 parameterType = typeof(object);
             }
-            
+
             bool isGenericArrayParameterType = false;
             Type? arrayType = parameterType.GetElementType();
-                    
+
             if (parameterType.IsArray &&
                 arrayType is not null &&
                 (arrayType.IsGenericParameter || arrayType.IsGenericMethodParameter)) {
@@ -1104,7 +1104,7 @@ if let __exceptionC {
             if (isGenericArrayParameterType) {
                 parameterType = typeof(Array);
             }
-            
+
             bool isNotNull = false;
             bool isArrayElementNotNull = false;
 
@@ -1125,7 +1125,7 @@ if let __exceptionC {
                     isArrayElementNotNull = parameterElementTypeNullability.ReadState == NullabilityState.NotNull;
                 }
             }
-            
+
             TypeDescriptor parameterTypeDescriptor = parameterType.GetTypeDescriptor(typeDescriptorRegistry);
 
             string unmanagedParameterTypeName = parameterTypeDescriptor.GetTypeName(
@@ -1146,7 +1146,7 @@ if let __exceptionC {
             }
 
             string parameterString;
-            
+
             if (onlyWriteParameterNames) {
                 if (writeModifiersForInvocation) {
                     parameterString = $"{(isByRefParameter || isOutParameter ? "&" : string.Empty)}{parameterName}";
@@ -1154,9 +1154,9 @@ if let __exceptionC {
                     parameterString = parameterName;
                 }
             } else {
-                parameterString = $"_ {parameterName}: {unmanagedParameterTypeName} /* {parameterType.GetFullNameOrName()} */";    
+                parameterString = $"_ {parameterName}: {unmanagedParameterTypeName} /* {parameterType.GetFullNameOrName()} */";
             }
-            
+
             parameterList.Add(parameterString);
         }
 
@@ -1167,9 +1167,9 @@ if let __exceptionC {
             if (setterOrEventHandlerType == null) {
                 throw new Exception("Setter or Event Handler Type may not be null");
             }
-            
+
             TypeDescriptor setterOrEventHandlerTypeDescriptor = setterOrEventHandlerType.GetTypeDescriptor(typeDescriptorRegistry);
-            
+
             string cSetterOrEventHandlerTypeName = setterOrEventHandlerTypeDescriptor.GetTypeName(
                 CodeLanguage.Swift,
                 true,
@@ -1182,7 +1182,7 @@ if let __exceptionC {
             string parameterString = onlyWriteParameterNames
                 ? parameterName
                 : $"_ {parameterName}: {cSetterOrEventHandlerTypeName} /* {setterOrEventHandlerType.GetFullNameOrName()} */";
-            
+
             parameterList.Add(parameterString);
         }
 
@@ -1190,7 +1190,7 @@ if let __exceptionC {
 
         return parametersString;
     }
-    
+
     internal static string WriteParameterConversions(
         CodeLanguage sourceLanguage,
         CodeLanguage targetLanguage,
@@ -1220,9 +1220,9 @@ if let __exceptionC {
         } else {
             throw new Exception("Unknown language pair");
         }
-        
+
         SwiftCodeBuilder sb = new();
-        
+
         convertedParameterNames = new();
         convertedGenericTypeArgumentNames = new();
         convertedGenericMethodArgumentNames = new();
@@ -1232,42 +1232,42 @@ if let __exceptionC {
             Type typeOfSystemType = typeof(Type);
             TypeDescriptor systemTypeTypeDescriptor = typeOfSystemType.GetTypeDescriptor(typeDescriptorRegistry);
             string systemTypeTypeName = typeOfSystemType.GetFullNameOrName();
-            
+
             string systemTypeTypeConversion = systemTypeTypeDescriptor.GetTypeConversion(
                 sourceLanguage,
                 targetLanguage,
                 Nullability.NotSpecified
             )!;
-    
+
             foreach (var genericArgumentType in genericTypeArguments) {
                 string name = genericArgumentType.Name;
-                
+
                 string convertedGenericArgumentName = $"{name}{convertedParameterNameSuffix}";
-                    
+
                 string fullTypeConversion = string.Format(systemTypeTypeConversion, name);
 
                 string typeConversionCode = Builder.Let(convertedGenericArgumentName)
                     .Value(fullTypeConversion)
                     .ToString();
-    
+
                 sb.AppendLine(typeConversionCode);
-                
+
                 convertedGenericTypeArgumentNames.Add(convertedGenericArgumentName);
             }
-            
+
             foreach (var genericArgumentType in genericMethodArguments) {
                 string name = genericArgumentType.Name;
-                
+
                 string convertedGenericArgumentName = $"{name}{convertedParameterNameSuffix}";
-                    
+
                 string fullTypeConversion = string.Format(systemTypeTypeConversion, name);
 
                 string typeConversionCode = Builder.Let(convertedGenericArgumentName)
                     .Value(fullTypeConversion)
                     .ToString();
-    
+
                 sb.AppendLine(typeConversionCode);
-                
+
                 convertedGenericMethodArgumentNames.Add(convertedGenericArgumentName);
             }
         }
@@ -1275,15 +1275,15 @@ if let __exceptionC {
         foreach (var parameter in parameters) {
             string? parameterName = parameter.Name
                 ?.EscapedSwiftName();
-            
+
             if (parameterName is null) {
                 throw new Exception("Parameter without a name");
             }
-            
+
             Type parameterType = parameter.ParameterType;
             bool isOutParameter = parameter.IsOut;
             bool isInParameter = parameter.IsIn;
-            
+
             WriteParameterConversion(
                 sourceLanguage,
                 targetLanguage,
@@ -1303,7 +1303,7 @@ if let __exceptionC {
             if (!string.IsNullOrEmpty(typeConversionCode)) {
                 sb.AppendLine(typeConversionCode);
             }
-            
+
             convertedParameterNames.Add(convertedParameterName);
 
             if (!string.IsNullOrEmpty(typeBackConversionCode)) {
@@ -1319,7 +1319,7 @@ if let __exceptionC {
             Type parameterType = setterOrEventHandlerType ?? throw new Exception("No setter or event handler type");
             const bool isOutParameter = false;
             const bool isInParameter = false;
-            
+
             WriteParameterConversion(
                 sourceLanguage,
                 targetLanguage,
@@ -1339,9 +1339,9 @@ if let __exceptionC {
             if (!string.IsNullOrEmpty(typeConversionCode)) {
                 sb.AppendLine(typeConversionCode);
             }
-            
+
             convertedParameterNames.Add(convertedParameterName);
-            
+
             if (!string.IsNullOrEmpty(typeBackConversionCode)) {
                 parameterTypeBackConversionCodes.Add(typeBackConversionCode);
             }
@@ -1367,11 +1367,11 @@ if let __exceptionC {
     )
     {
         if (string.IsNullOrEmpty(parameterName)) {
-            throw new Exception("Parameter has no name");   
+            throw new Exception("Parameter has no name");
         }
-        
+
         var nullabilityContext = new NullabilityInfoContext();
-        
+
         string convertedParameterNameSuffix;
 
         if (sourceLanguage == CodeLanguage.Swift &&
@@ -1383,7 +1383,7 @@ if let __exceptionC {
         } else {
             throw new Exception("Unknown language pair");
         }
-        
+
         bool isByRefParameter = parameterType.IsByRef;
         bool isArrayType = parameterType.IsArray;
         bool isInOut = isOutParameter || isInParameter || isByRefParameter;
@@ -1391,7 +1391,7 @@ if let __exceptionC {
         if (isByRefParameter) {
             parameterType = parameterType.GetNonByRefType();
         }
-        
+
         bool isGenericParameterType = parameterType.IsGenericParameter || parameterType.IsGenericMethodParameter;
 
         if (!isByRefParameter &&
@@ -1409,11 +1409,11 @@ if let __exceptionC {
                 }
             }
         }
-        
+
         TypeDescriptor parameterTypeDescriptor = parameterType.GetTypeDescriptor(typeDescriptorRegistry);
 
         Nullability parameterArrayElementNullability;
-        
+
         if (parameterInfo is not null) {
             var nullabilityInfoContext = new NullabilityInfoContext();
             var parameterNullabilityA = nullabilityInfoContext.Create(parameterInfo);
@@ -1436,19 +1436,19 @@ if let __exceptionC {
             targetLanguage,
             parameterArrayElementNullability
         );
-        
+
         if (typeConversion != null) {
             string parameterNameForConversion = parameterName;
-            
+
             if (parameterName.StartsWith("`") &&
                 parameterName.EndsWith("`")) {
                 parameterNameForConversion = parameterName.Trim('`');
             }
-            
+
             convertedParameterName = $"{parameterNameForConversion}{convertedParameterNameSuffix}";
 
             string optionalString;
-            
+
             if (sourceLanguage == CodeLanguage.Swift &&
                 targetLanguage == CodeLanguage.C) {
                 if (parameterInfo is not null &&
@@ -1456,22 +1456,22 @@ if let __exceptionC {
                     !isGenericParameterType &&
                     parameterType.IsReferenceType()) {
                     bool isNotNull = false;
-                    
+
                     var parameterNullabilityInfo = nullabilityContext.Create(parameterInfo);
 
                     if (parameterNullabilityInfo.ReadState == parameterNullabilityInfo.WriteState) {
                         isNotNull = parameterNullabilityInfo.ReadState == NullabilityState.NotNull;
                     }
-                    
+
                     parameterNullability = isNotNull
                         ? Nullability.NonNullable
-                        : parameterTypeDescriptor.Nullability;   
+                        : parameterTypeDescriptor.Nullability;
                 }
 
                 if (parameterNullability == Nullability.NotSpecified) {
                     parameterNullability = parameterTypeDescriptor.Nullability;
                 }
-                
+
                 optionalString = parameterNullability.GetSwiftOptionalitySpecifier();
             } else {
                 optionalString = string.Empty;
@@ -1486,7 +1486,7 @@ if let __exceptionC {
             typeConversionCode = Builder.Variable(variableKind, convertedParameterName)
                 .Value(fullTypeConversion)
                 .ToString();
-            
+
             if (isInOut) {
                 convertedParameterName = $"&{convertedParameterName}";
             }
@@ -1497,15 +1497,15 @@ if let __exceptionC {
                 targetLanguage == CodeLanguage.Swift &&
                 isInOut) {
                 string swiftParameterName = $"__{parameterName}Swift";
-                
+
                 typeConversionCode = $"var {swiftParameterName} = {parameterName}?.pointee ?? .init()";
                 typeBackConversionCode = $"{parameterName}?.pointee = {swiftParameterName}";
-                
+
                 convertedParameterName = $"&{swiftParameterName}";
             } else {
                 typeConversionCode = null;
                 typeBackConversionCode = null;
-                
+
                 if (isInOut) {
                     convertedParameterName = $"&{parameterName}";
                 } else {

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftPropertySyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftPropertySyntaxWriter.cs
@@ -12,19 +12,19 @@ public class SwiftPropertySyntaxWriter: SwiftMethodSyntaxWriter, IPropertySyntax
     {
         return Write((PropertyInfo)@object, state, configuration);
     }
-    
+
     public string Write(PropertyInfo property, State state, ISyntaxWriterConfiguration? configuration)
     {
         const bool addToState = false;
-        
+
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
 
         GeneratedMember? cSharpGeneratedMemberGetter = cSharpUnmanagedResult.GetGeneratedMember(property, MemberKind.PropertyGetter);
         GeneratedMember? cGeneratedMemberGetter = cResult.GetGeneratedMember(property, MemberKind.PropertyGetter);
-        
+
         GeneratedMember? cSharpGeneratedMemberSetter = cSharpUnmanagedResult.GetGeneratedMember(property, MemberKind.PropertySetter);
         GeneratedMember? cGeneratedMemberSetter = cResult.GetGeneratedMember(property, MemberKind.PropertySetter);
 
@@ -32,15 +32,15 @@ public class SwiftPropertySyntaxWriter: SwiftMethodSyntaxWriter, IPropertySyntax
             cSharpGeneratedMemberSetter is null) {
             throw new Exception("No generated C# Unmanaged Member");
         }
-        
+
         if (cGeneratedMemberGetter is null &&
             cGeneratedMemberSetter is null) {
             throw new Exception("No generated C Member");
         }
 
         bool getterMayThrow = cSharpGeneratedMemberGetter?.MayThrow ?? true;
-        bool setterMayThrow = cSharpGeneratedMemberSetter?.MayThrow ?? true; 
-        
+        bool setterMayThrow = cSharpGeneratedMemberSetter?.MayThrow ?? true;
+
         Type declaringType = property.DeclaringType ?? throw new Exception("No declaring type");
 
         IEnumerable<ParameterInfo> parameters = property.GetIndexParameters();
@@ -56,7 +56,7 @@ public class SwiftPropertySyntaxWriter: SwiftMethodSyntaxWriter, IPropertySyntax
             cSharpGeneratedMemberGetter is not null &&
             cGeneratedMemberGetter is not null) {
             bool isStaticMethod = getterMethod.IsStatic;
-            
+
             string getterCode = WriteMethod(
                 cSharpGeneratedMemberGetter,
                 cGeneratedMemberGetter,
@@ -76,7 +76,7 @@ public class SwiftPropertySyntaxWriter: SwiftMethodSyntaxWriter, IPropertySyntax
             );
 
             sb.AppendLine(getterCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.PropertyGetter,
                 property,
@@ -85,12 +85,12 @@ public class SwiftPropertySyntaxWriter: SwiftMethodSyntaxWriter, IPropertySyntax
                 CodeLanguage.Swift
             );
         }
-        
+
         if (setterMethod is not null &&
             cSharpGeneratedMemberSetter is not null &&
             cGeneratedMemberSetter is not null) {
             bool isStaticMethod = setterMethod.IsStatic;
-            
+
             string setterCode = WriteMethod(
                 cSharpGeneratedMemberSetter,
                 cGeneratedMemberSetter,
@@ -110,7 +110,7 @@ public class SwiftPropertySyntaxWriter: SwiftMethodSyntaxWriter, IPropertySyntax
             );
 
             sb.AppendLine(setterCode);
-            
+
             state.AddGeneratedMember(
                 MemberKind.PropertySetter,
                 property,

--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftTypeOfSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Swift/SwiftTypeOfSyntaxWriter.cs
@@ -20,10 +20,10 @@ public class SwiftTypeOfSyntaxWriter: SwiftMethodSyntaxWriter, ITypeOfSyntaxWrit
         }
 
         TypeDescriptorRegistry typeDescriptorRegistry = TypeDescriptorRegistry.Shared;
-        
+
         Result cSharpUnmanagedResult = state.CSharpUnmanagedResult ?? throw new Exception("No CSharpUnmanagedResult provided");
         Result cResult = state.CResult ?? throw new Exception("No CResult provided");
-        
+
         GeneratedMember cSharpGeneratedMember = cSharpUnmanagedResult.GetGeneratedTypeOf(type) ?? throw new Exception("No C# generated typeOf");
         GeneratedMember cGeneratedMember = cResult.GetGeneratedTypeOf(type) ?? throw new Exception("No C generated typeOf");
 

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/BoolTypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/BoolTypeDescriptor.cs
@@ -16,16 +16,16 @@ public partial class BuiltInTypeDescriptors
                     { CodeLanguage.Kotlin, "Boolean" }
                 },
                 new() {
-                    { 
-                        new(CodeLanguage.CSharp, CodeLanguage.CSharpUnmanaged), 
+                    {
+                        new(CodeLanguage.CSharp, CodeLanguage.CSharpUnmanaged),
                         "{0}.ToCBool()"
                     }, {
-                        new(CodeLanguage.CSharpUnmanaged, CodeLanguage.CSharp), 
+                        new(CodeLanguage.CSharpUnmanaged, CodeLanguage.CSharp),
                         "{0}.ToBool()"
                     }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/CharTypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/CharTypeDescriptor.cs
@@ -20,7 +20,7 @@ public partial class BuiltInTypeDescriptors
                     { new LanguagePair(CodeLanguage.Swift, CodeLanguage.C), "{0}.cValue" }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/DoubleTypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/DoubleTypeDescriptor.cs
@@ -16,7 +16,7 @@ public partial class BuiltInTypeDescriptors
                     { CodeLanguage.KotlinJNA, "Double" }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/FloatTypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/FloatTypeDescriptor.cs
@@ -16,7 +16,7 @@ public partial class BuiltInTypeDescriptors
                     { CodeLanguage.KotlinJNA, "Float" }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/Int16TypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/Int16TypeDescriptor.cs
@@ -16,7 +16,7 @@ public partial class BuiltInTypeDescriptors
                     { CodeLanguage.KotlinJNA, "Short" }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/Int32TypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/Int32TypeDescriptor.cs
@@ -16,7 +16,7 @@ public partial class BuiltInTypeDescriptors
                     { CodeLanguage.KotlinJNA, "Int" }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/Int64TypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/Int64TypeDescriptor.cs
@@ -16,7 +16,7 @@ public partial class BuiltInTypeDescriptors
                     { CodeLanguage.KotlinJNA, "Long" }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/Int8TypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/Int8TypeDescriptor.cs
@@ -16,7 +16,7 @@ public partial class BuiltInTypeDescriptors
                     { CodeLanguage.KotlinJNA, "Byte" }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/IntPtrTypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/IntPtrTypeDescriptor.cs
@@ -16,7 +16,7 @@ public partial class BuiltInTypeDescriptors
                     { CodeLanguage.KotlinJNA, "Pointer" }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/ReadOnlySpanOfByteTypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/ReadOnlySpanOfByteTypeDescriptor.cs
@@ -33,7 +33,7 @@ public partial class BuiltInTypeDescriptors
                     }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/UInt16TypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/UInt16TypeDescriptor.cs
@@ -26,7 +26,7 @@ public partial class BuiltInTypeDescriptors
                     }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/UInt32TypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/UInt32TypeDescriptor.cs
@@ -26,7 +26,7 @@ public partial class BuiltInTypeDescriptors
                     }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/UInt64TypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/UInt64TypeDescriptor.cs
@@ -27,7 +27,7 @@ public partial class BuiltInTypeDescriptors
                     }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/UInt8TypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/UInt8TypeDescriptor.cs
@@ -27,7 +27,7 @@ public partial class BuiltInTypeDescriptors
                     }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/UIntPtrTypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/UIntPtrTypeDescriptor.cs
@@ -26,7 +26,7 @@ public partial class BuiltInTypeDescriptors
                     }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/VoidTypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/BuiltIn/VoidTypeDescriptor.cs
@@ -16,7 +16,7 @@ public partial class BuiltInTypeDescriptors
                     { CodeLanguage.KotlinJNA, "void" }
                 }
             );
-        
+
             return descriptor;
         }
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/LanguagePair.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/LanguagePair.cs
@@ -10,7 +10,7 @@ public record struct LanguagePair
         if (sourceLanguage == targetLanguage) {
             throw new Exception("Source Language is same as Target Language");
         }
-        
+
         SourceLanguage = sourceLanguage;
         TargetLanguage = targetLanguage;
     }

--- a/Generator/Beyond.NET.CodeGenerator/Types/TypeDescriptor.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/TypeDescriptor.cs
@@ -14,7 +14,7 @@ public static class Nullability_Extensions
 {
     public const string ClangAttributeNullable = "_Nullable";
     public const string ClangAttributeNonNull = "_Nonnull";
-    
+
     public static string GetClangAttribute(this Nullability nullability)
     {
         switch (nullability) {
@@ -23,27 +23,27 @@ public static class Nullability_Extensions
             case Nullability.NonNullable:
                 return ClangAttributeNonNull;
             default:
-                return string.Empty; 
+                return string.Empty;
         }
     }
-    
+
     public static string GetSwiftOptionalitySpecifier(this Nullability nullability)
     {
         switch (nullability) {
             case Nullability.Nullable:
                 return "?";
             default:
-                return string.Empty; 
+                return string.Empty;
         }
     }
-    
+
     public static string GetKotlinOptionalitySpecifier(this Nullability nullability)
     {
         switch (nullability) {
             case Nullability.Nullable:
                 return "?";
             default:
-                return string.Empty; 
+                return string.Empty;
         }
     }
 }
@@ -52,7 +52,7 @@ public class TypeDescriptor
 {
     public static string SwiftDotNETInterfaceImplementationSuffix = "_DNInterface";
     public static string KotlinDotNETInterfaceImplementationSuffix = "_DNInterface";
-    
+
     public Type ManagedType { get; }
 
     public bool IsPrimitive => ManagedType.IsPrimitive;
@@ -68,7 +68,7 @@ public class TypeDescriptor
     public bool IsManagedPointer => ManagedType.IsPointer;
     public bool RequiresNativePointer => !IsVoid && !IsEnum && !IsPrimitive && !IsBool && !IsReadOnlyStructOfByte;
     public bool IsReadOnlyStructOfByte => ManagedType.IsReadOnlySpanOfByte();
-    
+
     public bool IsNullableValueType([NotNullWhen(true)] out Type? valueType)
     {
         return ManagedType.IsNullableValueType(out valueType);
@@ -104,14 +104,14 @@ public class TypeDescriptor
         ManagedType = managedType;
 
         m_defaultValue = defaultValue;
-        
+
         if (typeNames == null) {
             typeNames = new();
         }
 
         if (!typeNames.ContainsKey(CodeLanguage.CSharp)) {
             string csharpTypeName = managedType.GetFullNameOrName();
-            
+
             typeNames[CodeLanguage.CSharp] = csharpTypeName;
         }
 
@@ -120,7 +120,7 @@ public class TypeDescriptor
         if (typeConversions == null) {
             typeConversions = new();
         }
-        
+
         m_typeConversions = typeConversions;
 
         if (destructors == null) {
@@ -152,7 +152,7 @@ public class TypeDescriptor
 
         bool isAllowedToCache = !((isSwift || isKotlin) &&
                                   IsArray);
-        
+
         // Cannot cache array types because of element nullability
         if (isAllowedToCache &&
             m_typeNames.TryGetValue(language, out string? tempTypeName)) {
@@ -194,7 +194,7 @@ public class TypeDescriptor
         if (nullability == Nullability.NotSpecified) {
             nullability = Nullability;
         }
-        
+
         if (!RequiresNativePointer &&
             !isOutParameter &&
             !isByRefParameter &&
@@ -275,11 +275,11 @@ public class TypeDescriptor
                     var nonByRefTypeDescriptor = ManagedType.GetNonByRefType().GetTypeDescriptor();
 
                     if (nonByRefTypeDescriptor.IsPrimitive) {
-                        nonByRefTypeName = nonByRefTypeDescriptor.GetTypeName(CodeLanguage.Kotlin, false);                        
+                        nonByRefTypeName = nonByRefTypeDescriptor.GetTypeName(CodeLanguage.Kotlin, false);
                     } else {
                         nonByRefTypeName = typeName;
                     }
-                    
+
                     typeNameWithModifiers = $"{nonByRefTypeName}ByReference";
                 } else {
                     typeNameWithModifiers = $"{typeName}";
@@ -302,7 +302,7 @@ public class TypeDescriptor
             case CodeLanguage.Kotlin:
             {
                 string kotlinNullabilitySpecifier = nullability.GetKotlinOptionalitySpecifier();
-                
+
                 if (isOutParameter || isByRefParameter || isInParameter) {
                     var kotlinTypeName = GetTypeName(CodeLanguage.Kotlin, false);
                     string refTypeName;
@@ -346,10 +346,10 @@ public class TypeDescriptor
             case CodeLanguage.C:
                 string cTypeName = ManagedType.CTypeName();
                 string constructedCTypeName;
-                
+
                 if (IsReferenceType ||
                     IsStruct) {
-                    constructedCTypeName = $"{cTypeName}_t";    
+                    constructedCTypeName = $"{cTypeName}_t";
                 } else if (IsEnum) {
                     constructedCTypeName = $"{cTypeName}_t";
                 } else {
@@ -432,7 +432,7 @@ public class TypeDescriptor
                 Type? elementType = isArray
                     ? ManagedType.GetElementType()
                     : null;
-                
+
                 string kotlinTypeName;
 
                 if (isArray &&
@@ -461,7 +461,7 @@ public class TypeDescriptor
                         // Multidimensional array
                         // TODO: Support multi-dimensional arrays
                         return ManagedType.CTypeName();
-                        
+
                         // arrayTypeName = arrayElementNullability == Nullability.NonNullable
                         //     ? "DNMultidimensionalArray"
                         //     : "DNNullableMultidimensionalArray";
@@ -492,10 +492,10 @@ public class TypeDescriptor
     )
     {
         LanguagePair languagePair = new(sourceLanguage, targetLanguage);
-        
+
         bool isSwift = sourceLanguage == CodeLanguage.Swift || targetLanguage == CodeLanguage.Swift;
         bool isKotlin = sourceLanguage == CodeLanguage.Kotlin || targetLanguage == CodeLanguage.Kotlin;
-        
+
         bool isAllowedToCache = !((isSwift || isKotlin) &&
                                   IsArray);
 
@@ -525,7 +525,7 @@ public class TypeDescriptor
 
         return typeConversion;
     }
-    
+
     private string? GenerateTypeConversion(
         CodeLanguage sourceLanguage,
         CodeLanguage targetLanguage,
@@ -539,7 +539,7 @@ public class TypeDescriptor
             if (!RequiresNativePointer) {
                 return null;
             }
-            
+
             string conversion;
 
             if (type.IsDelegate()) {
@@ -558,12 +558,12 @@ public class TypeDescriptor
             if (!RequiresNativePointer) {
                 return null;
             }
-            
+
             string conversion;
 
             if (type.IsDelegate()) {
                 string cTypeName = type.CTypeName();
-                
+
                 conversion = $"new {cTypeName}({{0}}).AllocateGCHandleAndGetAddress()";
             } else {
                 if (IsNullableValueType(out Type? valueType)) {
@@ -586,10 +586,10 @@ public class TypeDescriptor
             if (IsEnum) {
                 return $"{swiftTypeName}(cValue: {{0}})";
             } else if (RequiresNativePointer) {
-                var suffix = IsInterface 
+                var suffix = IsInterface
                     ? SwiftDotNETInterfaceImplementationSuffix
                     : string.Empty;
-                
+
                 return $"{swiftTypeName}{suffix}(handle: {{0}})";
             } else {
                 return null;
@@ -615,10 +615,10 @@ public class TypeDescriptor
             if (IsEnum) {
                 return $"{kotlinTypeName}({{0}})";
             } else if (RequiresNativePointer) {
-                var suffix = IsInterface 
+                var suffix = IsInterface
                     ? KotlinDotNETInterfaceImplementationSuffix
                     : string.Empty;
-                
+
                 return $"{kotlinTypeName}{suffix}({{0}})";
             } else {
                 return null;
@@ -631,7 +631,7 @@ public class TypeDescriptor
                 Nullability.NotSpecified,
                 arrayElementNullability
             );
-            
+
             bool isArray = ManagedType.IsArray;
 
             Type? elementType = isArray
@@ -639,7 +639,7 @@ public class TypeDescriptor
                 : null;
 
             int arrayRank = isArray
-                ? ManagedType.GetArrayRank() 
+                ? ManagedType.GetArrayRank()
                 : 0;
 
             if (IsEnum) {
@@ -650,13 +650,13 @@ public class TypeDescriptor
                 // TODO: Support multi-dimensional arrays
                 // TODO: Shouldn't this go through TypeDescriptor?
                 var kotlinElementTypeName = elementType.CTypeName();
-                
+
                 return $"{kotlinTypeName}({{0}}, {kotlinElementTypeName}::class.java)";
             } else if (RequiresNativePointer) {
-                var suffix = IsInterface 
+                var suffix = IsInterface
                     ? KotlinDotNETInterfaceImplementationSuffix
                     : string.Empty;
-                
+
                 return $"{kotlinTypeName}{suffix}({{0}})";
             } else {
                 return null;
@@ -678,7 +678,7 @@ public class TypeDescriptor
     public string? GetDestructor(CodeLanguage language)
     {
         string? destructor;
-        
+
         if (m_destructors.TryGetValue(language, out string? tempDestructor)) {
             destructor = tempDestructor;
         } else {

--- a/Generator/Beyond.NET.CodeGenerator/Types/TypeDescriptorRegistry.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Types/TypeDescriptorRegistry.cs
@@ -3,7 +3,7 @@ namespace Beyond.NET.CodeGenerator.Types;
 public class TypeDescriptorRegistry
 {
     public static TypeDescriptorRegistry Shared { get; } = new();
-    
+
     private TypeDescriptorRegistry()
     {
         var builtInDescriptors = GetBuiltInTypeDescriptors();
@@ -27,7 +27,7 @@ public class TypeDescriptorRegistry
         if (typeDescriptor == null) {
             // TODO
             typeDescriptor = new(managedType);
-            
+
             Descriptors[managedType] = typeDescriptor;
         }
 
@@ -47,12 +47,12 @@ public class TypeDescriptorRegistry
     {
         HashSet<TypeDescriptor> descriptors = new() {
             BuiltIn.BuiltInTypeDescriptors.VoidTypeDescriptor,
-            
+
             BuiltIn.BuiltInTypeDescriptors.BoolTypeDescriptor,
             BuiltIn.BuiltInTypeDescriptors.CharTypeDescriptor,
             BuiltIn.BuiltInTypeDescriptors.NintTypeDescriptor,
             BuiltIn.BuiltInTypeDescriptors.NuintTypeDescriptor,
-            
+
             BuiltIn.BuiltInTypeDescriptors.Int8TypeDescriptor,
             BuiltIn.BuiltInTypeDescriptors.UInt8TypeDescriptor,
             BuiltIn.BuiltInTypeDescriptors.Int16TypeDescriptor,
@@ -61,12 +61,12 @@ public class TypeDescriptorRegistry
             BuiltIn.BuiltInTypeDescriptors.UInt32TypeDescriptor,
             BuiltIn.BuiltInTypeDescriptors.Int64TypeDescriptor,
             BuiltIn.BuiltInTypeDescriptors.UInt64TypeDescriptor,
-            
+
             BuiltIn.BuiltInTypeDescriptors.FloatTypeDescriptor,
             BuiltIn.BuiltInTypeDescriptors.DoubleTypeDescriptor,
-            
+
             BuiltIn.BuiltInTypeDescriptors.ReadOnlySpanOfByteTypeDescriptor,
-            
+
             // BuiltIn.BuiltInTypeDescriptors.StringTypeDescriptor
         };
 

--- a/README.md
+++ b/README.md
@@ -147,21 +147,21 @@ struct ContentView: View {
             Text("\(greeting(for: "You"))")
         }
     }
-    
+
     func greeting(for name: String) -> String {
         do {
             // Convert the Swift String into a .NET System.String
             let nameDN = name.dotNETString()
-            
+
             // Create an instance of the .NET class "Hello"
             let hello = try BeyondDemo.Hello(nameDN)
-            
+
             // Get a .NET System.String containing the greeting
             let theGreetingDN = try hello.getGreeting()
-            
+
             // Convert the .NET System.String to a Swift String
             let theGreeting = theGreetingDN.string()
-            
+
             // Return the greeting
             return theGreeting
         } catch {

--- a/Samples/Beyond.NET.Sample.Android/test-on-emulator.ps1
+++ b/Samples/Beyond.NET.Sample.Android/test-on-emulator.ps1
@@ -18,7 +18,7 @@ $avd = $env:ANDROID_AVD
 if (-not "$avd") {
     $avd = 'Pixel_Fold_API_35'
     Write-Warning "ANDROID_AVD environment variable not set, falling back to '${avd}'"
-}  
+}
 
 $port = 5566 # [System.Random]::Shared.Next(5555, 5587)
 Write-Host "Using ${emulator} with ${avd}"
@@ -37,12 +37,12 @@ try {
 
     for ($try = 1; $try -le 20; $try++) {
         Write-Host "Checking emulator boot status (attempt #${try})"
-    
+
         $status = & {
             $PSNativeCommandUseErrorActionPreference = $false
             & $adb -s "emulator-${port}" shell getprop sys.boot_completed
         }
-        
+
         $status = "$status".Trim()
         Write-Host "Emulator status: ${status}"
 
@@ -76,7 +76,7 @@ catch {
     # if there was a failure, it's possible that the `emulator` running in the background
     # encountered an issue -- print its output before terminating
     Receive-Job $job -Keep
-    
+
     throw "See emulator output above"
 }
 finally {

--- a/Samples/Beyond.NET.Sample.C/transform.c
+++ b/Samples/Beyond.NET.Sample.C/transform.c
@@ -61,7 +61,7 @@ System_String_t transformer_transform(
 	int shouldUppercase = transformer->uppercase;
 
 	System_String_t transformedSystemString;
-	
+
 	if (shouldUppercase) { // Uppercase
 		// Call the .NET System.String.ToUpper method
 		transformedSystemString = System_String_ToUpper(

--- a/Samples/Beyond.NET.Sample.Managed/Beyond.NET.Sample.Managed.csproj
+++ b/Samples/Beyond.NET.Sample.Managed/Beyond.NET.Sample.Managed.csproj
@@ -10,7 +10,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
     <!-- Disable no XML comment warnings -->
-    <NoWarn>CS1591</NoWarn> 
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/Samples/Beyond.NET.Sample.Managed/Source/Address.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/Address.cs
@@ -16,7 +16,7 @@ public class Address
     /// The Street of the Address.
     /// </summary>
     public string Street { get; }
-    
+
     /// <summary>
     /// The City of the Address.
     /// </summary>

--- a/Samples/Beyond.NET.Sample.Managed/Source/Animals/AnimalFactory.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/Animals/AnimalFactory.cs
@@ -14,7 +14,7 @@ public static class AnimalFactory
 
         return null;
     };
-    
+
     public static IAnimal? CreateAnimal(string animalName)
     {
         return CreateAnimal(
@@ -22,7 +22,7 @@ public static class AnimalFactory
             DEFAULT_CREATOR
         );
     }
-    
+
     public static IAnimal? CreateAnimal(
         string animalName,
         AnimalCreatorDelegate creator

--- a/Samples/Beyond.NET.Sample.Managed/Source/Animals/Dog.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/Animals/Dog.cs
@@ -4,8 +4,8 @@ public class Dog: BaseAnimal
 {
     public const string StaticName = "Dog";
     public const string DogName = StaticName;
-    
+
     public override string Name => DogName;
-    
+
     internal Dog() { }
 }

--- a/Samples/Beyond.NET.Sample.Managed/Source/Animals/Labrador.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/Animals/Labrador.cs
@@ -4,8 +4,8 @@ public class Labrador: Dog
 {
     public new const string StaticName = "Labrador";
     public const string LabradorName = StaticName;
-    
+
     public override string Name => LabradorName;
-    
+
     public Labrador() { }
 }

--- a/Samples/Beyond.NET.Sample.Managed/Source/ArrayTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/ArrayTests.cs
@@ -8,15 +8,15 @@ public class ArrayTests
         { true, false }
     };
 
-    public bool[,] TwoDimensionalArrayOfBoolAsReturn() 
+    public bool[,] TwoDimensionalArrayOfBoolAsReturn()
         => TwoDimensionalArrayOfBool;
-    
+
     public void SetTwoDimensionalArrayOfBoolWithParameter(bool[,] twoDimensionalArrayOfBool)
         => TwoDimensionalArrayOfBool = twoDimensionalArrayOfBool;
-    
+
     public void TwoDimensionalArrayOfBoolAsOut(out bool[,] twoDimensionalArrayOfBool)
         => twoDimensionalArrayOfBool = TwoDimensionalArrayOfBool;
-    
+
     public void TwoDimensionalArrayOfBoolAsRef(ref bool[,] twoDimensionalArrayOfBool)
         => twoDimensionalArrayOfBool = TwoDimensionalArrayOfBool;
     #endregion TwoDimensionalArrayOfBool
@@ -32,16 +32,16 @@ public class ArrayTests
     public string?[] ArrayOfNullableString { get; set; } = {
         null, "a", "b", "c"
     };
-    
-    public string?[] ArrayOfNullableStringAsReturn() 
+
+    public string?[] ArrayOfNullableStringAsReturn()
         => ArrayOfNullableString;
-    
+
     public void SetArrayOfNullableStringWithParameter(string?[] arrayOfNullableString)
         => ArrayOfNullableString = arrayOfNullableString;
-    
+
     public void ArrayOfNullableStringAsOut(out string?[] arrayOfNullableString)
         => arrayOfNullableString = ArrayOfNullableString;
-    
+
     public void ArrayOfNullableStringAsRef(ref string?[] arrayOfNullableString)
         => arrayOfNullableString = ArrayOfNullableString;
     #endregion ArrayOfNullableString
@@ -76,7 +76,7 @@ public class ArrayTests
     public byte[] ArrayOfBytes { get; set; } = [
         byte.MinValue, 1, 2, byte.MaxValue
     ];
-    
+
     public sbyte[] ArrayOfSBytes { get; set; } = [
         SByte.MinValue, 1, 2, sbyte.MaxValue
     ];
@@ -87,7 +87,7 @@ public class ArrayTests
         new Cat(), new Dog()
     ];
     #endregion ArrayOfInterfaces
-    
+
     #region ArrayOfInterfaces
     public IAnimal?[] ArrayOfNullableInterfaces { get; set; } = [
         null, new Dog()

--- a/Samples/Beyond.NET.Sample.Managed/Source/AsyncTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/AsyncTests.cs
@@ -25,7 +25,7 @@ public class AsyncTests
     )
     {
         var task = Task<int>.Factory.StartNew(() => transformerDelegate(number1, number2));
-        
+
         var result = await task;
 
         return result;

--- a/Samples/Beyond.NET.Sample.Managed/Source/CharTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/CharTests.cs
@@ -13,21 +13,21 @@ public static class CharTests
             throw new ArgumentOutOfRangeException(nameof(value));
         }
     }
-    
+
     public static void PassInUppercaseAOrThrow(char value)
     {
         if (value != UppercaseA) {
             throw new ArgumentOutOfRangeException(nameof(value));
         }
     }
-    
+
     public static void PassInOneOrThrow(char value)
     {
         if (value != One) {
             throw new ArgumentOutOfRangeException(nameof(value));
         }
     }
-    
+
     public static void PassInLowercaseUmlautAOrThrow(char value)
     {
         if (value != LowercaseUmlautA) {

--- a/Samples/Beyond.NET.Sample.Managed/Source/DelegatesTest.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/DelegatesTest.cs
@@ -56,17 +56,17 @@ public static class DelegatesTest
 
     public delegate Point PointTransformDelegate(Point point);
     // public delegate Point PointTransformWithRefDelegate(ref Point pointRef);
-    
+
     public static Point TransformPoint(
         Point point,
         PointTransformDelegate pointTransformer
     )
     {
         Point result = pointTransformer(point);
-    
+
         return result;
     }
-    
+
     // public static Point TransformRefPoint(
     //     ref Point pointRef,
     //     PointTransformWithRefDelegate pointTransformer

--- a/Samples/Beyond.NET.Sample.Managed/Source/DontStrip.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/DontStrip.cs
@@ -15,7 +15,7 @@ public static class DontStrip
     public static System.Security.Cryptography.ECDsa ECDsa => null!;
     public static System.Security.Cryptography.ECDiffieHellman ECDiffieHellman => null!;
     #endregion System.Security.Cryptography
-    
+
     #region System.Net
     public static System.Net.NetworkCredential NetworkCredential => null!;
     #endregion System.Net

--- a/Samples/Beyond.NET.Sample.Managed/Source/GenericTestClass.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/GenericTestClass.cs
@@ -9,7 +9,7 @@ public class GenericTestClass<T>
     {
         return typeof(T);
     }
-    
+
     public static Type[] ReturnGenericClassTypeAndGenericMethodType<TM>()
     {
         return new[] {
@@ -38,7 +38,7 @@ public class GenericTestClass<T1, T2>
 {
     public int AProperty { get; set; } = 0;
     public int AField = 0;
-    
+
     public Type[] ReturnGenericClassTypes()
     {
         return new[] {

--- a/Samples/Beyond.NET.Sample.Managed/Source/GenericTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/GenericTests.cs
@@ -16,7 +16,7 @@ public class GenericTests
     {
         return string.Join(separator, listOfString);
     }
-    
+
     public struct SimpleKeyValuePair
     {
         public object? Key { get; }
@@ -28,22 +28,22 @@ public class GenericTests
             Value = value;
         }
     }
-    
+
     public static Type ReturnGenericType<T>()
     {
         return typeof(T);
     }
-    
+
     public static void ReturnGenericTypeAsOutParameter<T>(out Type typeOfT)
     {
         typeOfT = typeof(T);
     }
-    
+
     public static void ReturnGenericTypeAsRefParameter<T>(ref Type typeOfT)
     {
         typeOfT = typeof(T);
     }
-    
+
     public static Type[] ReturnGenericTypes<T1, T2>()
     {
         return new [] {
@@ -51,7 +51,7 @@ public class GenericTests
             typeof(T2)
         };
     }
-    
+
     public static SimpleKeyValuePair ReturnSimpleKeyValuePair<TKey, TValue>(TKey key, TValue value)
     {
         return new SimpleKeyValuePair(key, value);
@@ -61,19 +61,19 @@ public class GenericTests
     {
         return default;
     }
-    
+
     public static T?[] ReturnArrayOfDefaultValuesOfGenericType<T>(int numberOfElements)
     {
         if (numberOfElements <= 0) {
             return Array.Empty<T>();
         }
-        
+
         List<T?> defaultValues = new();
 
         for (int i = 0; i < numberOfElements; i++) {
             defaultValues.Add(default);
         }
-        
+
         return defaultValues.ToArray();
     }
 
@@ -100,13 +100,13 @@ public class GenericTests
             if (value is null) {
                 continue;
             }
-            
+
             string? stringValue = value.ToString();
 
             if (stringValue is null) {
                 continue;
             }
-            
+
             strings.Add(stringValue);
         }
 

--- a/Samples/Beyond.NET.Sample.Managed/Source/IndexerTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/IndexerTests.cs
@@ -5,13 +5,13 @@ public class IndexerTests
     public string StoredString { get; private set; } = string.Empty;
     public int StoredNumber { get; private set; } = 0;
     public Guid StoredGuid { get; private set; } = Guid.Empty;
-    
+
     public object[] StoredValue { get; private set; } = new object[] {
         string.Empty,
-        0, 
+        0,
         Guid.Empty
     };
-    
+
     public object[] this[string aString, int aNumber, Guid aGuid]
     {
         get {
@@ -21,7 +21,7 @@ public class IndexerTests
             StoredString = aString;
             StoredNumber = aNumber;
             StoredGuid = aGuid;
-            
+
             StoredValue = value;
         }
     }

--- a/Samples/Beyond.NET.Sample.Managed/Source/InterfaceTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/InterfaceTests.cs
@@ -17,7 +17,7 @@ public readonly struct IInterface1_DelegateAdapter : IInterface1
     {
         _MethodInIInterface1_Adapter = methodInIInterface1_Adapter ?? throw new ArgumentNullException(nameof(methodInIInterface1_Adapter));
     }
-    
+
     public void MethodInIInterface1()
     {
         _MethodInIInterface1_Adapter();
@@ -41,7 +41,7 @@ public class TypeThatImplementsMultipleInterfaces: IInterface1, IInterface2, IIn
         Console.WriteLine($"{nameof(MethodInIInterface1)} called through {nameof(TypeThatImplementsMultipleInterfaces)}");
     }
 
-    private int _propertyInIInterface2; 
+    private int _propertyInIInterface2;
     public int PropertyInIInterface2
     {
         get
@@ -69,32 +69,32 @@ public class TypeThatUsesInterfaces
 {
     public delegate void DelegateThatReceivesIInterface1(IInterface1 interface1);
     public delegate IInterface1 DelegateThatReturnsIInterface1();
-    
+
     public void CallMethod1InIInterface1(IInterface1 interface1)
     {
         interface1.MethodInIInterface1();
     }
-    
+
     public void DelegateThatReceivesInterfaceTest(DelegateThatReceivesIInterface1 del, IInterface1 interface1)
     {
         del(interface1);
     }
-    
+
     public IInterface1 DelegateThatReturnsInterfaceTest(DelegateThatReturnsIInterface1 del)
     {
         return del();
     }
-    
+
     public void SetPropertyInIInterface2(IInterface2 interface2, int value)
     {
         interface2.PropertyInIInterface2 = value;
     }
-    
+
     public int GetPropertyInIInterface2(IInterface2 interface2)
     {
         return interface2.PropertyInIInterface2;
     }
-    
+
     public void CallMethod1InIInterface3(IInterface3 interface3)
     {
         interface3.MethodInIInterface3();
@@ -104,22 +104,22 @@ public class TypeThatUsesInterfaces
     {
         return new TypeThatImplementsMultipleInterfaces();
     }
-    
+
     public void GetTypeThatImplementsIInterface1AsOutParam(out IInterface1 interface1)
     {
         interface1 = new TypeThatImplementsMultipleInterfaces();
     }
-    
+
     public IInterface2 GetTypeThatImplementsIInterface2()
     {
         return new TypeThatImplementsMultipleInterfaces();
     }
-    
+
     public void GetTypeThatMaybeImplementsIInterface2AsOutParam(out IInterface2? interface2)
     {
         interface2 = null;
     }
-    
+
     public IInterface3 GetTypeThatImplementsIInterface3()
     {
         return new TypeThatImplementsMultipleInterfaces();
@@ -143,7 +143,7 @@ public abstract class BaseRegistrationData
     }
 }
 
-public sealed class RegistrationData1 : BaseRegistrationData, IRegistrationData  
+public sealed class RegistrationData1 : BaseRegistrationData, IRegistrationData
 {
     public static DataType RegisteredDataType { get; } = default;
 
@@ -154,7 +154,7 @@ public sealed class RegistrationData1 : BaseRegistrationData, IRegistrationData
     { }
 }
 
-public sealed class RegistrationData2 : BaseRegistrationData, IRegistrationData  
+public sealed class RegistrationData2 : BaseRegistrationData, IRegistrationData
 {
     public static DataType RegisteredDataType { get; } = default;
 

--- a/Samples/Beyond.NET.Sample.Managed/Source/NiceLevels.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/NiceLevels.cs
@@ -10,17 +10,17 @@ public enum NiceLevels: uint
     /// Not nice at all.
     /// </summary>
     NotNice,
-    
+
     /// <summary>
     /// A little bit nice.
     /// </summary>
     LittleBitNice,
-    
+
     /// <summary>
     /// Pretty nice.
     /// </summary>
     Nice,
-    
+
     /// <summary>
     /// Very nice.
     /// </summary>

--- a/Samples/Beyond.NET.Sample.Managed/Source/NullabilityTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/NullabilityTests.cs
@@ -4,9 +4,9 @@ public class NullabilityTests
 {
     public NullabilityTests()
     {
-        
+
     }
-    
+
     public NullabilityTests(bool throwAnException)
     {
         if (throwAnException) {
@@ -18,7 +18,7 @@ public class NullabilityTests
     {
         return new NullabilityTests(throwAnException);
     }
-    
+
     public string NonNullableStringProperty { get; set; } = "Hello";
     public string NonNullableStringField = "Hello";
 
@@ -36,12 +36,12 @@ public class NullabilityTests
 
         return value;
     }
-    
+
     public string MethodWithNonNullableStringParameterThatThrows(string value)
     {
         throw new Exception("Expected Exception");
     }
-    
+
     public string? MethodWithNullableStringParameter(string? value)
     {
         return value;

--- a/Samples/Beyond.NET.Sample.Managed/Source/OutParameterTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/OutParameterTests.cs
@@ -9,47 +9,47 @@ public class OutParameterTests
     {
         returnValue = 1;
     }
-    
+
     public void Return_Int_1_Optional(out int? returnValue)
     {
         returnValue = 1;
     }
-    
+
     public void Return_Int_Null(out int? returnValue)
     {
         returnValue = null;
     }
-    
+
     public void Return_Byte_1_NonOptional(out byte returnValue)
     {
         returnValue = 1;
     }
-    
+
     public void Return_SByte_1_NonOptional(out sbyte returnValue)
     {
         returnValue = 1;
     }
-    
+
     public void Return_UShort_1_NonOptional(out ushort returnValue)
     {
         returnValue = 1;
     }
-    
+
     public void Return_UInt_1_NonOptional(out uint returnValue)
     {
         returnValue = 1;
     }
-    
+
     public void Return_ULong_1_NonOptional(out ulong returnValue)
     {
         returnValue = 1;
     }
-    
+
     public void Return_Bool_true_NonOptional(out bool returnValue)
     {
         returnValue = true;
     }
-    
+
     // TODO: Currently not supported by Beyond.NET
     public void Return_Char_a_NonOptional(out char returnValue)
     {
@@ -62,63 +62,63 @@ public class OutParameterTests
     {
         returnValue = DateTimeKind.Utc;
     }
-    
+
     public void Return_DateTimeKind_Utc_Optional(out DateTimeKind? returnValue)
     {
         returnValue = DateTimeKind.Utc;
     }
-    
+
     public void Return_DateTimeKind_Null(out DateTimeKind? returnValue)
     {
         returnValue = null;
     }
     #endregion Enums
-    
+
     #region Structs
     public void Return_DateTime_MaxValue_NonOptional(out DateTime returnValue)
     {
         returnValue = DateTime.MaxValue;
     }
-    
+
     public void Return_DateTime_MaxValue_Optional(out DateTime? returnValue)
     {
         returnValue = DateTime.MaxValue;
     }
-    
+
     public void Return_DateTime_Null(out DateTime? returnValue)
     {
         returnValue = null;
     }
     #endregion Structs
-    
+
     #region Classes
     public void Return_String_Abc_NonOptional(out string returnValue)
     {
         returnValue = "Abc";
     }
-    
+
     public void Return_String_Abc_Optional(out string? returnValue)
     {
         returnValue = "Abc";
     }
-    
+
     public void Return_String_Null(out string? returnValue)
     {
         returnValue = null;
     }
     #endregion Classes
-    
+
     #region Interfaces
     public void Return_IEnumerable_String_Abc_NonOptional(out IEnumerable returnValue)
     {
         returnValue = "Abc";
     }
-    
+
     public void Return_IEnumerable_String_Abc_Optional(out IEnumerable? returnValue)
     {
         returnValue = "Abc";
     }
-    
+
     public void Return_IEnumerable_Null(out IEnumerable? returnValue)
     {
         returnValue = null;

--- a/Samples/Beyond.NET.Sample.Managed/Source/OverloadTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/OverloadTests.cs
@@ -5,11 +5,11 @@ public static class OverloadTests
     public static void Print(int value) {
         Console.WriteLine(value);
     }
-    
+
     public static void Print(DateTime value) {
         Console.WriteLine(value);
     }
-    
+
     public static void Print(string value) {
         Console.WriteLine(value);
     }

--- a/Samples/Beyond.NET.Sample.Managed/Source/OverrideTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/OverrideTests.cs
@@ -2,12 +2,12 @@ namespace Beyond.NET.Sample.Source;
 
 public interface IOverrideTestsInterface
 {
-    
+
 }
 
 public class OverrideTestsInterfaceImpl: IOverrideTestsInterface
 {
-    
+
 }
 
 public class OverrideTestsBaseClass
@@ -16,7 +16,7 @@ public class OverrideTestsBaseClass
     {
         return null;
     }
-    
+
     public virtual IOverrideTestsInterface? ReturnInterface()
     {
         return null;

--- a/Samples/Beyond.NET.Sample.Managed/Source/Person.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/Person.cs
@@ -25,13 +25,13 @@ public class Person
         }
         set {
             m_children = value;
-            
+
             NumberOfChildrenChanged?.Invoke();
         }
     }
 
     public event NumberOfChildrenChangedDelegate? NumberOfChildrenChanged;
-    
+
     public NiceLevels NiceLevel { get; set; } = NiceLevels.Nice;
 
     public string FullName => $"{FirstName} {LastName}";
@@ -53,7 +53,7 @@ public class Person
         LastName = lastName;
         Age = age;
     }
-    
+
     public Person(
         string firstName,
         string lastName
@@ -67,7 +67,7 @@ public class Person
 
     #region Methods
     public static Person MakeJohnDoe() => new("John", "Doe", 50);
-    
+
     public string GetNiceLevelString()
     {
         switch (NiceLevel) {
@@ -94,31 +94,31 @@ public class Person
         if (Children.Contains(child)) {
             return;
         }
-        
+
         List<Person> children = Children.ToList();
-        
+
         children.Add(child);
 
         Children = children.ToArray();
     }
-    
+
     public void RemoveChild(Person child)
     {
         if (!Children.Contains(child)) {
             return;
         }
-        
+
         List<Person> children = Children.ToList();
-        
+
         children.Remove(child);
 
         Children = children.ToArray();
     }
-    
+
     public void RemoveChildAt(int index)
     {
         List<Person> children = Children.ToList();
-        
+
         children.RemoveAt(index);
 
         Children = children.ToArray();
@@ -140,7 +140,7 @@ public class Person
     {
         if (index < 0 || index >= Children.Length) {
             child = null;
-            
+
             return false;
         }
 
@@ -154,7 +154,7 @@ public class Person
         if (newAgeProvider is null) {
             return;
         }
-        
+
         var newAge = newAgeProvider();
 
         Age = newAge;

--- a/Samples/Beyond.NET.Sample.Managed/Source/Person_Extensions.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/Person_Extensions.cs
@@ -3,7 +3,7 @@ namespace Beyond.NET.Sample;
 public static class Person_Extensions
 {
     public static void IncreaseAge(
-        this Person person, 
+        this Person person,
         int byYears
     )
     {
@@ -16,7 +16,7 @@ public static class Person_Extensions
     )
     {
         address = person.Address;
-        
+
         return address is not null;
     }
 }

--- a/Samples/Beyond.NET.Sample.Managed/Source/PrimitiveTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/PrimitiveTests.cs
@@ -6,41 +6,41 @@ public static class PrimitiveTests
     public static sbyte SByteMin => sbyte.MinValue;
     public static sbyte SByteMax => sbyte.MaxValue;
     public static sbyte ReturnSByte(sbyte input) => input;
-    
+
     public static short ShortMin => short.MinValue;
     public static short ShortMax => short.MaxValue;
     public static short ReturnShort(short input) => input;
-    
+
     public static int IntMin => int.MinValue;
     public static int IntMax => int.MaxValue;
     public static int ReturnInt(int input) => input;
-    
+
     public static long LongMin => long.MinValue;
     public static long LongMax => long.MaxValue;
     public static long ReturnLong(long input) => input;
-    
+
     public static nint NIntMin => nint.MinValue;
     public static nint NIntMax => nint.MaxValue;
     public static nint ReturnNInt(nint input) => input;
     #endregion Signed
-    
+
     #region Unsigned
     public static byte ByteMin => byte.MinValue;
     public static byte ByteMax => byte.MaxValue;
     public static byte ReturnByte(byte input) => input;
-    
+
     public static ushort UShortMin => ushort.MinValue;
     public static ushort UShortMax => ushort.MaxValue;
     public static ushort ReturnUShort(ushort input) => input;
-    
+
     public static uint UIntMin => uint.MinValue;
     public static uint UIntMax => uint.MaxValue;
     public static uint ReturnUInt(uint input) => input;
-    
+
     public static ulong ULongMin => ulong.MinValue;
     public static ulong ULongMax => ulong.MaxValue;
     public static ulong ReturnULong(ulong input) => input;
-    
+
     public static nuint NUIntMin => nuint.MinValue;
     public static nuint NUIntMax => nuint.MaxValue;
     public static nuint ReturnNUInt(nuint input) => input;
@@ -50,7 +50,7 @@ public static class PrimitiveTests
     public static float FloatMin => float.MinValue;
     public static float FloatMax => float.MaxValue;
     public static float ReturnFloat(float input) => input;
-    
+
     public static double DoubleMin => double.MinValue;
     public static double DoubleMax => double.MaxValue;
     public static double ReturnDouble(double input) => input;

--- a/Samples/Beyond.NET.Sample.Managed/Source/SpanTest.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/SpanTest.cs
@@ -6,7 +6,7 @@ public class SpanTest
     public delegate ReadOnlySpan<byte> ByteArrayToSpanDelegate(byte[] bytes);
     public delegate byte[] SpanToByteArrayDelegate(ReadOnlySpan<byte> span);
     #endregion Delegates
-    
+
     #region Source Data
     public byte[] Data { get; private set; }
     #endregion Source Data
@@ -16,12 +16,12 @@ public class SpanTest
     {
         Data = data ?? throw new ArgumentNullException(nameof(data));
     }
-    
+
     public SpanTest(Span<byte> dataAsSpan)
     {
         Data = dataAsSpan.ToArray();
     }
-    
+
     public SpanTest(ReadOnlySpan<byte> dataAsReadOnlySpan)
     {
         Data = dataAsReadOnlySpan.ToArray();
@@ -31,11 +31,11 @@ public class SpanTest
     #region Span<byte>
     public Span<byte> DataAsSpan => new(Data);
     public Span<byte> GetDataAsSpan() => DataAsSpan;
-    
+
     public bool TryGetDataAsSpan(out Span<byte> dataAsSpan)
     {
         dataAsSpan = DataAsSpan;
-        
+
         return true;
     }
     #endregion Span<byte>
@@ -51,14 +51,14 @@ public class SpanTest
             Data = value.ToArray();
         }
     }
-    
+
     public ReadOnlySpan<byte> GetDataAsReadOnlySpan() => DataAsSpan;
     public void SetDataAsReadOnlySpan(ReadOnlySpan<byte> span) => Data = span.ToArray();
-    
+
     public bool TryGetDataAsReadOnlySpan(out ReadOnlySpan<byte> dataAsReadOnlySpan)
     {
         dataAsReadOnlySpan = DataAsReadOnlySpan;
-        
+
         return true;
     }
 
@@ -69,7 +69,7 @@ public class SpanTest
     {
         return converter(bytes);
     }
-    
+
     public byte[] ConvertSpanToByteArray(
         ReadOnlySpan<byte> span,
         SpanToByteArrayDelegate converter

--- a/Samples/Beyond.NET.Sample.Managed/Source/StructTest.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/StructTest.cs
@@ -19,12 +19,12 @@ public struct StructTest
     // TODO: Uncommenting this makes Assembly.ExportedTypes throw
     // public static readonly StructTest? ReadOnlyNullInstanceField = null;
     public static StructTest? NullInstanceProperty => null;
-    
+
     // TODO: Uncommenting this makes Assembly.ExportedTypes throw
     // public static StructTest? NonNullInstanceField = new StructTest("Test");
-    
+
     public static StructTest? NonNullInstanceProperty => new StructTest("Test");
-    
+
     // TODO: Uncommenting this makes Assembly.ExportedTypes throw
     // public static StructTest? NullableStructPropertyWithGetterAndSetter { get; set; } = null;
 
@@ -36,9 +36,9 @@ public struct StructTest
             return new StructTest("Test");
         }
     }
-    
+
     public static void GetNullableStructReturnValueInOutParameter(
-        bool returnNull, 
+        bool returnNull,
         out StructTest? returnValue
     )
     {
@@ -48,12 +48,12 @@ public struct StructTest
             returnValue = new StructTest("Test");
         }
     }
-    
+
     public static StructTest? GetNullableStructReturnValueOfParameter(StructTest? returnValue)
     {
         return returnValue;
     }
-    
+
     public static StructTest? GetNullableStructReturnValueOfRefParameter(ref StructTest? returnValue)
     {
         return returnValue;

--- a/Samples/Beyond.NET.Sample.Managed/Source/TestClass.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/TestClass.cs
@@ -34,12 +34,12 @@ public class TestClass
     {
         return charReturnerDelegate();
     }
-    
+
     public void SayHello()
     {
         Console.WriteLine(GetHello());
     }
-    
+
     public void SayHello(string name)
     {
         Console.WriteLine(GetHello() + " " + name);
@@ -59,7 +59,7 @@ public class TestClass
     {
         return number1 + number2;
     }
-    
+
     public int Divide(int number1, int number2)
     {
         return number1 / number2;
@@ -73,7 +73,7 @@ public class TestClass
     public int ModifyByRefValueAndReturnOriginalValue(ref int valueToModify, int targetValue)
     {
         int originalValue = valueToModify;
-        
+
         valueToModify = targetValue;
 
         return originalValue;
@@ -104,7 +104,7 @@ public class TestClass
     public ref int IncreaseAndGetCurrentIntValueByRef()
     {
         CurrentIntValue += 1;
-        
+
         return ref CurrentIntValue;
     }
 }

--- a/Samples/Beyond.NET.Sample.Managed/Source/TestRecord.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/TestRecord.cs
@@ -20,7 +20,7 @@ public record struct TestRecordStruct(int anInt)
 
     public TestRecordStruct(DateTime dateTime) : this(0)
     {
-        
+
     }
 }
 

--- a/Samples/Beyond.NET.Sample.Managed/Source/Transformer.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/Transformer.cs
@@ -5,11 +5,11 @@ public static class Transformer
     public delegate string StringGetterDelegate();
     public delegate string StringTransformerDelegate(string inputString);
     public delegate double DoublesTransformerDelegate(double number1, double number2);
-    
+
     public static class BuiltInTransformers
     {
         public static StringTransformerDelegate UppercaseStringTransformer { get; set; } =
-            inputString => inputString.ToUpper();    
+            inputString => inputString.ToUpper();
     }
 
     public static string TransformString(
@@ -21,7 +21,7 @@ public static class Transformer
 
         return outputString;
     }
-    
+
     public static double TransformDoubles(
         double number1,
         double number2,

--- a/Samples/Beyond.NET.Sample.Native/Beyond.NET.Sample.Native.csproj
+++ b/Samples/Beyond.NET.Sample.Native/Beyond.NET.Sample.Native.csproj
@@ -14,7 +14,7 @@
 
     <!-- TODO: Disabled for now to get faster build times -->
     <Nullable>disable</Nullable>
-    
+
     <!-- Seems to not be required as long as we're providing the RuntimeIdentifier when calling dotnet publish/build -->
     <!-- <RuntimeIdentifiers>osx-x64;osx-arm64;linux-x64;ios-arm64;iossimulator-arm64;iossimulator-x64</RuntimeIdentifiers> -->
 
@@ -26,7 +26,7 @@
     <MacOSMinVersion>13.0</MacOSMinVersion>
     <iOSMinVersion>16.0</iOSMinVersion>
   </PropertyGroup>
-  
+
   <!-- Compiler Customization -->
   <!-- TODO / WIP -->
   <!-- Include pre-compiled Swift stuff -->

--- a/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/Base64View.swift
+++ b/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/Base64View.swift
@@ -4,10 +4,10 @@ import BeyondDotNETSampleKit
 struct Base64View: View {
     @State
     private var inputString = ""
-    
+
     @State
     private var outputString = ""
-    
+
     var body: some View {
         VStack {
             HStack {
@@ -18,7 +18,7 @@ struct Base64View: View {
                         updateBase64OutputString()
                     }
             }
-            
+
             HStack {
                 Text("Output:")
                 TextField("Output", text: $outputString)
@@ -33,28 +33,28 @@ private extension Base64View {
     func updateBase64OutputString() {
         outputString = Self.base64String(from: inputString)
     }
-    
+
     static func base64String(from inputString: String) -> String {
         let inputStringDN = inputString.dotNETString()
-        
+
         // Get the .NET UTF8 Text Encoding
         guard let utf8Encoding = try? System.Text.Encoding.uTF8 else {
             fatalError("Failed to get System.Text.Encoding.UTF8")
         }
-        
+
         // Convert the input string to a .NET byte array
         guard let inputStringBytes = try? utf8Encoding.getBytes(inputStringDN) else {
             fatalError("Failed to get bytes of input string")
         }
-        
+
         // Convert the .NET byte array to a Base64 string
         guard let base64OutputStringDN = try? System.Convert.toBase64String(inputStringBytes) else {
             fatalError("Failed to get Base64 String")
         }
-        
+
         // Convert the .NET System.String to a Swift string
         let base64OutputString = base64OutputStringDN.string()
-        
+
         return base64OutputString
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/ClockView.swift
+++ b/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/ClockView.swift
@@ -4,24 +4,24 @@ import BeyondDotNETSampleKit
 struct ClockView: View {
     @State
     private var dateTimeString = Self.currentDateTimeString()
-    
+
     private static var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .medium
-        
+
         return formatter
     }()
-    
+
     private let timer = Timer.publish(every: 1,
                                       on: .main,
                                       in: .common).autoconnect()
-    
+
     var body: some View {
         VStack {
             Text("The current date and time is…")
                 .padding(.bottom)
-            
+
             Text(dateTimeString)
                 .textSelection(.enabled)
                 .bold()
@@ -36,21 +36,21 @@ private extension ClockView {
     func updateDateTimeString() {
         dateTimeString = Self.currentDateTimeString()
     }
-    
+
     static func currentDateTimeString() -> String {
         // Get the current System.DateTime
         guard let nowDN = try? System.DateTime.now else {
             fatalError("Error while getting System.DateTime.now")
         }
-        
+
         // Convert the System.DateTime to a Swift Date
         guard let now = try? nowDN.swiftDate() else {
             fatalError("Error while converting System.DateTime to Swift Date")
         }
-        
+
         // Get a formatted date string
         let dateString = dateFormatter.string(from: now)
-        
+
         return dateString
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/ExceptionView.swift
+++ b/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/ExceptionView.swift
@@ -3,28 +3,28 @@ import BeyondDotNETSampleKit
 
 struct ExceptionView: View {
     private var error: DNError
-    
+
     private var localizedDescription: String {
         // The localizedDescription will contain the System.Exception.Message value
         error.localizedDescription
     }
-    
+
     private var stackTrace: String {
         // You can get the stack trace of the underlying System.Exception object using this convenience API
         error.stackTrace() ?? ""
     }
-    
+
     private var exceptionToString: String {
         // You also get access to the underlying System.Exception object
         (try? error.exception.toString().string()) ?? ""
     }
-    
+
     init() {
         do {
             // Try to get a System.Type by name which certainly does not exist
             // This will throw an Exception which gets wrapped in a Swift Error (DNError to be specific)
             _ = try System_Type.getType("This Type Does Not Exist".dotNETString(), true)
-            
+
             fatalError("System.Type.GetType with a non-existent type should throw but did not")
         } catch let dnError as DNError {
             self.error = dnError
@@ -33,7 +33,7 @@ struct ExceptionView: View {
             fatalError("The thrown error was not of type DNError")
         }
     }
-    
+
     var body: some View {
         ScrollView {
             VStack {
@@ -43,14 +43,14 @@ struct ExceptionView: View {
                     Text(localizedDescription)
                         .textSelection(.enabled)
                 }.padding(.bottom)
-                
+
                 VStack {
                     Text("Stack Trace:")
                         .bold()
                     Text(stackTrace)
                         .textSelection(.enabled)
                 }.padding(.bottom)
-                
+
                 VStack {
                     Text("System.Exception.ToString:")
                         .bold()

--- a/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/GuidView.swift
+++ b/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/GuidView.swift
@@ -4,16 +4,16 @@ import BeyondDotNETSampleKit
 struct GuidView: View {
     @State
     private var guidString = Self.newGuidString()
-    
+
     var body: some View {
         VStack {
             Text("Here's a new .NET System.Guid:")
-            
+
             Text(guidString)
                 .textSelection(.enabled)
                 .bold()
                 .padding(.bottom)
-            
+
             Button {
                 updateGuidString()
             } label: {
@@ -28,21 +28,21 @@ private extension GuidView {
     func updateGuidString() {
         guidString = Self.newGuidString()
     }
-    
+
     static func newGuidString() -> String {
         // Generate a new System.Guid
         guard let guid = try? System.Guid.newGuid() else {
             fatalError("Error while generating new System.Guid")
         }
-        
+
         // Convert the System.Guid to a System.String
         guard let guidStringDN = try? guid.toString() else {
             fatalError("Error while converting System.Guid to System.String")
         }
-        
+
         // Convert the System.String to a Swift String
         let guidString = guidStringDN.string()
-        
+
         return guidString
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/PerformanceView.swift
+++ b/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/PerformanceView.swift
@@ -16,33 +16,33 @@ struct PerformanceView: View {
 private extension PerformanceView {
     func testIterationPerformance() {
         let array = createArray()
-        
+
 //        Thread.sleep(forTimeInterval: 2)
-        
+
         iterate(array)
     }
-    
+
     func createArray() -> DNArray<System.Object> {
         do {
             let count: Int32 = 1_000_000
-            
+
             var values = [System.Object]()
-            
+
             let systemObjectArray = try DNArray<System.Object>(length: count)
-            
+
             for idx in 0..<count {
                 let obj = try System.Object()
-                
+
                 values.append(obj)
                 systemObjectArray[idx] = obj
             }
-            
+
             return systemObjectArray
         } catch {
             fatalError("Error: \(error.localizedDescription)")
         }
     }
-    
+
     func iterate(_ systemObjectArray: DNArray<System.Object>) {
         for obj in systemObjectArray {
             // Aka PleaseDontOptimizeThisOut

--- a/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/TimerView.swift
+++ b/Samples/Beyond.NET.Sample.Swift/SwiftUIApp/TimerView.swift
@@ -4,11 +4,11 @@ import BeyondDotNETSampleKit
 struct TimerView: View {
     @StateObject
     private var timer = TimerModel(interval: 1)
-    
+
     var body: some View {
         VStack {
             Text("Every second, a new System.Guid is generated using a System.Threading.Timer.")
-            
+
             ScrollView {
                 Text(timer.guidsString)
                     .font(.footnote)
@@ -24,48 +24,48 @@ private extension TimerView {
         @Published
         @MainActor
         private(set) var guidsString = ""
-        
+
         private var timer: System.Threading.Timer?
-        
+
         init(interval: TimeInterval) {
             startTimer(interval: interval)
         }
-        
+
         deinit {
             try? timer?.dispose()
         }
-        
+
         private func startTimer(interval: TimeInterval) {
             let dueTimeMS: Int32 = 0 // Immediately
             let periodMS: Int32 = .init(interval * 1_000)
-            
+
             let closure: System.Threading.TimerCallback.ClosureType = { [weak self] _ in
                 self?.addNewGuid()
             }
-            
+
             guard let timer = try? System.Threading.Timer(.init(closure),
                                                           nil,
                                                           dueTimeMS,
                                                           periodMS) else {
                 fatalError("Failed to create System.Threading.Timer")
             }
-            
+
             self.timer = timer
         }
-        
+
         private func addNewGuid() {
             guard let newGuid = try? System.Guid.newGuid() else {
                 fatalError("Failed to create new System.Guid")
             }
-            
+
             addGuid(newGuid)
         }
-        
+
         private func addGuid(_ newGuid: System.Guid) {
             guard let guidString = try? newGuid.toString().string() else {
                 fatalError("Failed to convert System.Guid to string")
             }
-            
+
             Task.detached { [weak self] in
                 await MainActor.run { [weak self] in
                     self?.guidsString += "\(guidString)\n"

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/ComparisonTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/ComparisonTests.swift
@@ -5,69 +5,69 @@ final class ComparisonTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testObjectComparisons() throws {
         let optionalObject: System.Object? = try System.Object()
-        
+
         guard let nonOptionalObject = optionalObject else {
             XCTFail("System.Object ctor should not throw and return an instance")
-            
+
             return
         }
-        
+
         let anotherOptionalObject: System.Object? = try System_Object()
-        
+
         guard let anotherNonOptionalObject = anotherOptionalObject else {
             XCTFail("System.Object ctor should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertTrue(optionalObject == optionalObject)
         XCTAssertFalse(optionalObject != optionalObject)
         XCTAssertTrue(optionalObject === optionalObject)
         XCTAssertFalse(optionalObject !== optionalObject)
-        
+
         XCTAssertTrue(optionalObject == nonOptionalObject)
         XCTAssertFalse(optionalObject != nonOptionalObject)
         XCTAssertTrue(optionalObject === nonOptionalObject)
         XCTAssertFalse(optionalObject !== nonOptionalObject)
-        
+
         XCTAssertFalse(optionalObject == anotherOptionalObject)
         XCTAssertTrue(optionalObject != anotherOptionalObject)
         XCTAssertFalse(optionalObject === anotherOptionalObject)
         XCTAssertTrue(optionalObject !== anotherOptionalObject)
-        
+
         XCTAssertFalse(nonOptionalObject == anotherOptionalObject)
         XCTAssertTrue(nonOptionalObject != anotherOptionalObject)
         XCTAssertFalse(nonOptionalObject === anotherOptionalObject)
         XCTAssertTrue(nonOptionalObject !== anotherOptionalObject)
-        
+
         XCTAssertFalse(optionalObject == anotherNonOptionalObject)
         XCTAssertTrue(optionalObject != anotherNonOptionalObject)
         XCTAssertFalse(optionalObject === anotherNonOptionalObject)
         XCTAssertTrue(optionalObject !== anotherNonOptionalObject)
-        
+
         XCTAssertFalse(nonOptionalObject == anotherNonOptionalObject)
         XCTAssertTrue(nonOptionalObject != anotherNonOptionalObject)
         XCTAssertFalse(nonOptionalObject === anotherNonOptionalObject)
         XCTAssertTrue(nonOptionalObject !== anotherNonOptionalObject)
     }
-    
+
     func testPrimitiveComparisons() {
         let int32Value: Int32 = 1234
         let boxedInt32Value = int32Value.dotNETObject()
-        
+
         let sameInt32Value: Int32 = 1234
         let boxedSameInt32Value = sameInt32Value.dotNETObject()
-        
+
         let otherInt32Value: Int32 = 4321
         let boxedOtherInt32Value = otherInt32Value.dotNETObject()
-        
+
         XCTAssertTrue(boxedInt32Value == boxedSameInt32Value)
         XCTAssertTrue(boxedInt32Value as System.Object? == boxedSameInt32Value)
         XCTAssertTrue(boxedInt32Value as System.Object? == boxedSameInt32Value as System.Object?)
@@ -80,7 +80,7 @@ final class ComparisonTests: XCTestCase {
         XCTAssertTrue(boxedInt32Value !== boxedSameInt32Value)
         XCTAssertTrue(boxedInt32Value !== boxedSameInt32Value as System.Object?)
         XCTAssertTrue(boxedInt32Value as System.Object? !== boxedSameInt32Value as System.Object?)
-        
+
         XCTAssertFalse(boxedInt32Value == boxedOtherInt32Value)
         XCTAssertFalse(boxedInt32Value as System.Object? == boxedOtherInt32Value)
         XCTAssertFalse(boxedInt32Value as System.Object? == boxedOtherInt32Value as System.Object?)
@@ -94,34 +94,34 @@ final class ComparisonTests: XCTestCase {
         XCTAssertTrue(boxedInt32Value !== boxedOtherInt32Value as System.Object?)
         XCTAssertTrue(boxedInt32Value as System.Object? !== boxedOtherInt32Value as System.Object?)
     }
-    
+
     func testGuidComparison() {
         let uuid1 = UUID()
         let uuid2 = UUID()
-        
+
         guard let guid1 = uuid1.dotNETGuid() else {
             XCTFail("Converting a Swift UUID to a System.Guid should return an instance")
-            
+
             return
         }
-        
+
         guard let guid1Copy = uuid1.dotNETGuid() else {
             XCTFail("Converting a Swift UUID to a System.Guid should return an instance")
-            
+
             return
         }
-        
+
         guard let guid2 = uuid2.dotNETGuid() else {
             XCTFail("Converting a Swift UUID to a System.Guid should return an instance")
-            
+
             return
         }
-        
+
         XCTAssertTrue(guid1 == guid1Copy)
         XCTAssertFalse(guid1 != guid1Copy)
         XCTAssertFalse(guid1 === guid1Copy)
         XCTAssertTrue(guid1 !== guid1Copy)
-        
+
         XCTAssertFalse(guid1 == guid2)
         XCTAssertTrue(guid1 != guid2)
         XCTAssertFalse(guid1 === guid2)

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/PrimitivesBoxingTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/PrimitivesBoxingTests.swift
@@ -5,23 +5,23 @@ final class PrimitivesBoxingTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testBool() {
         boxAndUnbox(value: true,
                     expectedTypeName: System.Boolean.fullTypeName,
 					boxFunc: { $0.dotNETObject() },
                     unboxFunc: { try $0.castToBool() })
-        
+
         boxAndUnbox(value: false,
                     expectedTypeName: System.Boolean.fullTypeName,
 					boxFunc: { $0.dotNETObject() },
                     unboxFunc: { try $0.castToBool() })
     }
-    
+
     func testFloat() {
         boxAndUnbox(value: -123.123 as Float,
                     expectedTypeName: System.Single.fullTypeName,
@@ -99,88 +99,88 @@ private extension PrimitivesBoxingTests {
                         boxFunc: (_ input: T) -> System.Object?,
                         unboxFunc: (_ input: System.Object) throws -> T?) where T: Equatable {
         let valueTypeName = expectedTypeName.dotNETString()
-        
+
         guard let valueType = try? System_Type.getType(valueTypeName) else {
             XCTFail("System.Type.GetType should not throw and return an instance")
-            
+
             return
         }
-        
+
         guard let valueObject = boxFunc(value) else {
             XCTFail("Should return an instance")
-            
+
             return
         }
-        
+
         guard let valueObjectType = try? valueObject.getType() else {
             XCTFail("System.Object.GetType should not throw and return an instance")
-            
+
             return
         }
-        
+
         guard let numberObjectTypeName = try? valueObjectType.fullName?.string() else {
             XCTFail("System.Type.FullName getter should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(expectedTypeName, numberObjectTypeName)
-        
+
         let valueRet: T?
-        
+
         do {
             valueRet = try unboxFunc(valueObject)
         } catch {
             XCTFail("Should not throw")
-            
+
             return
         }
-        
+
         XCTAssertEqual(value, valueRet)
-        
+
         guard let systemObject = try? System.Object() else {
             XCTFail("System.Object ctor should return an instance")
-            
+
             return
         }
-        
+
         do {
             _ = try unboxFunc(systemObject)
-            
+
             XCTFail("Should throw")
-            
+
             return
         } catch { }
-        
+
         let arrayLength: Int32 = 1
-        
+
         guard let array = try? System.Array.createInstance(valueType,
                                                            arrayLength) else {
             XCTFail("System.Array.CreateInstance should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertNoThrow(try array.setValue(valueObject,
                                             0 as Int32))
-        
+
         guard let valueObjectRetFromArray = try? array.getValue(0 as Int32) else {
             XCTFail("System.Array.GetValue should not throw and return an instance")
-            
+
             return
         }
-        
+
         let equal = valueObject == valueObjectRetFromArray
-        
+
         XCTAssertTrue(equal)
-        
+
         do {
             let valueRetFromArray = try unboxFunc(valueObjectRetFromArray)
-            
+
             XCTAssertEqual(value, valueRetFromArray)
         } catch {
             XCTFail("Should not throw")
-            
+
             return
         }
     }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemActionTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemActionTests.swift
@@ -5,32 +5,32 @@ final class SystemActionTests: XCTestCase {
 	override class func setUp() {
 		Self.sharedSetUp()
 	}
-	
+
 	override class func tearDown() {
 		Self.sharedTearDown()
 	}
-	
+
 	func testSystemActionType() throws {
 		let systemActionType = System_Action.typeOf
-		
+
 		let systemActionFullTypeName = try systemActionType.fullName?.string()
 		XCTAssertEqual("System.Action", systemActionFullTypeName)
 	}
-	
+
 	func testSystemAction() throws {
 		var numberOfTimesCalled = 0
-		
+
 		let closure: System_Action.ClosureType = {
 			numberOfTimesCalled += 1
 		}
-		
+
 		let action = System_Action(closure)
-		
+
 		XCTAssertEqual(0, numberOfTimesCalled)
-		
+
 		try action.invoke()
 		XCTAssertEqual(1, numberOfTimesCalled)
-		
+
 		try action.invoke()
 		try action.invoke()
 		try action.invoke()

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemArrayTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemArrayTests.swift
@@ -5,96 +5,96 @@ final class SystemArrayTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testGenericArray() throws {
         let now = try System_DateTime.now
-        
+
         let arrayOfDateTime = try DNArray<System_DateTime>(length: 1)
-        
+
         let expectedType = DNArray<System_DateTime>.typeOf
         let type = try arrayOfDateTime.getType()
         XCTAssertEqual(type, expectedType)
-        
+
         let typeName = DNArray<System_DateTime>.typeName
         XCTAssertEqual(typeName, "DateTime[]")
-        
+
         let fullTypeName = DNArray<System_DateTime>.fullTypeName
         XCTAssertEqual(fullTypeName, "System.DateTime[]")
-        
+
         let rank = try arrayOfDateTime.rank
         XCTAssertEqual(rank, 1)
-        
+
         let index: Int32 = 0
-        
+
         arrayOfDateTime[index] = now
         let retrievedNow = arrayOfDateTime[index]
-        
+
         let equals = now == retrievedNow
         XCTAssertTrue(equals)
-        
+
         XCTAssertThrowsError(try arrayOfDateTime.setValue("A System.String is not a System.DateTime".dotNETString(), index))
     }
-    
+
     func testSystemArray() throws {
         let now = try System_DateTime.now
         let dateTimeType = try now.getType()
-        
+
         let arrayLength: Int32 = 1
-        
+
         let arrayOfDateTime = try System_Array.createInstance(dateTimeType,
                                                               arrayLength)
-        
+
         let rank = try arrayOfDateTime.rank
         XCTAssertEqual(rank, 1)
-        
+
         let index: Int32 = 0
-        
+
         try arrayOfDateTime.setValue(now, index)
-        
+
         let retrievedNow = try arrayOfDateTime.getValue(index)
-        
+
         let equals = now == retrievedNow
         XCTAssertTrue(equals)
     }
-	
+
 	func testSystemArrayConvertedToIList() throws {
 		let now = try System_DateTime.now
 		let dateTimeType = try now.getType()
-		
+
 		let arrayLength: Int32 = 1
-		
+
         let arrayOfDateTime = try System_Array.createInstance(dateTimeType,
                                                               arrayLength)
-		
+
 		let index: Int32 = 0
-		
+
 		try arrayOfDateTime.item_set(index, now)
-		
+
 		let retrievedNow = try arrayOfDateTime.item(index)
-		
+
 		let equals = now == retrievedNow
 		XCTAssertTrue(equals)
 	}
-    
+
     func testEmptyArrayWithExtensionExplicitElementType() throws {
         let systemStringType = System_String.typeOf
-        
+
         let emptyArrayOfStrings = try DNArray<System_String>.empty
-        
+
         let expectedType = DNArray<System_String>.typeOf
         let type = try emptyArrayOfStrings.getType()
         XCTAssertEqual(type, expectedType)
-        
+
         let typeName = DNArray<System_String>.typeName
         XCTAssertEqual(typeName, "String[]")
-        
+
         let fullTypeName = DNArray<System_String>.fullTypeName
         XCTAssertEqual(fullTypeName, "System.String[]")
-        
+
         let length = try emptyArrayOfStrings.length
         XCTAssertEqual(0, .init(length))
 
@@ -107,16 +107,16 @@ final class SystemArrayTests: XCTestCase {
 
         let arrayElementTypeIsSystemString = arrayElementType == systemStringType
         XCTAssertTrue(arrayElementTypeIsSystemString)
-        
+
         let rank = try emptyArrayOfStrings.rank
         XCTAssertEqual(rank, 1)
     }
-    
+
     func testEmptyArrayWithExtensionOnExplicitArrayType() throws {
         let systemStringType = System_String.typeOf
-        
+
         let emptyArrayOfStrings = try DNArray<System_String>.empty
-        
+
         let length = try emptyArrayOfStrings.length
         XCTAssertEqual(0, .init(length))
 
@@ -130,12 +130,12 @@ final class SystemArrayTests: XCTestCase {
         let arrayElementTypeIsSystemString = arrayElementType == systemStringType
         XCTAssertTrue(arrayElementTypeIsSystemString)
     }
-    
+
     func testEmptyArrayWithInitializerOnExplicitArrayType() throws {
         let systemStringType = System_String.typeOf
-        
+
         let emptyArrayOfStrings = try DNArray<System_String>.empty
-        
+
         let length = try emptyArrayOfStrings.length
         XCTAssertEqual(0, .init(length))
 
@@ -149,7 +149,7 @@ final class SystemArrayTests: XCTestCase {
         let arrayElementTypeIsSystemString = arrayElementType == systemStringType
         XCTAssertTrue(arrayElementTypeIsSystemString)
     }
-    
+
     func testEmptyArrayWithGenerics() throws {
         let systemStringType = System_String.typeOf
 
@@ -168,7 +168,7 @@ final class SystemArrayTests: XCTestCase {
         let arrayElementTypeIsSystemString = arrayElementType == systemStringType
         XCTAssertTrue(arrayElementTypeIsSystemString)
     }
-    
+
     func testFillArrayWithGenerics() throws {
         let systemStringType = System_String.typeOf
 
@@ -178,7 +178,7 @@ final class SystemArrayTests: XCTestCase {
 
         let string = "Abc"
         let stringDN = string.dotNETString()
-        
+
         try System_Array.fill(T: systemStringType,
                               arrayOfString,
                               stringDN)
@@ -190,7 +190,7 @@ final class SystemArrayTests: XCTestCase {
             XCTAssertEqual(string, stringElement.string())
         }
     }
-    
+
     func testReverseArrayWithGenerics() throws {
         let systemStringType = System_String.typeOf
 
@@ -205,10 +205,10 @@ final class SystemArrayTests: XCTestCase {
 
         for (idx, string) in strings.enumerated() {
             let stringDN = string.dotNETString()
-            
+
             arrayOfString[Int32(idx)] = stringDN
         }
-        
+
         try System_Array.reverse(T: systemStringType,
                                  arrayOfString)
 
@@ -222,115 +222,115 @@ final class SystemArrayTests: XCTestCase {
             XCTAssertEqual(expectedString, stringElement)
         }
     }
-	
+
 	func testSystemArrayIterator() throws {
 		let length: Int32 = 10
-		
+
         let arrayOfInt32 = try DNArray<System_Int32>(length: length)
-		
+
 		var int32s = [Int32]()
-		
+
 		for idx in 0..<length {
 			let randomInt32 = Int32.random(in: Int32.min..<Int32.max)
             let randomInt32Obj = randomInt32.dotNETObject()
-			
+
             arrayOfInt32[idx] = randomInt32Obj
-			
+
 			int32s.append(randomInt32)
 		}
-        
+
 		for (idx, int32Obj) in arrayOfInt32.enumerated() {
 			guard let int32 = try? int32Obj.value else {
 				XCTFail("Object in array is not a Int32")
-				
+
 				return
 			}
-			
+
 			XCTAssertEqual(int32, int32s[idx])
 		}
 	}
-	
+
 	func testSystemArraySubscript() throws {
 		let strings = [
 			"Hello",
 			"World"
 		]
-		
+
         let arrayOfString = try DNArray<System_String>(length: .init(strings.count))
-        
+
 		for (idx, string) in strings.enumerated() {
 			try arrayOfString.setValue(string.dotNETString(), Int32(idx))
 		}
-        
+
         let firstObject = arrayOfString[0]
-		
+
 		guard let firstString = firstObject.castAs(System_String.self)?.string() else {
 			XCTFail("Failed to retrieve first object or cast as string")
-			
+
 			return
 		}
-		
+
 		XCTAssertEqual(strings[0], firstString)
-		
+
         let secondObject = arrayOfString[1]
-        
+
 		guard let secondString = secondObject.castAs(System_String.self)?.string() else {
 			XCTFail("Failed to retrieve second object or cast as string")
-			
+
 			return
 		}
-		
+
 		XCTAssertEqual(strings[1], secondString)
 	}
-    
+
     func testMutatingSystemArray() throws {
         let strings = [
             "Hello",
             "World"
         ]
-        
+
         let arrayOfString = try DNArray<System.String>(length: .init(strings.count))
-        
+
         for (idx, string) in strings.enumerated() {
             arrayOfString[.init(idx)] = string.dotNETString()
         }
-        
+
         for (idx, stringDN) in arrayOfString.enumerated() {
             let convertedString = stringDN.string()
             let originalString = strings[idx]
-            
+
             XCTAssertEqual(convertedString, originalString)
         }
-        
+
         let newStringAtIdxOne = "New World"
-        
+
         arrayOfString[1] = newStringAtIdxOne.dotNETString()
-        
+
         XCTAssertEqual(arrayOfString[1].castAs(System.String.self)?.string(), newStringAtIdxOne)
     }
-    
+
     func testIteratingArrayPerformance() throws {
         let count: Int32 = 10_000
-        
+
         var values = [System.Object]()
-        
+
         let systemArray = try DNArray<System.Object>(length: count)
-        
+
         for idx in 0..<count {
             let obj = try System.Object()
-            
+
             values.append(obj)
             systemArray[idx] = obj
         }
-        
+
         XCTAssertEqual(systemArray.count, values.count)
-        
+
         for (idx, obj) in systemArray.enumerated() {
             let expectedObj = values[idx]
-            
+
             XCTAssertTrue(obj === expectedObj)
         }
-        
+
         measure {
             for obj in systemArray {
                 // Aka PleaseDontOptimizeThisOut

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemBuffersBinaryBinaryPrimitivesTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemBuffersBinaryBinaryPrimitivesTests.swift
@@ -5,31 +5,31 @@ final class SystemBuffersBinaryBinaryPrimitivesTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testReadInt64() throws {
         let value = Int64.max
         let valueData = value.data
-        
+
         let valueRet = try System.Buffers.Binary.BinaryPrimitives.readInt64LittleEndian(valueData)
         XCTAssertEqual(value, valueRet)
     }
-    
+
     func testTryReadUInt32() throws {
         let value = UInt32.max
         let valueData = value.data
-        
+
         var valueRet: UInt32 = .min
-        
+
         guard try System.Buffers.Binary.BinaryPrimitives.tryReadUInt32LittleEndian(valueData, &valueRet) else {
             XCTFail("System.Buffers.Binary.BinaryPrimitives.TryReadUInt32LittleEndian should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(value, valueRet)
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemCollectionsGenericDictionaryTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemCollectionsGenericDictionaryTests.swift
@@ -5,53 +5,53 @@ final class SystemCollectionsGenericDictionaryTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testCreate() throws {
         let systemStringType = System_String.typeOf
         let systemExceptionType = System_Exception.typeOf
-        
+
         let dictionary = try System_Collections_Generic_Dictionary_A2(TKey: systemStringType,
                                                                       TValue: systemExceptionType)
-        
+
         let dictionaryType = try dictionary.getType()
-        
+
         guard let dictionaryTypeName = try? dictionaryType.fullName?.string() else {
             XCTFail("System.Type.FullName getter should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertTrue(dictionaryTypeName.contains("System.Collections.Generic.Dictionary`2[[System.String"))
         XCTAssertTrue(dictionaryTypeName.contains(",[System.Exception"))
     }
-    
+
     func testUse() throws {
         let systemStringType = System_String.typeOf
         let systemExceptionType = System_Exception.typeOf
-        
+
         let dictionary = try System_Collections_Generic_Dictionary_A2(TKey: systemStringType,
                                                                       TValue: systemExceptionType)
 
         let exceptionMessage = "My Exception Message"
         let exceptionMessageDN = exceptionMessage.dotNETString()
-        
+
         let exceptionValue = try System_Exception(exceptionMessageDN)
-        
+
         guard try dictionary.tryAdd(TKey: systemStringType,
                                     TValue: systemExceptionType,
                                     exceptionMessageDN,
                                     exceptionValue) else {
             XCTFail("System.Collections.Generic.Dictionary<System.String, System.Exception>.TryAdd should not throw and return true")
-            
+
             return
         }
-        
+
         let emptyString = System_String.empty
-        
+
         var valueForEmptyString: System_Object?
 
         guard !(try dictionary.tryGetValue(TKey: systemStringType,
@@ -63,7 +63,7 @@ final class SystemCollectionsGenericDictionaryTests: XCTestCase {
 
             return
         }
-		
+
         guard let valueRet = try dictionary.item(TKey: systemStringType,
                                                  TValue: systemExceptionType,
                                                  exceptionMessageDN) else {

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemCollectionsGenericListTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemCollectionsGenericListTests.swift
@@ -5,112 +5,112 @@ final class SystemCollectionsGenericListTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testTypeOf() throws {
         let systemTypeType = System_Type.typeOf
         let type = System_Collections_Generic_List_A1.typeOf
-        
+
         let isGenericType = try type.isGenericType
         XCTAssertTrue(isGenericType)
-        
+
         let isConstructedGenericType = try type.isConstructedGenericType
         XCTAssertFalse(isConstructedGenericType)
-        
+
         let genericArguments = try type.getGenericArguments()
         let numberOfGenericArguments = try genericArguments.length
         XCTAssertEqual(1, numberOfGenericArguments)
-        
+
         let genericArgument = genericArguments[0]
-        
+
         XCTAssertTrue(genericArgument.is(systemTypeType))
-        
+
         guard let genericArgumentType = genericArgument.castAs(System_Type.self) else {
             XCTFail("Should be convertible to System.Type")
-            
+
             return
         }
-        
+
         let genericArgumentTypeName = try genericArgumentType.name.string()
         XCTAssertEqual("T", genericArgumentTypeName)
     }
-    
+
     func testCreate() throws {
         let systemStringType = System_String.typeOf
-        
+
         let list = try System_Collections_Generic_List_A1(T: systemStringType)
         let listType = try list.getType()
-        
+
         guard let listTypeName = try listType.fullName?.string() else {
             XCTFail("System.Type.FullName getter should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertTrue(listTypeName.contains("System.Collections.Generic.List`1[[System.String"))
     }
-    
+
     func testUse() throws {
         let systemStringType = System_String.typeOf
-        
+
         let list = try System_Collections_Generic_List_A1(T: systemStringType)
-        
+
         let strings = [
             "01. A",
             "02. B",
             "03. C"
         ]
-        
+
         for string in strings {
             let stringDN = string.dotNETString()
-            
+
             try list.add(T: systemStringType,
                          stringDN)
         }
-        
+
         let listCount = try list.count(T: systemStringType)
         XCTAssertEqual(strings.count, .init(listCount))
-        
+
         for idx in 0..<listCount {
             guard let element = try? list.item(T: systemStringType,
                                                idx) else {
                 XCTFail("System.Collections.Generic.List<System.String>[] getter not throw and return an instance")
-                
+
                 return
             }
-            
+
             XCTAssertTrue(element.is(systemStringType))
-            
+
             guard let elementString = element.castAs(System_String.self)?.string() else {
                 XCTFail("Failed to get string")
-                
+
                 return
             }
-            
+
             let expectedString = strings[.init(idx)]
-            
+
             XCTAssertEqual(expectedString, elementString)
         }
-		
+
 		let idx1: Int32 = 1
-		
+
 		let newStringForIdx1 = "New String"
 		let newStringForIdx1DN = newStringForIdx1.dotNETString()
-		
+
         try list.item_set(T: systemStringType,
                           idx1,
                           newStringForIdx1DN)
-		
+
         guard let newElement1String = try? list.item(T: systemStringType,
                                                      idx1)?.castAs(System_String.self)?.string() else {
 			XCTFail("System.Collections.Generic.List<System.String>[] getter not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertEqual(newStringForIdx1, newElement1String)
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemConvertTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemConvertTests.swift
@@ -5,78 +5,78 @@ final class SystemConvertTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testBooleanConversion() throws {
         let trueStringDN = "true".dotNETString()
         let falseStringDN = "false".dotNETString()
         let nonsenseStringDN = "nonsense".dotNETString()
-        
+
         let result1 = try System.Convert.toBoolean(trueStringDN)
         XCTAssertTrue(result1)
-        
+
         let result2 = try System.Convert.toBoolean(falseStringDN)
         XCTAssertFalse(result2)
-        
+
         do {
             let _ = try System_Convert.toBoolean(nonsenseStringDN)
-            
+
             XCTFail("System.Convert.ToBoolean should throw")
         } catch { }
     }
-    
+
     func testIntegerConversion() throws {
         let number1: Int32 = 123456789
         let number1StringDN = "\(number1)".dotNETString()
-        
+
         XCTAssertEqual(number1,
                        try System.Convert.toInt32(number1StringDN))
-        
+
         let number2: Int64 = -123456789
         let number2StringDN = "\(number2)".dotNETString()
-        
+
         XCTAssertEqual(number2,
                        try System.Convert.toInt64(number2StringDN))
-        
+
         let number3StringDN = "nonsense".dotNETString()
         XCTAssertThrowsError(try System.Convert.toInt64(number3StringDN))
-        
+
         let number4StringDN = "nonsense".dotNETString()
         XCTAssertThrowsError(try System.Convert.toUInt64(number4StringDN))
     }
-    
+
     func testBase64Conversion() throws {
         let text = "Hello World!"
         let textDN = text.dotNETString()
-        
+
         let utf8Encoding = try System_Text_Encoding.uTF8
         let textBytes = try utf8Encoding.getBytes(textDN)
         let textAsBase64StringDN = try System_Convert.toBase64String(textBytes)
         let textAsBase64String = textAsBase64StringDN.string()
-        
+
         guard let textAsBase64Data = textAsBase64String.data(using: .utf8) else {
             XCTFail("Failed to convert base64 string to data")
-            
+
             return
         }
-        
+
         guard let textData = Data(base64Encoded: textAsBase64Data) else {
             XCTFail("Failed to decode base64 encoded data")
-            
+
             return
         }
-        
+
         guard let decodedText = String(data: textData, encoding: .utf8) else {
             XCTFail("Failed to decode text data to string")
-            
+
             return
         }
-        
+
         XCTAssertEqual(text, decodedText)
-        
+
         let textBytesRet = try System_Convert.fromBase64String(textAsBase64StringDN)
         let textRet = try utf8Encoding.getString(textBytesRet).string()
         XCTAssertEqual(text, textRet)

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemDateTimeTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemDateTimeTests.swift
@@ -5,18 +5,18 @@ final class SystemDateTimeTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testSystemDateTime() throws {
         let nowSwift = Date()
         let calendar = Calendar.current
-        
+
         let components = calendar.dateComponents([ .year, .month, .day, .hour, .minute, .second ],
                                                  from: nowSwift)
-        
+
         guard let expectedYear = components.year,
               let expectedMonth = components.month,
               let expectedDay = components.day,
@@ -24,38 +24,38 @@ final class SystemDateTimeTests: XCTestCase {
               let expectedMinute = components.minute,
               let expectedSecond = components.second else {
             XCTFail("Failed to get year/month/day hour/minute/second")
-            
+
             return
         }
-        
+
         let nowDotNet = try System_DateTime(.init(expectedYear),
                                             .init(expectedMonth),
                                             .init(expectedDay),
                                             .init(expectedHour),
                                             .init(expectedMinute),
                                             .init(expectedSecond))
-        
+
         let year = try nowDotNet.year
         let month = try nowDotNet.month
         let day = try nowDotNet.day
         let hour = try nowDotNet.hour
         let minute = try nowDotNet.minute
-        
+
         XCTAssertEqual(expectedYear, .init(year))
         XCTAssertEqual(expectedMonth, .init(month))
         XCTAssertEqual(expectedDay, .init(day))
-        
+
         XCTAssertEqual(expectedHour, .init(hour))
         XCTAssertEqual(expectedMinute, .init(minute))
     }
-    
+
     func testSystemDateTimeParse() throws {
         let nowSwift = Date()
         let calendar = Calendar.current
-        
+
         let components = calendar.dateComponents([ .year, .month, .day, .hour, .minute, .second ],
                                                  from: nowSwift)
-        
+
         guard let expectedYear = components.year,
               let expectedMonth = components.month,
               let expectedDay = components.day,
@@ -63,59 +63,59 @@ final class SystemDateTimeTests: XCTestCase {
               let expectedMinute = components.minute,
               let expectedSecond = components.second else {
             XCTFail("Failed to get year/month/day hour/minute/second")
-            
+
             return
         }
-        
+
         let cultureNameDN = "en-US".dotNETString()
-        
+
         guard let enUSCulture = try? System_Globalization_CultureInfo(cultureNameDN) else {
             XCTFail("System.CultureInfo ctor should not throw and return an instance")
-            
+
             return
         }
-        
+
         let dateString = "\(expectedMonth)/\(expectedDay)/\(expectedYear) \(expectedHour):\(expectedMinute):\(expectedSecond)"
         let dateStringDN = dateString.dotNETString()
-        
+
         var nowDotNet = System_DateTime.minValue
-        
+
         guard try System_DateTime.tryParse(dateStringDN,
                                            enUSCulture,
                                            &nowDotNet) else {
             XCTFail("System.DateTime.TryParse should return true, an instance as out parameter and not throw")
-            
+
             return
         }
-        
+
         let year = try nowDotNet.year
         let month = try nowDotNet.month
         let day = try nowDotNet.day
         let hour = try nowDotNet.hour
         let minute = try nowDotNet.minute
-        
+
         XCTAssertEqual(expectedYear, .init(year))
         XCTAssertEqual(expectedMonth, .init(month))
         XCTAssertEqual(expectedDay, .init(day))
-        
+
         XCTAssertEqual(expectedHour, .init(hour))
         XCTAssertEqual(expectedMinute, .init(minute))
     }
-    
+
     func testDateConversion() throws {
         let referenceSwiftDate = Date(timeIntervalSince1970: 0)
-        
+
         let dateTime = try System.DateTime(1970, 1, 1, 0, 0, 0, 0, 0, .utc)
-        
+
         let dateTimeMinValue = System.DateTime.minValue
-        
+
         let retDate = try dateTime.swiftDate()
-        
+
         XCTAssertEqual(retDate, referenceSwiftDate)
         XCTAssertNotEqual(retDate, .init())
-        
+
         let retDateTime = try retDate.dotNETDateTime()
-        
+
         XCTAssertTrue(retDateTime == dateTime)
         XCTAssertFalse(retDateTime == dateTimeMinValue)
     }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemDecimalTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemDecimalTests.swift
@@ -5,90 +5,90 @@ final class SystemDecimalTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testDecimalParse() throws {
         let number = 1234
         let numberString = "\(number)"
         let numberStringDN = numberString.dotNETString()
-        
+
         var decimal = System_Decimal.minValue
-        
+
         guard try System_Decimal.tryParse(numberStringDN,
                                           &decimal) else {
             XCTFail("System.Decimal.TryParse should not throw, return true and an instance as out parameter")
-            
+
             return
         }
-        
+
         let numberRet = try System_Decimal.toInt64(decimal)
         XCTAssertEqual(number, .init(numberRet))
-        
+
         let numberStringRet = try decimal.toString().string()
         XCTAssertEqual(numberString, numberStringRet)
     }
-    
+
     func testDecimalCalculations() throws {
         let number1: UInt64 = 123
         let number2: UInt64 = 321
-        
+
         let addResult = number1 + number2
         let subtractResult = number2 - number1
         let multiplyResult = number1 * number2
         let divideResult = number2 / number1
-        
+
         let decimal1 = try System_Decimal(number1)
         let decimal2 = try System_Decimal(number2)
-        
+
         let addResultDecimal = try System_Decimal.add(decimal1,
                                                       decimal2)
-        
+
         let addResultRet = try System_Decimal.toUInt64(addResultDecimal)
         XCTAssertEqual(addResult, addResultRet)
-        
+
         let subtractResultDecimal = try System_Decimal.subtract(decimal2,
                                                                 decimal1)
-        
+
         let subtractResultRet = try System_Decimal.toUInt64(subtractResultDecimal)
         XCTAssertEqual(subtractResult, subtractResultRet)
-        
+
         let multiplyResultDecimal = try System_Decimal.multiply(decimal1,
                                                                 decimal2)
-        
+
         let multiplyResultRet = try System_Decimal.toUInt64(multiplyResultDecimal)
         XCTAssertEqual(multiplyResult, multiplyResultRet)
-        
+
         let divideResultDecimal = try System_Decimal.divide(decimal2,
                                                              decimal1)
-        
+
         let divideResultRet = try System_Decimal.toUInt64(divideResultDecimal)
         XCTAssertEqual(divideResult, divideResultRet)
     }
-    
+
     func testDivisionByZero() throws {
         let decimalZero = System_Decimal.zero
-        
+
         let number1: Int32 = 123
-        
+
         let decimal1 = try System_Decimal(number1)
-        
+
         do {
             let _ = try System_Decimal.divide(decimal1,
                                               decimalZero)
-            
+
             XCTFail("System.Decimal.Divide should throw when dividing by zero and not return a value")
         } catch {
             guard error is DNError else {
                 XCTFail("Error should be of DNError type")
-                
+
                 return
             }
-            
+
             let errorMessage = error.localizedDescription
-            
+
             XCTAssertTrue(errorMessage.contains("divide by zero"))
         }
     }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemEnumTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemEnumTests.swift
@@ -5,11 +5,11 @@ final class SystemEnumTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testSystemEnum() throws {
         let systemDateTimeKindType = System_DateTimeKind.typeOf
 
@@ -19,7 +19,7 @@ final class SystemEnumTests: XCTestCase {
         XCTAssertEqual(3, namesCount)
 
         var names = [String]()
-        
+
         for enumNameDN in enumNames {
             let enumName = enumNameDN.string()
 
@@ -33,17 +33,17 @@ final class SystemEnumTests: XCTestCase {
         XCTAssertEqual(unspecified, names[0])
         XCTAssertEqual(utc, names[1])
         XCTAssertEqual(local, names[2])
-        
+
         XCTAssertEqual(System_DateTimeKind.unspecified.rawValue, 0)
         XCTAssertEqual(System_DateTimeKind.utc.rawValue, 1)
         XCTAssertEqual(System_DateTimeKind.local.rawValue, 2)
-        
+
         XCTAssertEqual(System_DateTimeKind(rawValue: System_DateTimeKind.unspecified.rawValue),
                        System_DateTimeKind.unspecified)
-        
+
         XCTAssertEqual(System_DateTimeKind(rawValue: System_DateTimeKind.utc.rawValue),
                        System_DateTimeKind.utc)
-        
+
         XCTAssertEqual(System_DateTimeKind(rawValue: System_DateTimeKind.local.rawValue),
                        System_DateTimeKind.local)
     }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemExceptionTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemExceptionTests.swift
@@ -5,17 +5,17 @@ final class SystemExceptionTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testSystemException() throws {
         let exceptionMessage = "I'm a nice exception"
-        
+
         let createdException = try System_Exception(exceptionMessage.dotNETString())
         let retrievedExceptionMessage = try createdException.message.string()
-        
+
         XCTAssertEqual(exceptionMessage, retrievedExceptionMessage)
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemGuidTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemGuidTests.swift
@@ -5,152 +5,152 @@ final class SystemGuidTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testSystemGuid() throws {
         let uuid = UUID()
-        
+
         let uuidString = uuid.uuidString
         let uuidStringDN = uuidString.dotNETString()
-        
+
         let guid = try System_Guid(uuidStringDN)
         let guidString = try guid.toString().string()
-        
+
         XCTAssertEqual(uuidString.lowercased(), guidString.lowercased())
-        
+
         let guidTypeName = "System.Guid"
         let guidTypeNameDN = guidTypeName.dotNETString()
-        
+
         let guidType = try System_Type.getType(guidTypeNameDN)
         let guidTypeFromInstance = try guid.getType()
-        
+
         let equals = guidType == guidTypeFromInstance
         XCTAssertTrue(equals)
-        
+
         let emptyGuid = System_Guid.empty
-        
+
         let emptyGuidString = try emptyGuid.toString().string()
-        
+
         XCTAssertEqual("00000000-0000-0000-0000-000000000000", emptyGuidString)
     }
-    
+
     func testSystemGuidParameterlessConstructor() throws {
         let guid = try System_Guid()
         let emptyGuid = System_Guid.empty
-        
+
         XCTAssertTrue(guid == emptyGuid)
-        
+
         let guidString = try guid.toString().string()
         let emptyGuidString = try emptyGuid.toString().string()
-        
+
         XCTAssertEqual(guidString.lowercased(), emptyGuidString.lowercased())
     }
-    
+
     func testSystemGuidParsing() throws {
         let uuid = UUID()
-        
+
         let uuidString = uuid.uuidString
         let uuidStringDN = uuidString.dotNETString()
-        
+
         var guid = System_Guid.empty
-        
+
         guard try System_Guid.tryParse(uuidStringDN, &guid) else {
             XCTFail("System.Guid.TryParse should not throw and return an instance as out parameter")
-            
+
             return
         }
-        
+
         let uuidStringRet = try guid.toString().string()
-        
+
         XCTAssertEqual(uuidString.lowercased(), uuidStringRet.lowercased())
     }
-    
+
     func testInvalidSystemGuidParsing() throws {
         let emptyGuid = System_Guid.empty
-        
+
         let uuidString = "nonsense"
         let uuidStringDN = uuidString.dotNETString()
-        
+
         var guid = System_Guid.empty
-        
+
         guard !(try System_Guid.tryParse(uuidStringDN, &guid)) else {
             XCTFail("System.Guid.TryParse should not throw, the return value should be false and the returned instance as out parameter should be an empty System.Guid")
-            
+
             return
         }
-        
+
         let equal = emptyGuid == guid
         XCTAssertTrue(equal)
     }
-    
+
     func testSwiftUUIDConversion() throws {
         let uuidString = "7F579986-D12F-4889-9A14-FDE340A59E08"
-        
+
         var guid = System_Guid.empty
-        
+
         guard try System_Guid.tryParse(uuidString.dotNETString(),
                                        &guid) else {
             XCTFail("System.Guid.TryParse should not throw, return true and an instance as out parameter")
-            
+
             return
         }
-        
+
         let guidString = try guid.toString().string()
-        
+
         XCTAssertEqual(uuidString.lowercased(), guidString.lowercased())
-        
+
         guard let uuid = UUID(uuidString: guidString) else {
             XCTFail("Should be able to form a UUID from a System.Guid's string")
-            
+
             return
         }
-        
+
         let uuidStringRet = uuid.uuidString
-        
+
         XCTAssertEqual(uuidString.lowercased(), uuidStringRet.lowercased())
     }
-	
+
 	func testSwiftUUIDConversionWithExtensions() throws {
 		let iterations = 100
-		
+
 		// System.Guid -> UUID
 		for _ in 0..<iterations {
 			let newGuid = try System_Guid.newGuid()
-			
+
 			guard let uuidRet = newGuid.uuid() else {
 				XCTFail("Should be able to convert a System.Guid to a Swift UUID")
-				
+
 				return
 			}
-			
+
 			let newGuidString = try newGuid.toString().string()
-			
+
 			let uuidRetString = uuidRet.uuidString
-			
+
 			XCTAssertEqual(newGuidString.lowercased(), uuidRetString.lowercased())
 		}
-		
+
 		// UUID -> System.Guid
 		for _ in 0..<iterations {
 			let newUUID = UUID()
-			
+
 			guard let guidRet = newUUID.dotNETGuid() else {
 				XCTFail("Should be able to convert a Swift UUID to a System.Guid")
-				
+
 				return
 			}
-			
+
 			let guidRetString = try guidRet.toString().string()
-			
+
 			let newUUIDString = newUUID.uuidString
-			
+
 			XCTAssertEqual(newUUIDString.lowercased(), guidRetString.lowercased())
 		}
 	}
-    
+
     // MARK: - Performance Tests
 //    private let numberOfIDs = 100_000
 //
@@ -158,65 +158,65 @@ final class SystemGuidTests: XCTestCase {
 //        let guid = try System.Guid.newGuid()
 //        let guidStrDN = try guid.toString()
 //        let guidStr = guidStrDN.string()
-//        
+//
 //        return guidStr
 //    }
-//    
+//
 //    private func makeUUIDString() -> String {
 //        let uuid = UUID()
 //        let uuidStr = uuid.uuidString
-//        
+//
 //        return uuidStr
 //    }
 //
 //
 //    func testSystemGuidPerformance() throws {
 //        let numberOfIDs = self.numberOfIDs
-//        
+//
 //        measure {
 //            for _ in 0..<numberOfIDs {
 //                _ = try? makeGuidString()
 //            }
 //        }
 //    }
-//    
+//
 //    func testUUIDPerformance() throws {
 //        let numberOfIDs = self.numberOfIDs
-//        
+//
 //        measure {
 //            for _ in 0..<numberOfIDs {
 //                _ = makeUUIDString()
 //            }
 //        }
 //    }
-//    
+//
 //    func testGuidToUUIDPerformance() throws {
 //        let numberOfIDs = self.numberOfIDs
-//        
+//
 //        var guids = [System.Guid]()
-//        
+//
 //        for _ in 0..<numberOfIDs {
 //            let newGuid = try System.Guid.newGuid()
 //            guids.append(newGuid)
 //        }
-//        
+//
 //        measure {
 //            for guid in guids {
 //                _ = guid.uuid()
 //            }
 //        }
 //    }
-//    
+//
 //    func testUUIDToGuidPerformance() throws {
 //        let numberOfIDs = self.numberOfIDs
-//        
+//
 //        var uuids = [UUID]()
-//        
+//
 //        for _ in 0..<numberOfIDs {
 //            let newUUID = UUID()
 //            uuids.append(newUUID)
 //        }
-//        
+//
 //        measure {
 //            for uuid in uuids {
 //                _ = uuid.dotNETGuid()

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemIOPathTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemIOPathTests.swift
@@ -5,44 +5,44 @@ final class SystemIOPathTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testPath() throws {
         let dirPath = "/some/path"
         let dirPathDN = dirPath.dotNETString()
-        
+
         let fileName = "a file.txt"
         let fileNameDN = fileName.dotNETString()
-        
+
         let expectedFilePath = (dirPath as NSString).appendingPathComponent(fileName)
         let expectedFilePathDN = expectedFilePath.dotNETString()
-        
+
         let expectedFileExtension = ".\((expectedFilePath as NSString).pathExtension)"
         let expectedFileNameWithoutExtension = (fileName as NSString).deletingPathExtension
-        
+
         let filePathDN = try System_IO_Path.combine(dirPathDN,
                                                     fileNameDN)
-        
+
         let filePath = filePathDN.string()
         XCTAssertEqual(expectedFilePath, filePath)
-        
+
         guard let fileExtension = try? System_IO_Path.getExtension(filePathDN)?.string() else {
             XCTFail("System.IO.Path.GetExtension should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(expectedFileExtension, fileExtension)
-        
+
         guard let fileNameWithoutExtension = try? System_IO_Path.getFileNameWithoutExtension(expectedFilePathDN)?.string() else {
             XCTFail("System.IO.Path.GetFileNameWithoutExtension should not throw and return an instance of a C String")
-            
+
             return
         }
-        
+
         XCTAssertEqual(expectedFileNameWithoutExtension, fileNameWithoutExtension)
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemMathTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemMathTests.swift
@@ -5,11 +5,11 @@ final class SystemMathTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testMath() throws {
         XCTAssertEqual(599, try System_Math.abs(Int64(-599)))
         XCTAssertEqual(599.995, try System_Math.abs(-599.995))

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemObjectTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemObjectTests.swift
@@ -5,38 +5,38 @@ final class SystemObjectTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testSystemObject() throws {
         let systemObjectType = System.Object.typeOf
-        
+
         let object1 = try System.Object()
         let object1Type = try object1.getType()
-        
+
         guard systemObjectType == object1Type else {
             XCTFail("System.Object.Equals should not throw and return true")
-            
+
             return
         }
-        
+
         let object2 = try System.Object()
-        
+
         guard object1 != object2 else {
             XCTFail("System.Object.Equals should not throw and return false")
-            
+
             return
         }
-        
+
         guard object1 !== object2 else {
             XCTFail("System.Object.ReferenceEquals should not throw and return false")
-            
+
             return
         }
     }
-    
+
     func testCreatingAndDestroyingManyObjects() {
         measure {
             let numberOfObjects = 10_000
@@ -48,17 +48,17 @@ final class SystemObjectTests: XCTestCase {
                     return
                 }
             }
-            
+
             do {
                 try System.GC.collect()
             } catch {
                 XCTFail("System.GC.Collect should not throw")
-                
+
                 return
             }
         }
     }
-    
+
     func testCreatingAndDestroyingManyObjectsByInstantlyCollectingGC() {
         measure {
             let numberOfObjects = 500
@@ -67,24 +67,24 @@ final class SystemObjectTests: XCTestCase {
                 {
                     guard let _ = try? System.Object() else {
                         XCTFail("System.Object ctor should not throw and return an instance")
-                        
+
                         return
                     }
                 }()
-                
+
                 do {
                     try System.GC.collect()
                 } catch {
                     XCTFail("System.GC.Collect should not throw")
-                    
+
                     return
                 }
-                
+
                 do {
                     try System.GC.waitForPendingFinalizers()
                 } catch {
                     XCTFail("System.GC.WaitForPendingFinalizers should not throw")
-                    
+
                     return
                 }
             }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemRandomTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemRandomTests.swift
@@ -5,23 +5,23 @@ final class SystemRandomTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testRandom() throws {
         let random = try System_Random()
-        
+
         let minValue: Int32 = 5
         let maxValue: Int32 = 15
-        
+
         for _ in 0..<200 {
             let value: Int32
-            
+
             value = try random.next(minValue,
                                     maxValue)
-            
+
             XCTAssertGreaterThanOrEqual(value, minValue)
             XCTAssertLessThan(value, maxValue)
         }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemReflectionAssemblyTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemReflectionAssemblyTests.swift
@@ -5,39 +5,39 @@ final class SystemReflectionAssemblyTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testAssembly() throws {
         let assembly = try System_Reflection_Assembly.getExecutingAssembly()
         let assemblyName = try assembly.getName()
         let assemblyNameString = try assemblyName.name?.string()
-        
+
         XCTAssertEqual("BeyondDotNETSampleKit", assemblyNameString)
     }
-    
+
     func testLoadAssembly() throws {
         let data = Data([ 0, 1 ])
         let byteArray = try data.dotNETByteArray()
-        
+
         do {
             _ = try System_Reflection_Assembly.load(byteArray)
-            
+
             XCTFail("System.Reflection.Assembly.Load should throw but did not")
         } catch {
             guard let dnError = error as? DNError else {
                 XCTFail("System.Reflection.Assembly.Load should throw an DNError but did not")
-                
+
                 return
             }
-            
+
             let ex = dnError.exception
-            
+
             guard ex.is(System_PlatformNotSupportedException.typeOf) else {
                 XCTFail("System.Reflection.Assembly.Load should throw a System.PlatformNotSupportedException but did not")
-                
+
                 return
             }
         }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemRuntimeInteropServicesMarshalTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemRuntimeInteropServicesMarshalTests.swift
@@ -10,7 +10,7 @@ final class SystemRuntimeInteropServicesMarshalTests: XCTestCase {
         static let kb200    = 200 * 1024
         static let kb250    = 250 * 1024
         static let kb500    = 500 * 1024
-        
+
         static let mb1      =   1 * 1024 * 1024
         static let mb10     =  10 * 1024 * 1024
         static let mb50     =  50 * 1024 * 1024
@@ -18,42 +18,42 @@ final class SystemRuntimeInteropServicesMarshalTests: XCTestCase {
         static let mb200    = 200 * 1024 * 1024
         static let mb250    = 250 * 1024 * 1024
         static let mb500    = 500 * 1024 * 1024
-        
+
         static let gb1      = 1 * 1024 * 1024 * 1024
     }
-    
+
     private let correctnessTestsByteCount = Bytes.kb1
-    
+
     // NOTE: Since the .NET runtime likes to raise SIGUSR1 (which makes lldb halt execution) when using higher numbers here, we set it to a relatively number.
     // Feel free to increase the byte count but don't forget to tell lldb to ignore SIGUSR1 before running the tests (`process handle SIGUSR1 -n true -p true -s false`).
     private let performanceTestsByteCount = Bytes.kb500
-    
+
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testSwiftDataToSystemByteArray() throws {
         let dataCount = Int32(correctnessTestsByteCount)
-        
+
         guard let data = Data.randomData(count: .init(dataCount)) else {
             XCTFail("Failed to generate random data")
-            
+
             return
         }
-        
+
         let systemByteArray = try DNArray<System_Byte>(length: dataCount)
-        
+
         data.withUnsafeBytes {
             guard let unsafeBytesPointer = $0.baseAddress else {
                 XCTFail("Failed to get unsafe bytes")
-                
+
                 return
             }
-            
+
             do {
                 try System.Runtime.InteropServices.Marshal.copy(.init(mutating: unsafeBytesPointer),
                                                                 systemByteArray,
@@ -61,91 +61,91 @@ final class SystemRuntimeInteropServicesMarshalTests: XCTestCase {
                                                                 dataCount)
             } catch {
                 XCTFail("System.Runtime.InteropServices.Marshal.Copy should not throw")
-                
+
                 return
             }
         }
-        
+
         validateSystemByteArray(systemByteArray,
                                 matchesData: data)
     }
-    
+
     func testSwiftDataToSystemByteArrayWithExtension() throws {
         let dataCount = correctnessTestsByteCount
-        
+
         guard let data = Data.randomData(count: dataCount) else {
             XCTFail("Failed to generate random data")
-            
+
             return
         }
-        
+
         let systemByteArray = try data.dotNETByteArray()
-        
+
         validateSystemByteArray(systemByteArray,
                                 matchesData: data)
     }
-    
+
     func testPerformanceOfSwiftDataToSystemByteArray() {
         let dataCount = performanceTestsByteCount
-        
+
         guard let data = Data.randomData(count: dataCount) else {
             XCTFail("Failed to generate random data")
-            
+
             return
         }
-        
+
         var systemByteArray: DNArray<System_Byte>?
-        
+
         measure {
             systemByteArray = try? data.dotNETByteArray()
         }
-        
+
         guard let systemByteArray else {
             XCTFail("Swift Data.dotNETByteArray should not throw and return an instance")
-            
+
             return
         }
-        
+
         guard let systemByteArrayLength = try? systemByteArray.length else {
             XCTFail("byte[].Length should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(.init(systemByteArrayLength), dataCount)
     }
-    
+
     func testEmptySwiftDataToSystemByteArrayWithExtension() throws {
         let data = Data()
-        
+
         let systemByteArray = try data.dotNETByteArray()
-        
+
         validateSystemByteArray(systemByteArray,
                                 matchesData: data)
     }
-    
+
     func testSystemByteArrayToSwiftData() throws {
         let bytesCount = correctnessTestsByteCount
-        
+
         guard let systemByteArray = try randomSystemByteArray(count: bytesCount) else {
             XCTFail("System.Array should be possible to cast to byte[]")
-            
+
             return
         }
-        
+
         let systemByteArrayLength = try systemByteArray.length
-        
+
         XCTAssertEqual(.init(systemByteArrayLength), bytesCount)
-        
+
         var data = Data(count: .init(systemByteArrayLength))
-        
+
         data.withUnsafeMutableBytes {
             guard let unsafeBytesPointer = $0.baseAddress else {
                 XCTFail("Failed to get unsafe bytes")
-                
+
                 return
             }
-            
+
             do {
                 try System.Runtime.InteropServices.Marshal.copy(systemByteArray,
                                                                 0,
@@ -153,97 +153,97 @@ final class SystemRuntimeInteropServicesMarshalTests: XCTestCase {
                                                                 systemByteArrayLength)
             } catch {
                 XCTFail("System.Runtime.InteropServices.Marshal.Copy should not throw")
-                
+
                 return
             }
         }
-        
+
         validateSystemByteArray(systemByteArray,
                                 matchesData: data)
     }
-    
+
     func testSystemByteArrayToSwiftDataWithExtension() throws {
         let bytesCount = correctnessTestsByteCount
-        
+
         guard let systemByteArray = try randomSystemByteArray(count: bytesCount) else {
             XCTFail("System.Array should be possible to cast to byte[]")
-            
+
             return
         }
-        
+
         let copiedData = try systemByteArray.data()
-        
+
         validateSystemByteArray(systemByteArray,
                                 matchesData: copiedData)
-        
+
         let pinnedData = try systemByteArray.data(noCopy: true)
-        
+
         validateSystemByteArray(systemByteArray,
                                 matchesData: pinnedData)
     }
-    
+
     func testPerformanceOfSystemByteArrayToSwiftDataWithExtension() throws {
         let bytesCount = performanceTestsByteCount
-        
+
         guard let systemByteArray = try randomSystemByteArray(count: bytesCount) else {
             XCTFail("Failed to create random byte[]")
-            
+
             return
         }
-        
+
         let systemByteArrayLength = try systemByteArray.length
-        
+
         var copiedData: Data?
-        
+
         measure {
             copiedData = try? systemByteArray.data()
         }
-        
+
         guard let copiedData else {
             XCTFail("System_Byte_Array.data should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(copiedData.count, .init(systemByteArrayLength))
     }
-    
+
     func testPerformanceOfSystemByteArrayToSwiftDataWithExtensionNoCopy() throws {
         let bytesCount = performanceTestsByteCount
-        
+
         guard let systemByteArray = try randomSystemByteArray(count: bytesCount) else {
             XCTFail("Failed to create random byte[]")
-            
+
             return
         }
-        
+
         let systemByteArrayLength = try systemByteArray.length
-        
+
         var pinnedData: Data?
-        
+
         measure {
             pinnedData = try? systemByteArray.data(noCopy: true)
         }
-        
+
         guard let pinnedData else {
             XCTFail("System_Byte_Array.data should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(pinnedData.count, .init(systemByteArrayLength))
     }
-    
+
     func testEmptySystemByteArrayToSwiftDataWithExtension() throws {
         let systemByteArray = try DNArray<System_Byte>(length: 0)
-        
+
         let copiedData = try systemByteArray.data()
-        
+
         validateSystemByteArray(systemByteArray,
                                 matchesData: copiedData)
-        
+
         let pinnedData = try systemByteArray.data(noCopy: true)
-        
+
         validateSystemByteArray(systemByteArray,
                                 matchesData: pinnedData)
     }
@@ -254,52 +254,52 @@ private extension SystemRuntimeInteropServicesMarshalTests {
                                  matchesData data: Data) {
         guard let systemByteArrayLength = try? systemByteArray.length else {
             XCTFail("System.Array.Length should not throw and return an integer")
-            
+
             return
         }
-        
+
         let dataCount = data.count
-        
+
         XCTAssertEqual(Int(systemByteArrayLength), dataCount)
-        
+
         for idx in 0..<dataCount {
             guard let idxAsInt32 = Int32(exactly: idx) else {
                 XCTFail("Index doesn't fit in Int32")
-                
+
                 return
             }
-            
+
             let dataByte = data[idx]
-            
+
             let systemByteObject = systemByteArray[idxAsInt32]
-            
+
             guard let systemByte = try? systemByteObject.value else {
                 XCTFail("Should get a byte/UInt8 but failed to cast")
-                
+
                 return
             }
-            
+
             XCTAssertEqual(systemByte, dataByte)
         }
     }
-    
+
     func randomSystemByteArray(count: Int) throws -> DNArray<System_Byte>? {
         guard let random = try? System.Random() else {
             XCTFail("System.Random ctor should not throw and return an instance")
-            
+
             return nil
         }
-        
+
         let systemByteArray = try DNArray<System_Byte>(length: .init(count))
-        
+
         do {
             try random.nextBytes(systemByteArray)
         } catch {
             XCTFail("System.Random.NextBytes should not throw")
-            
+
             return nil
         }
-        
+
         return systemByteArray
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemSecurityCryptographyTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemSecurityCryptographyTests.swift
@@ -5,97 +5,97 @@ final class SystemSecurityCryptographyTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testAES() throws {
         let unencryptedData = "Hello 🌎!"
-        
+
         let encryptResult = try encrypt(data: unencryptedData)
         let encryptedData = encryptResult.encryptedData
         let iv = encryptResult.iv
         let key = encryptResult.key
-        
+
         XCTAssertNotEqual(encryptedData, "")
-        
+
         let decryptedData = try decrypt(data: encryptedData,
                                         iv: iv,
                                         key: key)
-        
+
         XCTAssertEqual(decryptedData, unencryptedData)
     }
 }
 
 fileprivate extension SystemSecurityCryptographyTests {
-    func encrypt(data: String) throws -> (encryptedData: String, 
+    func encrypt(data: String) throws -> (encryptedData: String,
                                           iv: DNArray<System.Byte>,
                                           key: DNArray<System.Byte>) {
         let aes = try System.Security.Cryptography.Aes.create()
-        
+
         try aes.generateIV()
         try aes.generateKey()
-        
+
         let iv = try aes.iV
         let key = try aes.key
-        
+
         let encryptor = try aes.createEncryptor()
         let memoryStream = try System.IO.MemoryStream()
-        
+
         let cryptoStream = try System.Security.Cryptography.CryptoStream(memoryStream,
                                                                          encryptor,
                                                                          .write)
-        
+
         let streamWriter = try System.IO.StreamWriter(cryptoStream)
-        
+
         try streamWriter.write(data.dotNETString())
-        
+
         try cryptoStream.flush()
-        
+
         try streamWriter.dispose()
         try cryptoStream.dispose()
         try memoryStream.dispose()
         try aes.dispose()
-        
+
         let encryptedData = try memoryStream.toArray()
-        
+
         let base64EncryptedDataDN = try System.Convert.toBase64String(encryptedData)
         let base64EncryptedData = base64EncryptedDataDN.string()
-        
+
         return (encryptedData: base64EncryptedData,
                 iv: iv,
                 key: key)
     }
-    
+
     func decrypt(data: String,
                  iv: DNArray<System.Byte>,
                  key: DNArray<System.Byte>) throws -> String {
         let buffer = try System.Convert.fromBase64String(data.dotNETString())
-        
+
         let aes = try System.Security.Cryptography.Aes.create()
         try aes.iV_set(iv)
         try aes.key_set(key)
-        
+
         let decryptor = try aes.createDecryptor()
         let memoryStream = try System.IO.MemoryStream(buffer)
-        
+
         let cryptoStream = try System.Security.Cryptography.CryptoStream(memoryStream,
                                                                          decryptor,
                                                                          .read)
-        
+
         let streamReader = try System.IO.StreamReader(cryptoStream)
-        
+
         try cryptoStream.flush()
-        
+
         let decryptedDataDN = try streamReader.readToEnd()
         let decryptedData = decryptedDataDN.string()
-        
+
         try cryptoStream.dispose()
         try memoryStream.dispose()
         try aes.dispose()
         try streamReader.dispose()
-        
+
         return decryptedData
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemStringTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemStringTests.swift
@@ -5,98 +5,98 @@ final class SystemStringTests: XCTestCase {
     private lazy var randomStrings: [String] = {
         let numberOfStrings = 1_000
         let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        
+
         let strings: [String] = (0..<numberOfStrings).compactMap({ _ in
             guard let letter = letters.randomElement() else {
                 return nil
             }
-            
+
             return String(letter)
         })
-        
+
         return strings
     }()
-    
+
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testString() throws {
         let emptyStringDN = System_String.empty
-        
+
         let emptyString = String(dotNETString: emptyStringDN)
         XCTAssertTrue(emptyString.isEmpty)
-        
+
         let isNullOrEmpty = try System_String.isNullOrEmpty(emptyStringDN)
         XCTAssertTrue(isNullOrEmpty)
-        
+
         let isNullOrWhiteSpace = try System_String.isNullOrWhiteSpace(emptyStringDN)
         XCTAssertTrue(isNullOrWhiteSpace)
-        
+
         let nonEmptyString = "Hello World!"
         let nonEmptyStringDN = nonEmptyString.dotNETString()
-        
+
         let isNonEmptyStringNullOrEmpty = try System_String.isNullOrEmpty(nonEmptyStringDN)
         XCTAssertFalse(isNonEmptyStringNullOrEmpty)
-        
+
         let stringForTrimmingDN = " \(nonEmptyString) ".dotNETString()
-        
+
         let trimmedString = try stringForTrimmingDN.trim().string()
         XCTAssertEqual(nonEmptyString, trimmedString)
-        
+
         let worldDN = "World".dotNETString()
         let expectedIndexOfWorld: Int32 = 6
-        
+
         let indexOfWorld = try nonEmptyStringDN.indexOf(worldDN)
         XCTAssertEqual(expectedIndexOfWorld, indexOfWorld)
-        
+
         let splitOptions: System_StringSplitOptions = [ .removeEmptyEntries, .trimEntries ]
-        
+
         let blankDN = " ".dotNETString()
-        
+
         let split = try nonEmptyStringDN.split(blankDN, splitOptions)
-        
+
         guard try split.length == 2 else {
             XCTFail("System.Array.Length getter should not throw and return 2")
-            
+
             return
         }
     }
-    
+
     func testStringReplace() throws {
         let hello = "Hello"
         let otherPart = " World 😀"
         let originalString = "\(hello)\(otherPart)"
         let emptyString = ""
-        
+
         let expectedString = originalString.replacingOccurrences(of: hello,
                                                                  with: emptyString)
-        
+
         let originalStringDN = originalString.dotNETString()
         let helloDN = hello.dotNETString()
         let emptyStringDN = emptyString.dotNETString()
-        
+
         let replacedString = try originalStringDN.replace(helloDN, emptyStringDN).string()
         XCTAssertEqual(expectedString, replacedString)
     }
-    
+
     func testStringSubstring() throws {
         let string = "Hello World 😀"
         let needle = "World"
-        
+
         let stringDN = string.dotNETString()
         let needleDN = needle.dotNETString()
-        
+
         let expectedIndex: Int32 = 6
-        
+
         let index = try stringDN.indexOf(needleDN)
         XCTAssertEqual(expectedIndex, index)
     }
-    
+
     func testStringSplitAndJoin() throws {
         let components = [
             "1. First",
@@ -104,93 +104,93 @@ final class SystemStringTests: XCTestCase {
             "",
             "3. Third "
         ]
-        
+
         var cleanedComponents = [String]()
-        
+
         for component in components {
             let trimmedComponent = component.trimmingCharacters(in: .whitespacesAndNewlines)
-            
+
             guard !trimmedComponent.isEmpty else {
                 continue
             }
-            
+
             cleanedComponents.append(trimmedComponent)
         }
-        
+
         let separator = ";"
         let separatorDN = separator.dotNETString()
-        
+
         let joined = components.joined(separator: separator)
         let joinedDN = joined.dotNETString()
-        
+
         let cleanedJoined = cleanedComponents.joined(separator: separator)
-        
+
         let splitOptions: System_StringSplitOptions = [ .removeEmptyEntries, .trimEntries ]
-        
+
         let split = try joinedDN.split(separatorDN, splitOptions)
-        
+
         let length = try split.length
-        
+
         XCTAssertEqual(cleanedComponents.count, .init(length))
-        
+
         for (idx, component) in cleanedComponents.enumerated() {
             let componentRetObj = split[Int32(idx)]
-            
+
             let componentRetDN: System_String
-            
+
             do {
                 componentRetDN = try componentRetObj.castTo()
             } catch {
                 XCTFail("castTo should not throw")
-                
+
                 return
             }
-            
+
             let componentRet = componentRetDN.string()
-            
+
             XCTAssertEqual(component, componentRet)
         }
-        
+
         let joinedRet = try? System_String.join(separatorDN,
                                                 split.nullable()).string()
-        
+
         XCTAssertEqual(cleanedJoined, joinedRet)
     }
-    
+
     func testStringComparison() {
         let hello = "Hello"
         let helloDN = hello.dotNETString()
-        
+
         let hello2 = "Hello"
         let hello2DN = hello2.dotNETString()
-        
+
         let world = "World"
         let worldDN = world.dotNETString()
-        
+
         XCTAssertTrue(helloDN == hello2DN)
         XCTAssertFalse(helloDN === hello2DN)
-        
+
         XCTAssertFalse(helloDN == worldDN)
         XCTAssertFalse(helloDN === worldDN)
     }
-    
+
     func testSwiftStringToSystemStringConversionPerformance() {
         let strings = randomStrings
-        
+
         measure {
             for string in strings {
                 _ = string.dotNETString()
             }
         }
     }
-    
+
     func testSystemStringToSwiftStringConversionPerformance() {
         let strings = randomStrings
-        
+
         let dnStrings = strings.map({
             $0.dotNETString()
         })
-        
+
         measure {
             for string in dnStrings {
                 _ = string.string()

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemTextStringBuilderTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemTextStringBuilderTests.swift
@@ -5,30 +5,30 @@ final class SystemTextStringBuilderTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testStringBuilder() throws {
         let hello = "Hello"
         let helloDN = hello.dotNETString()
-        
+
         let lineBreak = "\n"
-        
+
         let world = "World"
         let worldDN = world.dotNETString()
-        
+
         let expectedFinalString = "\(hello)\(lineBreak)\(world)"
-        
+
         let sb = try System_Text_StringBuilder(helloDN)
         let helloRet = try sb.toString().string()
-        
+
         XCTAssertEqual(hello, helloRet)
-        
+
         XCTAssertNoThrow(try sb.appendLine())
         XCTAssertNoThrow(try sb.append(worldDN))
-        
+
         let finalStringRet = try sb.toString().string()
         XCTAssertEqual(expectedFinalString, finalStringRet)
     }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemThreadingThreadTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemThreadingThreadTests.swift
@@ -5,29 +5,29 @@ final class SystemThreadingThreadTests: XCTestCase {
 	override class func setUp() {
 		Self.sharedSetUp()
 	}
-	
+
 	override class func tearDown() {
 		Self.sharedTearDown()
 	}
-	
+
 	func testThread() throws {
 		var numberOfTimesCalled = 0
-		
+
 		let closure: System_Threading_ThreadStart.ClosureType = {
 			XCTAssertFalse(Thread.isMainThread)
-			
+
 			numberOfTimesCalled += 1
 		}
-		
+
         let threadStart = System_Threading_ThreadStart(closure)
 		let thread = try System_Threading_Thread(threadStart)
-		
+
 		try thread.start()
 
 		while numberOfTimesCalled < 1 {
 			Thread.sleep(forTimeInterval: 0.01)
 		}
-		
+
 		XCTAssertEqual(1, numberOfTimesCalled)
 	}
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemThreadingTimerTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemThreadingTimerTests.swift
@@ -5,50 +5,50 @@ final class SystemThreadingTimerTests: XCTestCase {
 	override class func setUp() {
 		Self.sharedSetUp()
 	}
-	
+
 	override class func tearDown() {
 		Self.sharedTearDown()
 	}
-	
+
 	func testTimer() throws {
 		let maximumNumberOfTimesToCall = 30
 		var numberOfTimesCalled = 0
-		
+
 		var timer: System_Threading_Timer? = nil
-		
+
 		let closure: System_Threading_TimerCallback.ClosureType = { state in
 			XCTAssertFalse(Thread.isMainThread)
-			
+
 			numberOfTimesCalled += 1
-			
+
 			if numberOfTimesCalled == maximumNumberOfTimesToCall {
 				guard let timer else {
 					XCTFail("timer is nil")
-					
+
 					return
 				}
-				
+
 				do {
 					try timer.dispose()
 				} catch {
 					XCTFail("System.Threading.Timer.Dispose should not throw")
-					
+
 					return
 				}
 			}
 		}
-        
+
         let _timer = try System_Threading_Timer(.init(closure),
                                                 nil,
                                                 50 as Int32,
                                                 10 as Int32)
-		
+
 		timer = _timer
-		
+
 		while numberOfTimesCalled != maximumNumberOfTimesToCall {
 			Thread.sleep(forTimeInterval: 0.01)
 		}
-		
+
 		XCTAssertEqual(numberOfTimesCalled, maximumNumberOfTimesToCall)
 	}
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemTupleTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemTupleTests.swift
@@ -5,14 +5,14 @@ final class SystemTupleTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testTupleA1() throws {
         let systemStringType = System_String.typeOf
-        
+
         let string = "Hello World"
         let stringDN = string.dotNETString()
 
@@ -28,14 +28,14 @@ final class SystemTupleTests: XCTestCase {
         let stringRet = stringRetDN.string()
         XCTAssertEqual(string, stringRet)
     }
-    
+
     func testTupleA2() throws {
         let systemStringType = System_String.typeOf
         let systemExceptionType = System_Exception.typeOf
-        
+
         let string = "The Exception Message"
         let stringDN = string.dotNETString()
-        
+
         let exception = try System_Exception(stringDN)
 
         let tupleOfStringAndException = try System_Tuple_A2(T1: systemStringType,
@@ -52,7 +52,7 @@ final class SystemTupleTests: XCTestCase {
 
         let stringRet = stringRetDN.string()
         XCTAssertEqual(string, stringRet)
-        
+
         guard let exceptionRet = try tupleOfStringAndException.item2(T1: systemStringType,
                                                                      T2: systemExceptionType)?.castAs(System_Exception.self) else {
             XCTFail("System.Tuple<System.String, System.Exception>.Item2 getter should not throw and return an instance")

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemTypeTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemTypeTests.swift
@@ -5,55 +5,55 @@ final class SystemTypeTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testSystemType() throws {
         let systemObjectTypeName = System_Object.fullTypeName
         let systemObjectType = System_Object.typeOf
-        
+
         guard let systemObjectTypeViaName = try? System_Type.getType(systemObjectTypeName.dotNETString()) else {
             XCTFail("System.Type.GetType should not throw and return an instance of System.Type")
-            
+
             return
         }
-        
+
         guard systemObjectType == systemObjectTypeViaName else {
             XCTFail("System.Object.Equals should not throw and return true")
-            
+
             return
         }
-        
+
         guard let retrievedSystemObjectTypeName = (try? systemObjectType.fullName)?.string() else {
             XCTFail("System.Type.FullName getter should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(systemObjectTypeName, retrievedSystemObjectTypeName)
     }
-    
+
     func testInvalidType() {
         let invalidTypeName = "! This.Type.Surely.Does.Not.Exist !"
 
         var invalidType: System_Type?
-        
+
         do {
             invalidType = try System_Type.getType(invalidTypeName.dotNETString(),
                                                   true)
-            
+
             XCTFail("System.Type.GetType should throw")
         } catch {
             XCTAssertNil(invalidType)
-            
+
             let exceptionMessage = error.localizedDescription
-            
+
             XCTAssertTrue(exceptionMessage.contains("The type \'\(invalidTypeName)\' cannot be found"))
         }
     }
-    
+
     func testPrimitiveTypes() {
         verifyTypeFullName(System_Boolean.typeOf, "System.Boolean")
         verifyTypeFullName(System_Char.typeOf, "System.Char")
@@ -76,21 +76,21 @@ private extension SystemTypeTests {
     func verifyTypeFullName(_ type: System_Type,
                             _ expectedFullName: String) {
         let fullTypeName: String?
-        
+
         do {
             fullTypeName = try type.fullName?.string()
         } catch {
             XCTFail("Failed to get type name: \((error as NSError).description)")
-            
+
             return
         }
-        
+
         guard let fullTypeName else {
             XCTFail("Failed to get type name")
-            
+
             return
         }
-        
+
         XCTAssertEqual(fullTypeName, expectedFullName)
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemUriTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemUriTests.swift
@@ -5,51 +5,51 @@ final class SystemUriTests: XCTestCase {
 	override class func setUp() {
 		Self.sharedSetUp()
 	}
-	
+
 	override class func tearDown() {
 		Self.sharedTearDown()
 	}
-	
+
 	func testUriCreationOptions() throws {
         let creationOptions = try System.UriCreationOptions()
         let type = System.UriCreationOptions.typeOf
 		let typeRet = try creationOptions.getType()
 		XCTAssertTrue(type == typeRet)
-		
+
 		let value = true
 
         try creationOptions.dangerousDisablePathAndQueryCanonicalization_set(value)
         let valueRet = try creationOptions.dangerousDisablePathAndQueryCanonicalization
         XCTAssertEqual(value, valueRet)
 	}
-	
+
 	func testTryCreateUriWithInParameter() throws {
 		let urlString = "https://royalapps.com/"
-		
+
         var creationOptions = try System.UriCreationOptions()
-		
+
 		var uriRet: System_Uri?
-        
+
         guard try System.Uri.tryCreate(urlString.dotNETString(),
                                        &creationOptions,
                                        &uriRet),
               let uriRet else {
             XCTFail("System.Uri.TryCreate should not throw, return true and an System.Uri object as out parameter")
-            
+
             return
         }
-		
+
 		let absoluteUriString = try uriRet.absoluteUri.string()
 		XCTAssertEqual(urlString, absoluteUriString)
-        
+
         guard let url = URL(string: absoluteUriString) else {
             XCTFail("Should be able to init a Swift URL with a .NET URI String")
-            
+
             return
         }
-        
+
         let absoluteURLString = url.absoluteString
-        
+
         XCTAssertEqual(absoluteUriString, absoluteURLString)
 	}
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemVersionTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemVersionTests.swift
@@ -5,108 +5,108 @@ final class SystemVersionTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testSystemVersionFromComponents() throws {
         let systemVersionType = System_Version.typeOf
-        
+
         let major: Int32    = 1
         let minor: Int32    = 2
         let build: Int32    = 3
         let revision: Int32 = 4
-        
+
         let versionString = "\(major).\(minor).\(build).\(revision)"
-        
+
         let version = try System_Version(major,
                                          minor,
                                          build,
                                          revision)
-        
+
         let versionFromComponentsType = try version.getType()
-        
+
         guard systemVersionType == versionFromComponentsType else {
             XCTFail("System.Object.Equals should not throw and return true")
-            
+
             return
         }
-        
+
         let majorRet = try version.major
         XCTAssertEqual(major, majorRet)
-        
+
         let minorRet = try version.minor
         XCTAssertEqual(minor, minorRet)
-        
+
         let buildRet = try version.build
         XCTAssertEqual(build, buildRet)
-        
+
         let revisionRet = try version.revision
         XCTAssertEqual(revision, revisionRet)
-        
+
         let versionStringRet = try version.toString().string()
         XCTAssertEqual(versionString, versionStringRet)
     }
-    
+
     func testSystemVersionFromString() throws {
         let major: Int32    = 123
         let minor: Int32    = 234
         let build: Int32    = 345
         let revision: Int32 = 456
-        
+
         let versionString = "\(major).\(minor).\(build).\(revision)"
         let versionStringDN = versionString.dotNETString()
-        
+
         let version = try System_Version(versionStringDN)
-        
+
         let majorRet = try version.major
         XCTAssertEqual(major, majorRet)
-        
+
         let minorRet = try version.minor
         XCTAssertEqual(minor, minorRet)
-        
+
         let buildRet = try version.build
         XCTAssertEqual(build, buildRet)
-        
+
         let revisionRet = try version.revision
         XCTAssertEqual(revision, revisionRet)
-        
+
         let versionStringRet = try version.toString().string()
         XCTAssertEqual(versionString, versionStringRet)
     }
-    
+
     func testSystemVersionParse() throws {
         let major: Int32    = 123
         let minor: Int32    = 234
         let build: Int32    = 345
         let revision: Int32 = 456
-        
+
         let versionString = "\(major).\(minor).\(build).\(revision)"
         let versionStringDN = versionString.dotNETString()
-        
+
         var version: System_Version?
-        
+
         guard try System_Version.tryParse(versionStringDN,
                                           &version),
               let version else {
             XCTFail("System.Version.TryParse should not throw, return true and return an instance as out parameter")
-            
+
             return
         }
-        
+
         let majorRet = try version.major
         XCTAssertEqual(major, majorRet)
-        
+
         let minorRet = try version.minor
         XCTAssertEqual(minor, minorRet)
-        
+
         let buildRet = try version.build
         XCTAssertEqual(build, buildRet)
-        
+
         let revisionRet = try version.revision
         XCTAssertEqual(revision, revisionRet)
-        
+
         let versionStringRet = try version.toString().string()
         XCTAssertEqual(versionString, versionStringRet)
     }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemWeakReferenceTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemWeakReferenceTests.swift
@@ -5,57 +5,57 @@ final class SystemWeakReferenceTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testWeakReferenceToLongLivedObject() throws {
         let anObject = try System.Object()
-        
+
         guard let weakRef = weakReferenceToObject(anObject) else {
             XCTFail("System.WeakReference ctor should not throw and return an instance")
-            
+
             return
         }
-        
+
         try System.GC.collect()
-        
+
         let isAlive = try weakRef.isAlive
         let target = try weakRef.target
-        
+
         XCTAssertTrue(isAlive)
-        
+
         guard let unwrappedTarget = target else {
             XCTFail("We should have a target object")
-            
+
             return
         }
-        
+
         let isTargetSameAsObject = try System.Object.referenceEquals(anObject, target)
         let isUnwrappedTargetSameAsObjectUsingBuiltInComparison = anObject === unwrappedTarget
         let isUnwrappedTargetNotSameAsObjectUsingBuiltInComparison = anObject !== unwrappedTarget
         let isTargetSameAsObjectUsingBuiltInComparison = anObject === target
         let isTargetNotSameAsObjectUsingBuiltInComparison = anObject !== target
-        
+
         XCTAssertTrue(isTargetSameAsObject)
         XCTAssertTrue(isUnwrappedTargetSameAsObjectUsingBuiltInComparison)
         XCTAssertFalse(isUnwrappedTargetNotSameAsObjectUsingBuiltInComparison)
         XCTAssertTrue(isTargetSameAsObjectUsingBuiltInComparison)
         XCTAssertFalse(isTargetNotSameAsObjectUsingBuiltInComparison)
     }
-    
+
     func testWeakReferenceToTemporaryObject() {
         guard let weakRef = weakReferenceToTemporaryObject() else {
             XCTFail("System.WeakReference ctor should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertNoThrow(try System.GC.collect())
-        
+
         let isAlive = (try? weakRef.isAlive) ?? false
-        
+
         XCTAssertFalse(isAlive)
     }
 }
@@ -64,22 +64,22 @@ private extension SystemWeakReferenceTests {
     func weakReferenceToObject(_ targetObject: System.Object) -> System.WeakReference? {
         guard let weakRef = try? System.WeakReference(targetObject) else {
             XCTFail("System.WeakReference ctor should not throw and return an instance")
-            
+
             return nil
         }
-        
+
         return weakRef
     }
-    
+
     func weakReferenceToTemporaryObject() -> System.WeakReference? {
         guard let tempObject = try? System.Object() else {
             XCTFail("System.Object ctor should not throw and return an instance")
-            
+
             return nil
         }
-        
+
         let weakRef = weakReferenceToObject(tempObject)
-        
+
         return weakRef
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/TypeConversionTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/TypeConversionTests.swift
@@ -5,85 +5,85 @@ final class TypeConversionTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testIs() throws {
         let systemObjectType = System.Object.self
         let systemObjectTypeDN = systemObjectType.typeOf
-        
+
         let systemStringType = System.String.self
         let systemStringTypeDN = systemStringType.typeOf
-        
+
         let systemExceptionType = System.Exception.self
         let systemExceptionTypeDN = systemExceptionType.typeOf
-        
+
         let systemGuidType = System.Guid.self
         let systemGuidTypeDN = systemGuidType.typeOf
-        
+
         // MARK: - System.Object
         let systemObject = try System.Object()
-        
+
         XCTAssertTrue(systemObject.is(systemObjectTypeDN))
         XCTAssertTrue(systemObject.is(systemObjectType))
-        
+
         XCTAssertFalse(systemObject.is(systemStringTypeDN))
         XCTAssertFalse(systemObject.is(systemStringType))
-        
+
         XCTAssertFalse(systemObject.is(systemExceptionTypeDN))
         XCTAssertFalse(systemObject.is(systemExceptionType))
-        
+
         XCTAssertFalse(systemObject.is(systemGuidTypeDN))
         XCTAssertFalse(systemObject.is(systemGuidType))
-        
+
         // MARK: - System.String
         let systemString = System.String.empty
-        
+
         XCTAssertTrue(systemString.is(systemObjectTypeDN))
         XCTAssertTrue(systemString.is(systemObjectType))
-        
+
         XCTAssertTrue(systemString.is(systemStringTypeDN))
         XCTAssertTrue(systemString.is(systemStringType))
-        
+
         XCTAssertFalse(systemString.is(systemExceptionTypeDN))
         XCTAssertFalse(systemString.is(systemExceptionType))
-        
+
         XCTAssertFalse(systemString.is(systemGuidTypeDN))
         XCTAssertFalse(systemString.is(systemGuidType))
-        
+
         // MARK: - System.Exception
         let systemException = try System.Exception()
-        
+
         XCTAssertTrue(systemException.is(systemObjectTypeDN))
         XCTAssertTrue(systemException.is(systemObjectType))
-        
+
         XCTAssertFalse(systemException.is(systemStringTypeDN))
         XCTAssertFalse(systemException.is(systemStringType))
-        
+
         XCTAssertTrue(systemException.is(systemExceptionTypeDN))
         XCTAssertTrue(systemException.is(systemExceptionType))
-        
+
         XCTAssertFalse(systemException.is(systemGuidTypeDN))
         XCTAssertFalse(systemException.is(systemGuidType))
-        
+
         // MARK: - System.Guid
         let systemGuid = try System.Guid.newGuid()
-        
+
         XCTAssertTrue(systemGuid.is(systemObjectTypeDN))
         XCTAssertTrue(systemGuid.is(systemObjectType))
-        
+
         XCTAssertFalse(systemGuid.is(systemStringTypeDN))
         XCTAssertFalse(systemGuid.is(systemStringType))
-        
+
         XCTAssertFalse(systemGuid.is(systemExceptionTypeDN))
         XCTAssertFalse(systemGuid.is(systemExceptionType))
-        
+
         XCTAssertTrue(systemGuid.is(systemGuidTypeDN))
         XCTAssertTrue(systemGuid.is(systemGuidType))
     }
-    
+
     func testCastAs() throws {
         let systemObject = try System.Object()
         let systemGuid = try System.Guid.newGuid()
@@ -108,7 +108,7 @@ final class TypeConversionTests: XCTestCase {
         let systemNullReferenceExceptionCastToSystemException = systemNullReferenceException.castAs(System.Exception.self)
         XCTAssertNotNil(systemNullReferenceExceptionCastToSystemException)
     }
-    
+
     func testCastTo() {
         guard let systemObject = try? System.Object() else {
             XCTFail("System.Object ctor should not throw and return an instance")

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/AddressTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/AddressTests.swift
@@ -5,40 +5,40 @@ final class AddressTests: XCTestCase {
 	override class func setUp() {
 		Self.sharedSetUp()
 	}
-	
+
 	override class func tearDown() {
 		Self.sharedTearDown()
 	}
-	
+
 	func testAddress() throws {
 		let street = "Schwedenplatz"
 		let streetDN = street.dotNETString()
-		
+
 		let city = "Vienna"
 		let cityDN = city.dotNETString()
-		
+
         let address = try Beyond_NET_Sample_Address(streetDN,
                                                     cityDN)
-		
+
 		let retrievedStreet = try address.street.string()
 		XCTAssertEqual(street, retrievedStreet)
-		
+
 		let addressType = try address.getType()
 		let expectedAddressTypeFullName = "Beyond.NET.Sample.Address"
 		let actualAddressFullTypeName = try addressType.fullName?.string()
 		XCTAssertEqual(expectedAddressTypeFullName, actualAddressFullTypeName)
 	}
-	
+
 	func testAddressMover() throws {
 		let originalStreet = "Schwedenplatz"
 		let originalStreetDN = originalStreet.dotNETString()
-		
+
 		let newStreet = "Stephansplatz"
 		let newStreetDN = newStreet.dotNETString()
 
 		let originalCity = "Vienna"
 		let originalCityDN = originalCity.dotNETString()
-		
+
 		let newCity = "Wien"
 		let newCityDN = newCity.dotNETString()
 
@@ -49,17 +49,17 @@ final class AddressTests: XCTestCase {
 			guard let newAddress = try? Beyond_NET_Sample_Address(newStreetInnerDN,
 																				   newCityInnerDN) else {
 				XCTFail("Address ctor should not throw and return an instance")
-				
+
 				return nil
 			}
-			
+
 			return newAddress
 		}
 
         let newAddress = try originalAddress.move(.init(moverFunc),
                                                   newStreetDN,
                                                   newCityDN)
-		
+
 		let retrievedNewStreet = try newAddress.street.string()
 		XCTAssertEqual(newStreet, retrievedNewStreet)
 

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/AnimalTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/AnimalTests.swift
@@ -5,53 +5,53 @@ final class AnimalTests: XCTestCase {
 	override class func setUp() {
 		Self.sharedSetUp()
 	}
-	
+
 	override class func tearDown() {
 		Self.sharedTearDown()
 	}
-	
+
 	func testDog() throws {
 		let dogNameDN = Beyond_NET_Sample_Dog.dogName
 		let dogName = dogNameDN.string()
-		
+
 		guard let dog = try Beyond_NET_Sample_AnimalFactory.createAnimal(dogNameDN) else {
 			XCTFail("AnimalFactory.CreateAnimal should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		let retrievedDogName = try dog.name.string()
 		XCTAssertEqual(dogName, retrievedDogName)
-		
+
 		let food = "Bone"
 		let foodDN = food.dotNETString()
-		
+
 		let eat = try dog.eat(foodDN).string()
 		let expectedEat = "\(dogName) is eating \(food)."
 		XCTAssertEqual(expectedEat, eat)
 	}
-	
+
 	func testCat() throws {
 		let catNameDN = Beyond_NET_Sample_Cat.catName
 		let catName = catNameDN.string()
-		
+
 		guard let cat = try Beyond_NET_Sample_AnimalFactory.createAnimal(catNameDN) else {
 			XCTFail("AnimalFactory.CreateAnimal should not throw and return an instance")
-			
+
 			return
 		}
-        
+
         let retrievedCatName = try cat.name.string()
 		XCTAssertEqual(catName, retrievedCatName)
-		
+
 		let food = "Catnip"
 		let foodDN = food.dotNETString()
-		
+
 		let eat = try cat.eat(foodDN).string()
 		let expectedEat = "\(catName) is eating \(food)."
 		XCTAssertEqual(expectedEat, eat)
 	}
-	
+
 	func testCustomAnimalCreator() throws {
 		let creatorFunc: Beyond_NET_Sample_AnimalCreatorDelegate.ClosureType = { innerAnimalName in
 			guard let animal = try? Beyond_NET_Sample_GenericAnimal(innerAnimalName) else {
@@ -59,26 +59,26 @@ final class AnimalTests: XCTestCase {
 
 				return nil
 			}
-			
+
 			return animal
 		}
 
 		let creatorDelegate = Beyond_NET_Sample_AnimalCreatorDelegate(creatorFunc)
-		
+
 		let animalName = "Horse"
         let animalNameDN = animalName.dotNETString()
-        
+
         guard let horse = try Beyond_NET_Sample_AnimalFactory.createAnimal(animalNameDN,
                                                                            creatorDelegate) else {
             XCTFail("AnimalFactory.CreateAnimal should not throw and return an instance")
-            
+
             return
         }
-        
+
         let retrievedAnimalName = try horse.name.string()
 		XCTAssertEqual(animalName, retrievedAnimalName)
 	}
-	
+
 	func testGettingDefaultAnimalCreator() throws {
 		let defaultCreator = Beyond_NET_Sample_AnimalFactory.dEFAULT_CREATOR
 
@@ -107,36 +107,36 @@ final class AnimalTests: XCTestCase {
 		let catNameRet = try cat.name.string()
 		XCTAssertEqual(catName, catNameRet)
 	}
-	
+
 	func testCreatingAnimalThroughGenerics() throws {
 		// MARK: Cat
 		let catType = Beyond_NET_Sample_Cat.typeOf
-		
+
         let cat = try Beyond_NET_Sample_AnimalFactory.createAnimal(T: catType)
 		let catTypeRet = try cat.getType()
 		let catTypesAreEqual = catType == catTypeRet
 		XCTAssertTrue(catTypesAreEqual)
-		
+
 		// MARK: Dog
 		let dogType = Beyond_NET_Sample_Dog.typeOf
-		
+
         let dog = try Beyond_NET_Sample_AnimalFactory.createAnimal(T: dogType)
 		let dogTypeRet = try dog.getType()
 		let dogTypesAreEqual = dogType == dogTypeRet
 		XCTAssertTrue(dogTypesAreEqual)
-		
+
 		// MARK: Invalid Type
 		let stringType = System_String.typeOf
-		
+
 		do {
             _ = try Beyond_NET_Sample_AnimalFactory.createAnimal(T: stringType)
-			
+
 			XCTFail("Should throw")
 		} catch {
 			XCTAssertTrue(error.localizedDescription.contains("violates the constraint"))
 		}
 	}
-    
+
     func testStaticMemberShadowing() {
         let dogNameDN = Beyond_NET_Sample_Dog.staticName
         let dogName = dogNameDN.string()
@@ -146,7 +146,7 @@ final class AnimalTests: XCTestCase {
 
         XCTAssertEqual(dogName, "Dog")
         XCTAssertEqual(labradorName, "Labrador")
-        
+
         XCTAssertNotEqual(dogName, labradorName)
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/ArrayTestsTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/ArrayTestsTests.swift
@@ -5,417 +5,417 @@ final class ArrayTestsTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testTwoDimensionalArrayOfBool() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         let array = try tests.twoDimensionalArrayOfBool
-        
+
         // Check initial state
         try verifyTwoDimensionalArrayOfBoolInitialState(array)
-        
+
         // Modify it
         array[[0, 0]] = true.dotNETObject()
         array[[0, 1]] = false.dotNETObject()
         array[[1, 0]] = false.dotNETObject()
         array[[1, 1]] = true.dotNETObject()
-        
+
         // Check modified state
         XCTAssertEqual(try array.getValue(Int32(0), Int32(0))?.castToBool(), true)
         XCTAssertEqual(try array[[0, 0]].castToBool(), true)
-        
+
         XCTAssertEqual(try array.getValue(Int32(0), Int32(1))?.castToBool(), false)
         XCTAssertEqual(try array[[0, 1]].castToBool(), false)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(0))?.castToBool(), false)
         XCTAssertEqual(try array[[1, 0]].castToBool(), false)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(1))?.castToBool(), true)
         XCTAssertEqual(try array[[1, 1]].castToBool(), true)
     }
-    
+
     func testCreatingTwoDimensionalArrayOfBool() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         let newArray = try DNMultidimensionalArray<System.Boolean>(lengths: [2, 2])
         let rank = try newArray.rank
-        
+
         XCTAssertEqual(rank, 2)
-        
+
         // Set values
         newArray[[0, 0]] = true.dotNETObject()
         newArray[[0, 1]] = false.dotNETObject()
         newArray[[1, 0]] = false.dotNETObject()
         newArray[[1, 1]] = true.dotNETObject()
-        
+
         try tests.twoDimensionalArrayOfBool_set(newArray)
-        
+
         let array = try tests.twoDimensionalArrayOfBool
         XCTAssertEqual(try array.rank, 2)
-        
+
         // Check state
         XCTAssertEqual(try array.getValue(Int32(0), Int32(0))?.castToBool(), true)
         XCTAssertEqual(try array[[0, 0]].castToBool(), true)
-        
+
         XCTAssertEqual(try array.getValue(Int32(0), Int32(1))?.castToBool(), false)
         XCTAssertEqual(try array[[0, 1]].castToBool(), false)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(0))?.castToBool(), false)
         XCTAssertEqual(try array[[1, 0]].castToBool(), false)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(1))?.castToBool(), true)
         XCTAssertEqual(try array[[1, 1]].castToBool(), true)
     }
-    
+
     func testTwoDimensionalArrayOfBoolAsReturn() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
         let array = try tests.twoDimensionalArrayOfBoolAsReturn()
-        
+
         try verifyTwoDimensionalArrayOfBoolInitialState(array)
     }
-    
+
     func testSetTwoDimensionalArrayOfBoolWithParameter() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         let newArray = try DNMultidimensionalArray<System.Boolean>(lengths: [2, 2])
         let rank = try newArray.rank
-        
+
         XCTAssertEqual(rank, 2)
-        
+
         // Set values
         newArray[[0, 0]] = true.dotNETObject()
         newArray[[0, 1]] = false.dotNETObject()
         newArray[[1, 0]] = false.dotNETObject()
         newArray[[1, 1]] = true.dotNETObject()
-        
+
         try tests.setTwoDimensionalArrayOfBoolWithParameter(newArray)
-        
+
         let array = try tests.twoDimensionalArrayOfBool
         XCTAssertEqual(try array.rank, 2)
-        
+
         // Check state
         XCTAssertEqual(try array.getValue(Int32(0), Int32(0))?.castToBool(), true)
         XCTAssertEqual(try array[[0, 0]].castToBool(), true)
-        
+
         XCTAssertEqual(try array.getValue(Int32(0), Int32(1))?.castToBool(), false)
         XCTAssertEqual(try array[[0, 1]].castToBool(), false)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(0))?.castToBool(), false)
         XCTAssertEqual(try array[[1, 0]].castToBool(), false)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(1))?.castToBool(), true)
         XCTAssertEqual(try array[[1, 1]].castToBool(), true)
     }
-    
+
     func testTwoDimensionalArrayOfBoolAsOut() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         var array = DNMultidimensionalArray<System.Boolean>.outParameterPlaceholder
         try tests.twoDimensionalArrayOfBoolAsOut(&array)
-        
+
         try verifyTwoDimensionalArrayOfBoolInitialState(array)
     }
-    
+
     func testTwoDimensionalArrayOfBoolAsRef() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         var array: DNMultidimensionalArray<System.Boolean> = try .init(lengths: [ 1, 1 ])
         try tests.twoDimensionalArrayOfBoolAsRef(&array)
-        
+
         try verifyTwoDimensionalArrayOfBoolInitialState(array)
     }
-    
+
     func verifyTwoDimensionalArrayOfBoolInitialState(_ array: DNMultidimensionalArray<System.Boolean>) throws {
         XCTAssertEqual(try array.rank, 2)
-        
+
         XCTAssertEqual(try array.getValue(Int32(0), Int32(0))?.castToBool(), false)
         XCTAssertEqual(try array[[0, 0]].castToBool(), false)
-        
+
         XCTAssertEqual(try array.getValue(Int32(0), Int32(1))?.castToBool(), true)
         XCTAssertEqual(try array[[0, 1]].castToBool(), true)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(0))?.castToBool(), true)
         XCTAssertEqual(try array[[1, 0]].castToBool(), true)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(1))?.castToBool(), false)
         XCTAssertEqual(try array[[1, 1]].castToBool(), false)
     }
-    
+
     func testThreeDimensionalArrayOfInt32() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         let array = try tests.threeDimensionalArrayOfInt32
         let rank = try array.rank
-        
+
         XCTAssertEqual(rank, 3)
-        
+
         // Check initial state
         XCTAssertEqual(try array.getValue(Int32(0), Int32(0), Int32(0))?.castToInt32(), 1)
         XCTAssertEqual(try array[[0, 0, 0]].castToInt32(), 1)
-        
+
         XCTAssertEqual(try array.getValue(Int32(0), Int32(0), Int32(1))?.castToInt32(), 2)
         XCTAssertEqual(try array[[0, 0, 1]].castToInt32(), 2)
-        
+
         XCTAssertEqual(try array.getValue(Int32(0), Int32(0), Int32(2))?.castToInt32(), 3)
         XCTAssertEqual(try array[[0, 0, 2]].castToInt32(), 3)
-        
+
         XCTAssertEqual(try array.getValue(Int32(0), Int32(1), Int32(0))?.castToInt32(), 4)
         XCTAssertEqual(try array[[0, 1, 0]].castToInt32(), 4)
-        
+
         XCTAssertEqual(try array.getValue(Int32(0), Int32(1), Int32(1))?.castToInt32(), 5)
         XCTAssertEqual(try array[[0, 1, 1]].castToInt32(), 5)
-        
+
         XCTAssertEqual(try array.getValue(Int32(0), Int32(1), Int32(2))?.castToInt32(), 6)
         XCTAssertEqual(try array[[0, 1, 2]].castToInt32(), 6)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(0), Int32(0))?.castToInt32(), 7)
         XCTAssertEqual(try array[[1, 0, 0]].castToInt32(), 7)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(0), Int32(1))?.castToInt32(), 8)
         XCTAssertEqual(try array[[1, 0, 1]].castToInt32(), 8)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(0), Int32(2))?.castToInt32(), 9)
         XCTAssertEqual(try array[[1, 0, 2]].castToInt32(), 9)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(1), Int32(0))?.castToInt32(), 10)
         XCTAssertEqual(try array[[1, 1, 0]].castToInt32(), 10)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(1), Int32(1))?.castToInt32(), 11)
         XCTAssertEqual(try array[[1, 1, 1]].castToInt32(), 11)
-        
+
         XCTAssertEqual(try array.getValue(Int32(1), Int32(1), Int32(2))?.castToInt32(), 12)
         XCTAssertEqual(try array[[1, 1, 2]].castToInt32(), 12)
-        
+
         // Modify it
         array[[0, 0, 0]] = Int32(12).dotNETObject()
         array[[0, 0, 1]] = Int32(11).dotNETObject()
         array[[0, 0, 2]] = Int32(10).dotNETObject()
-        
+
         array[[0, 1, 0]] = Int32(9).dotNETObject()
         array[[0, 1, 1]] = Int32(8).dotNETObject()
         array[[0, 1, 2]] = Int32(7).dotNETObject()
-        
+
         array[[1, 0, 0]] = Int32(6).dotNETObject()
         array[[1, 0, 1]] = Int32(5).dotNETObject()
         array[[1, 0, 2]] = Int32(4).dotNETObject()
-        
+
         array[[1, 1, 0]] = Int32(3).dotNETObject()
         array[[1, 1, 1]] = Int32(2).dotNETObject()
         array[[1, 1, 2]] = Int32(1).dotNETObject()
-        
+
         // Check modified state
         XCTAssertEqual(try array[[0, 0, 0]].castToInt32(), 12)
         XCTAssertEqual(try array[[0, 0, 1]].castToInt32(), 11)
         XCTAssertEqual(try array[[0, 0, 2]].castToInt32(), 10)
-        
+
         XCTAssertEqual(try array[[0, 1, 0]].castToInt32(), 9)
         XCTAssertEqual(try array[[0, 1, 1]].castToInt32(), 8)
         XCTAssertEqual(try array[[0, 1, 2]].castToInt32(), 7)
-        
+
         XCTAssertEqual(try array[[1, 0, 0]].castToInt32(), 6)
         XCTAssertEqual(try array[[1, 0, 1]].castToInt32(), 5)
         XCTAssertEqual(try array[[1, 0, 2]].castToInt32(), 4)
-        
+
         XCTAssertEqual(try array[[1, 1, 0]].castToInt32(), 3)
         XCTAssertEqual(try array[[1, 1, 1]].castToInt32(), 2)
         XCTAssertEqual(try array[[1, 1, 2]].castToInt32(), 1)
     }
-    
+
     func testCreatingThreeDimensionalArrayOfInt32() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         let newArray = try DNMultidimensionalArray<System.Int32>(lengths: [3, 3, 3])
         let rank = try newArray.rank
-        
+
         XCTAssertEqual(rank, 3)
-        
+
         // Set values
         newArray[[0, 0, 0]] = Int32(12).dotNETObject()
         newArray[[0, 0, 1]] = Int32(11).dotNETObject()
         newArray[[0, 0, 2]] = Int32(10).dotNETObject()
-        
+
         newArray[[0, 1, 0]] = Int32(9).dotNETObject()
         newArray[[0, 1, 1]] = Int32(8).dotNETObject()
         newArray[[0, 1, 2]] = Int32(7).dotNETObject()
-        
+
         newArray[[1, 0, 0]] = Int32(6).dotNETObject()
         newArray[[1, 0, 1]] = Int32(5).dotNETObject()
         newArray[[1, 0, 2]] = Int32(4).dotNETObject()
-        
+
         newArray[[1, 1, 0]] = Int32(3).dotNETObject()
         newArray[[1, 1, 1]] = Int32(2).dotNETObject()
         newArray[[1, 1, 2]] = Int32(1).dotNETObject()
-        
+
         try tests.threeDimensionalArrayOfInt32_set(newArray)
-        
+
         let array = try tests.threeDimensionalArrayOfInt32
-        
+
         // Check state
         XCTAssertEqual(try array[[0, 0, 0]].castToInt32(), 12)
         XCTAssertEqual(try array[[0, 0, 1]].castToInt32(), 11)
         XCTAssertEqual(try array[[0, 0, 2]].castToInt32(), 10)
-        
+
         XCTAssertEqual(try array[[0, 1, 0]].castToInt32(), 9)
         XCTAssertEqual(try array[[0, 1, 1]].castToInt32(), 8)
         XCTAssertEqual(try array[[0, 1, 2]].castToInt32(), 7)
-        
+
         XCTAssertEqual(try array[[1, 0, 0]].castToInt32(), 6)
         XCTAssertEqual(try array[[1, 0, 1]].castToInt32(), 5)
         XCTAssertEqual(try array[[1, 0, 2]].castToInt32(), 4)
-        
+
         XCTAssertEqual(try array[[1, 1, 0]].castToInt32(), 3)
         XCTAssertEqual(try array[[1, 1, 1]].castToInt32(), 2)
         XCTAssertEqual(try array[[1, 1, 2]].castToInt32(), 1)
     }
-    
+
     func testArrayOfNullableString() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         let array = try tests.arrayOfNullableString
-        
+
         // Check initial state
         try verifyArrayOfNullableStringInitialState(array)
-        
+
         // Modify it
         array[3] = nil
-        
+
         try tests.arrayOfNullableString_set(array)
         let newArray = try tests.arrayOfNullableString
-        
+
         // Check modified state
         XCTAssertNil(newArray[0])
         XCTAssertEqual(newArray[1]?.string(), "a")
         XCTAssertEqual(newArray[2]?.string(), "b")
         XCTAssertNil(newArray[3])
     }
-    
+
     func testArrayOfNullableStringAsReturn() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
         let array = try tests.arrayOfNullableStringAsReturn()
-        
+
         try verifyArrayOfNullableStringInitialState(array)
     }
-    
+
     func testSetArrayOfNullableStringWithParameter() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         let newArray = try DNNullableArray<System.String>(length: 3)
         XCTAssertEqual(try newArray.rank, 1)
-        
+
         // Set values
         newArray[0] = "z".dotNETString()
         newArray[1] = "y".dotNETString()
         newArray[2] = "x".dotNETString()
-        
+
         try tests.setArrayOfNullableStringWithParameter(newArray)
-        
+
         let array = try tests.arrayOfNullableString
         XCTAssertEqual(try array.rank, 1)
-        
+
         // Check state
         XCTAssertEqual(try array.getValue(Int32(0))?.castTo(System.String.self).string(), "z")
         XCTAssertEqual(array[0]?.string(), "z")
-        
+
         XCTAssertEqual(try array.getValue(Int32(1))?.castTo(System.String.self).string(), "y")
         XCTAssertEqual(array[1]?.string(), "y")
-        
+
         XCTAssertEqual(try array.getValue(Int32(2))?.castTo(System.String.self).string(), "x")
         XCTAssertEqual(array[2]?.string(), "x")
     }
-    
+
     func testArrayOfNullableStringAsOut() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         var array: DNNullableArray<System.String> = try .empty
         try tests.arrayOfNullableStringAsOut(&array)
-        
+
         try verifyArrayOfNullableStringInitialState(array)
     }
-    
+
     func testArrayOfNullableStringAsRef() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         var array: DNNullableArray<System.String> = try .empty
         try tests.arrayOfNullableStringAsRef(&array)
-        
+
         try verifyArrayOfNullableStringInitialState(array)
     }
-    
+
     func verifyArrayOfNullableStringInitialState(_ array: DNNullableArray<System.String>) throws {
         XCTAssertEqual(try array.rank, 1)
-        
+
         XCTAssertNil(array[0])
         XCTAssertEqual(array[1]?.string(), "a")
         XCTAssertEqual(array[2]?.string(), "b")
         XCTAssertEqual(array[3]?.string(), "c")
     }
-    
+
     func testArrayOfGuids() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         let array = try tests.arrayOfGuids
         let rank = try array.rank
-        
+
         XCTAssertEqual(rank, 1)
-        
+
         let emptyGuid = System.Guid.empty
-        
+
         // Check initial state
         XCTAssertEqual(array[0], emptyGuid)
         XCTAssertNotEqual(array[1], emptyGuid)
-        
+
         // Modify it
         array[0] = try System.Guid.newGuid()
         array[1] = emptyGuid
-        
+
         try tests.arrayOfGuids_set(array)
         let newArray = try tests.arrayOfGuids
-        
+
         // Check modified state
         XCTAssertNotEqual(newArray[0], emptyGuid)
         XCTAssertEqual(newArray[1], emptyGuid)
     }
-    
+
     func testArrayOfCharacters() throws {
         let tests = try Beyond.NET.Sample.ArrayTests()
-        
+
         let array = try tests.arrayOfCharacters
         let rank = try array.rank
-        
+
         XCTAssertEqual(rank, 1)
-        
+
         let aCharSwift = "a" as Character
         let aChar = try XCTUnwrap(DNChar(character: aCharSwift))
         let aCharSwiftRet = try XCTUnwrap(aChar.character)
         XCTAssertEqual(aCharSwiftRet, aCharSwift)
-        
+
         let bCharSwift = "b" as Character
         let bChar = try XCTUnwrap(DNChar(character: bCharSwift))
         let bCharSwiftRet = try XCTUnwrap(bChar.character)
         XCTAssertEqual(bCharSwiftRet, bCharSwift)
-        
+
         let cCharSwift = "c" as Character
         let cChar = try XCTUnwrap(DNChar(character: cCharSwift))
         let cCharSwiftRet = try XCTUnwrap(cChar.character)
         XCTAssertEqual(cCharSwiftRet, cCharSwift)
-        
+
         // Check initial state
         XCTAssertEqual(try array[0].castToChar(), aChar)
         XCTAssertEqual(try array[1].castToChar(), bChar)
         XCTAssertEqual(try array[2].castToChar(), cChar)
-        
+
         // Modify it
         array[0] = cChar.dotNETObject()
         array[1] = aChar.dotNETObject()
         array[2] = bChar.dotNETObject()
-        
+
         try tests.arrayOfCharacters_set(array)
         let newArray = try tests.arrayOfCharacters
-        
+
         // Check modified state
         XCTAssertEqual(try newArray[0].castToChar(), cChar)
         XCTAssertEqual(try newArray[1].castToChar(), aChar)

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/AsyncTestTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/AsyncTestTests.swift
@@ -5,61 +5,61 @@ final class AsyncTestTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testAddAsync() throws {
         let number1: Int32 = 5
         let number2: Int32 = 10
         let expectedResult = number1 + number2
-        
+
         let asyncTests = try Beyond.NET.Sample.AsyncTests()
-        
+
         let task = try asyncTests.addAsync(number1, number2)
-        
+
         try task.wait()
-        
+
         guard let result = try task.result(TResult: System.Int32.typeOf),
               let unboxedResult = try? result.castToInt32() else {
             XCTFail("System.Threading.Tasks.Task.Wait should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(unboxedResult, expectedResult)
     }
-    
+
     func testTransformNumbersAsync() throws {
         let number1: Int32 = 5
         let number2: Int32 = 10
-        
+
         func multiplierFunc(inputNumber1: Int32,
                             inputNumber2: Int32) -> Int32 {
             inputNumber1 * inputNumber2
         }
-        
+
         let expectedResult = multiplierFunc(inputNumber1: number1,
                                             inputNumber2: number2)
-        
+
         let asyncTests = try Beyond.NET.Sample.AsyncTests()
-        
+
         let transformerDelegate = Beyond.NET.Sample.AsyncTests_TransformerDelegate(multiplierFunc)
-        
+
         let task = try asyncTests.transformNumbersAsync(number1,
                                                         number2,
                                                         transformerDelegate)
-        
+
         try task.wait()
-        
+
         guard let result = try task.result(TResult: System.Int32.typeOf),
               let unboxedResult = try? result.castToInt32() else {
             XCTFail("System.Threading.Tasks.Task.Wait should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(unboxedResult, expectedResult)
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/DelegateTestTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/DelegateTestTests.swift
@@ -5,25 +5,25 @@ final class DelegateTestTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testTransformInt() throws {
         let original: Int32 = 0
         let valueToAdd: Int32 = 1
         let expectedResult: Int32 = original + valueToAdd
-        
+
         let result = try Beyond.NET.Sample.DelegatesTest.transformInt(original, .init({ i in
             let innerResult = i + valueToAdd
-            
+
             return innerResult
         }))
 
         XCTAssertEqual(result, expectedResult)
     }
-    
+
     func testTransformStepMode() throws {
         var original: Beyond.NET.Sample.StepMode = .in
         var result = try Beyond.NET.Sample.DelegatesTest.transformStepMode(original)
@@ -37,7 +37,7 @@ final class DelegateTestTests: XCTestCase {
         result = try Beyond.NET.Sample.DelegatesTest.transformStepMode(original)
         XCTAssertEqual(result, original)
     }
-    
+
     // TODO: Delegates with ref parameters
 //    func testTransformIntWithRef() {
 //        let original: Int32 = 0
@@ -57,63 +57,63 @@ final class DelegateTestTests: XCTestCase {
 //        XCTAssertEqual(originalVar, expectedResult)
 //        XCTAssertEqual(original, 0)
 //    }
-    
+
     func testTransformPoint() throws {
         let originalX: Double = 0
         let originalY: Double = 0
-        
+
         let valueToAddToX: Double = 0.1
         let valueToAddToY: Double = 0.2
-        
+
         let original = try Beyond.NET.Sample.Point(originalX, originalY)
         let expectedResult = try Beyond.NET.Sample.Point(originalX + valueToAddToX, originalY + valueToAddToY)
-        
+
         let result = try Beyond.NET.Sample.DelegatesTest.transformPoint(original, .init({ p in
             guard let pX = try? p.x else {
                 XCTFail("Beyond.NET.Sample.Point.X should not throw")
-                
+
                 guard let emptyPoint = try? Beyond.NET.Sample.Point() else {
                     fatalError("Beyond.NET.Sample.Point ctor should not throw and return an instance")
                 }
-                
+
                 return emptyPoint
             }
-            
+
             guard let pY = try? p.y else {
                 XCTFail("Beyond.NET.Sample.Point.Y should not throw")
-                
+
                 guard let emptyPoint = try? Beyond.NET.Sample.Point() else {
                     fatalError("Beyond.NET.Sample.Point ctor should not throw and return an instance")
                 }
-                
+
                 return emptyPoint
             }
-            
+
             let newX = pX + valueToAddToX
             let newY = pY + valueToAddToY
-            
+
             guard let innerResult = try? Beyond.NET.Sample.Point(newX, newY) else {
                 XCTFail("Beyond.NET.Sample.Point ctor should not throw and return an instance")
 
                 guard let emptyPoint = try? Beyond.NET.Sample.Point() else {
                     fatalError("Beyond.NET.Sample.Point ctor should not throw and return an instance")
                 }
-                
+
                 return emptyPoint
             }
-            
+
             return innerResult
         }))
-        
+
         let resultX = try result.x
         let resultY = try result.y
         let expectedX = try expectedResult.x
         let expectedY = try expectedResult.y
-        
+
         XCTAssertEqual(resultX, expectedX)
         XCTAssertEqual(resultY, expectedY)
     }
-    
+
     // TODO: Delegates with ref parameters
 //    func testTransformPointWithRef() {
 //        let originalX: Double = 0

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/EventTestsTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/EventTestsTests.swift
@@ -5,58 +5,58 @@ final class EventTestTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     /* func testEventsAsInDocs() {
         // Create an instance of Beyond.NET.Sample.EventTests
         let eventTest = try! Beyond.NET.Sample.EventTests()!
-        
+
         // Create a variable that will hold the last value passed in to our event handler
         var lastValuePassedIntoEventHandler: Int32 = 0
-        
+
         // Create an event handler
         let eventHandler = Beyond.NET.Sample.EventTests_ValueChangedDelegate { sender, newValue in
             // Remember the last value passed in here
             lastValuePassedIntoEventHandler = newValue
         }
-        
+
         // Add the event handler
         eventTest.valueChanged_add(eventHandler)
-        
+
         // Set a new value (our event handler will be called for this one)
         try! eventTest.value_set(5)
-        
+
         // Remove the event handler
         eventTest.valueChanged_remove(eventHandler)
-        
+
         // Set a another new value (our event handler will NOT be called for this one because we already removed the event handler)
         try! eventTest.value_set(10)
-        
+
         // Prints "5"
         print(lastValuePassedIntoEventHandler)
     } */
-    
+
     func testEventTest() throws {
         let eventTest = try Beyond.NET.Sample.EventTests()
-        
+
         let expectedNewValue: Int32 = 5
         var newValuesPassedToValueChangedHandler = [Int32]()
-        
+
         let eventHandler = Beyond.NET.Sample.EventTests_ValueChangedDelegate { sender, newValue in
             newValuesPassedToValueChangedHandler.append(newValue)
         }
-        
+
         eventTest.valueChanged_add(eventHandler)
-        
+
         try eventTest.value_set(expectedNewValue)
-        
+
         eventTest.valueChanged_remove(eventHandler)
-        
+
         try eventTest.value_set(10)
-        
+
         XCTAssertEqual(1, newValuesPassedToValueChangedHandler.count)
         XCTAssertEqual(newValuesPassedToValueChangedHandler[0], expectedNewValue)
     }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/GenericTestClassTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/GenericTestClassTests.swift
@@ -6,86 +6,86 @@ final class GenericTestClassTests: XCTestCase {
 	override class func setUp() {
 		Self.sharedSetUp()
 	}
-	
+
 	override class func tearDown() {
 		Self.sharedTearDown()
 	}
-	
+
 	func testWith1GenericArgument() throws {
 		let systemStringType = System_String.typeOf
-		
+
         let genericTestClass = try Beyond_NET_Sample_GenericTestClass_A1(T: systemStringType)
 		let genericTestClassType = try genericTestClass.getType()
-		
+
 		guard let genericTestClassTypeName = try genericTestClassType.fullName?.string() else {
 			XCTFail("System.Type.FullName getter should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertTrue(genericTestClassTypeName.contains("GenericTestClass`1[[System.String"))
-		
+
         let genericArgumentType = try genericTestClass.returnGenericClassType(T: systemStringType)
-		
+
 		let typesEqual = systemStringType == genericArgumentType
 		XCTAssertTrue(typesEqual)
-		
+
 		let value: Int32 = 5
-		
+
         try genericTestClass.aProperty_set(T: systemStringType, value)
-		
+
         let propValueRet = try genericTestClass.aProperty(T: systemStringType)
-		
+
 		XCTAssertEqual(value, propValueRet)
-		
+
         genericTestClass.aField_set(T: systemStringType, value)
-		
+
         let fieldValueRet = genericTestClass.aField(T: systemStringType)
 		XCTAssertEqual(value, fieldValueRet)
-		
+
 		let systemArrayType = System_Array.typeOf
-        
+
         let genericArgumentAndMethodType = try Beyond_NET_Sample_GenericTestClass_A1.returnGenericClassTypeAndGenericMethodType(T: systemStringType,
                                                                                                                                 TM: systemArrayType)
-		
+
 		let genericArgumentAndMethodTypeLength = try genericArgumentAndMethodType.length
 		XCTAssertEqual(2, genericArgumentAndMethodTypeLength)
-		
+
 		guard let genericTypeArgument = try genericArgumentAndMethodType.getValue(0 as Int32) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertTrue(systemStringType == genericTypeArgument)
-		
+
 		guard let genericMethodArgument = try genericArgumentAndMethodType.getValue(1 as Int32) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertTrue(systemArrayType == genericMethodArgument)
 	}
-	
+
 	func testExtremeWith1GenericArgument() throws {
 		let systemStringType = System_String.typeOf
 		let systemExceptionType = System_Exception.typeOf
-		
+
         let genericTestClass = try Beyond_NET_Sample_GenericTestClass_A1(T: systemStringType)
-		
+
 		let string = "Hello World"
 		let stringDN = string.dotNETString()
-		
+
 		let originalException = try System_Exception(stringDN)
-		
+
 		var inOutExceptionAsObject: System_Object? = originalException
-		
+
 		let countIn: Int32 = 15
 		var countOut: Int32 = -1
-		
+
 		var output: System_Object?
-		
+
         let returnValue = try genericTestClass.extreme(T: systemStringType,
                                                        TM: systemExceptionType,
                                                        countIn,
@@ -93,111 +93,111 @@ final class GenericTestClassTests: XCTestCase {
                                                        stringDN,
                                                        &output,
                                                        &inOutExceptionAsObject)
-		
+
 		XCTAssertEqual(countIn, countOut)
-		
+
 		let outputEqualsInput = stringDN == output
 		XCTAssertTrue(outputEqualsInput)
-		
+
 		let returnValueEqualsInput = stringDN == returnValue
 		XCTAssertTrue(returnValueEqualsInput)
-		
+
 		XCTAssertNil(inOutExceptionAsObject)
 	}
-	
+
 	func testWith2GenericArguments() throws {
 		let systemStringType = System_String.typeOf
 		let systemExceptionType = System_Exception.typeOf
-		
+
         let genericTestClass = try Beyond_NET_Sample_GenericTestClass_A2(T1: systemStringType,
                                                                          T2: systemExceptionType)
-		
+
 		let genericTestClassType = try genericTestClass.getType()
-		
+
 		guard let genericTestClassTypeName = try genericTestClassType.fullName?.string() else {
 			XCTFail("System.Type.FullName getter should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertTrue(genericTestClassTypeName.contains("GenericTestClass`2[[System.String"))
 		XCTAssertTrue(genericTestClassTypeName.contains(",[System.Exception"))
-		
+
         let genericArgumentTypes = try genericTestClass.returnGenericClassTypes(T1: systemStringType,
                                                                                 T2: systemExceptionType)
-		
+
 		let numberOfGenericArguments = try genericArgumentTypes.length
 		XCTAssertEqual(2, numberOfGenericArguments)
-		
+
 		guard let firstGenericArgument = try genericArgumentTypes.getValue(0 as Int32) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		let firstGenericTypeEqual = systemStringType == firstGenericArgument
 		XCTAssertTrue(firstGenericTypeEqual)
-		
+
 		guard let secondGenericArgument = try genericArgumentTypes.getValue(1 as Int32) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		let secondGenericTypeEqual = systemExceptionType == secondGenericArgument
 		XCTAssertTrue(secondGenericTypeEqual)
-		
+
 		let value: Int32 = 5
-		
+
         try genericTestClass.aProperty_set(T1: systemStringType,
                                            T2: systemExceptionType,
                                            value)
-        
+
         let propValueRet = try genericTestClass.aProperty(T1: systemStringType,
                                                           T2: systemExceptionType)
-        
+
         XCTAssertEqual(value, propValueRet)
-		
+
         genericTestClass.aField_set(T1: systemStringType,
                                     T2: systemExceptionType,
 									value)
-		
+
         let fieldValueRet = genericTestClass.aField(T1: systemStringType,
                                                     T2: systemExceptionType)
-		
+
 		XCTAssertEqual(value, fieldValueRet)
-		
+
 		let systemArrayType = System_Array.typeOf
-		
+
         let genericArgumentsAndMethodType = try Beyond_NET_Sample_GenericTestClass_A2.returnGenericClassTypeAndGenericMethodType(T1: systemStringType,
                                                                                                                                  T2: systemExceptionType,
                                                                                                                                  TM: systemArrayType)
-		
+
 		let genericArgumentsAndMethodTypeLength = try genericArgumentsAndMethodType.length
 		XCTAssertEqual(3, genericArgumentsAndMethodTypeLength)
-		
+
 		guard let firstGenericTypeArgument = try genericArgumentsAndMethodType.getValue(0 as Int32) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertTrue(systemStringType == firstGenericTypeArgument)
-		
+
 		guard let secondGenericTypeArgument = try genericArgumentsAndMethodType.getValue(1 as Int32) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertTrue(systemExceptionType == secondGenericTypeArgument)
-		
+
 		guard let genericMethodArgument = try genericArgumentsAndMethodType.getValue(2 as Int32) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertTrue(systemArrayType == genericMethodArgument)
 	}
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/GenericTestsTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/GenericTestsTests.swift
@@ -5,88 +5,88 @@ final class GenericTestsTests: XCTestCase {
 	override class func setUp() {
 		Self.sharedSetUp()
 	}
-	
+
 	override class func tearDown() {
 		Self.sharedTearDown()
 	}
-	
+
 	func testReturnGenericTypeWithReferenceType() throws {
 		let genericType = System_String.typeOf
-		
+
         let typeRet = try Beyond_NET_Sample_GenericTests.returnGenericType(T: genericType)
 		let typesEqual = genericType == typeRet
 		XCTAssertTrue(typesEqual)
 	}
-	
+
 	// Currently, value types as generic parameters aren't supported through reflection when compiling with NativeAOT
 	// It's possible to specifically include these types with a Rd.xml
 	// https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/rd-xml-format.md
 	func testReturnGenericTypeWithValueType() {
 		let genericType = System_Guid.typeOf
-		
+
 		do {
             _ = try Beyond_NET_Sample_GenericTests.returnGenericType(T: genericType)
-			
+
 			XCTFail("This should fail")
 		} catch { }
 	}
-	
+
 	func testReturnGenericTypeAsOutParameter() throws {
         let genericType = System_String.typeOf
-        
+
         var typeRet: System_Type?
-        
+
         try Beyond_NET_Sample_GenericTests.returnGenericTypeAsOutParameter(T: genericType,
                                                                            &typeRet)
-        
+
         guard let typeRet else {
 			XCTFail("ReturnGenericTypeAsOutParameter<System.String> should not throw and return an instance as out parameter")
-			
+
 			return
 		}
-		
+
 		let typesEqual = genericType == typeRet
 		XCTAssertTrue(typesEqual)
 	}
-	
+
 	func testReturnGenericTypeAsRefParameter() throws {
 		let genericType = System_String.typeOf
 		let systemObjectType = System_Object.typeOf
-        
+
         var typeRet: System_Type? = systemObjectType
-        
+
         try Beyond_NET_Sample_GenericTests.returnGenericTypeAsRefParameter(T: genericType,
                                                                            &typeRet)
-        
+
         guard let typeRet else {
             XCTFail("ReturnGenericTypeAsRefParameter<System.String> should not throw and return an instance as ref parameter")
-            
+
 			return
 		}
-		
+
 		let typesEqual = genericType == typeRet
 		XCTAssertTrue(typesEqual)
 	}
-	
+
 	func testReturnGenericTypes() throws {
 		let genericType1 = System_String.typeOf
         let genericType2 = System_Array.typeOf
-        
+
         let typesArrayRet = try Beyond_NET_Sample_GenericTests.returnGenericTypes(T1: genericType1,
                                                                                   T2: genericType2)
-        
+
         let typesLength = try typesArrayRet.length
         XCTAssertEqual(2, .init(typesLength))
-        
+
         for idx in 0..<typesLength {
             guard let type = try typesArrayRet.getValue(idx) else {
 				XCTFail("System.Array.GetValue should not throw and return an instance")
-				
+
 				return
 			}
-			
+
 			let typeToCompareTo: System_Type
-			
+
 			switch idx {
 				case 0:
 					typeToCompareTo = genericType1
@@ -94,39 +94,39 @@ final class GenericTestsTests: XCTestCase {
 					typeToCompareTo = genericType2
 				default:
 					XCTFail("Unknown index")
-					
+
 					return
 			}
-			
+
 			let typesEqual = type == typeToCompareTo
 			XCTAssertTrue(typesEqual)
 		}
 	}
-	
+
 	func testReturnDefaultValueOfGenericType() throws {
 		let genericType = System_String.typeOf
-		
+
         let defaultValueRet = try Beyond_NET_Sample_GenericTests.returnDefaultValueOfGenericType(T: genericType)
         XCTAssertNil(defaultValueRet)
 	}
-	
+
 	func testReturnArrayOfDefaultValuesOfGenericType() throws {
 		let genericType = System_String.typeOf
-		
+
 		let numberOfElements: Int32 = 10
-		
+
         let defaultValuesArrayRet = try Beyond_NET_Sample_GenericTests.returnArrayOfDefaultValuesOfGenericType(T: genericType,
                                                                                                                numberOfElements)
-		
+
 		let length = try defaultValuesArrayRet.length
 		XCTAssertEqual(numberOfElements, length)
-		
+
 		for i in 0..<length {
             let defaultValue = try defaultValuesArrayRet.getValue(i)
             XCTAssertNil(defaultValue)
 		}
 	}
-	
+
 	func testReturnArrayOfRepeatedValues() throws {
 		let numberOfElements: Int32 = 100
 
@@ -153,139 +153,139 @@ final class GenericTestsTests: XCTestCase {
 			XCTAssertTrue(equal)
 		}
 	}
-	
+
 	func testReturnSimpleKeyValuePair() throws {
 		let keyType = System_Type.typeOf
 		let valueType = System_Text_StringBuilder.typeOf
 		let key = System_Type.typeOf
-		
+
 		let value = try System_Text_StringBuilder()
-		
+
 		let expectedString = "Hello World"
 		let expectedStringDN = expectedString.dotNETString()
-        
+
         guard try value.append(expectedStringDN) == value else {
             XCTFail("Should return true")
-            
+
             return
         }
-        
+
         let keyValuePair = try Beyond_NET_Sample_GenericTests.returnSimpleKeyValuePair(TKey: keyType,
                                                                                        TValue: valueType,
                                                                                        key,
                                                                                        value)
-		
+
 		guard let keyRet = try keyValuePair.key else {
 			XCTFail("SimpleKeyValuePair.Key getter should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		let keyEqual = key == keyRet
 		XCTAssertTrue(keyEqual)
-		
+
 		guard let valueRet = try keyValuePair.value else {
 			XCTFail("SimpleKeyValuePair.Value getter should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		let valueEqual = value == valueRet
 		XCTAssertTrue(valueEqual)
-		
+
 		let stringRet = try valueRet.castTo(System_Text_StringBuilder.self).toString().string()
 		XCTAssertEqual(expectedString, stringRet)
 	}
-	
+
 	func testIncorrectParametersInGenericMethod() throws {
 		let keyType = System_Type.typeOf
 		let valueType = System_Text_StringBuilder.typeOf
 		let key = System_Type.typeOf
-		
+
 		let value = try System_Object()
-        
+
         do {
             _ = try Beyond_NET_Sample_GenericTests.returnSimpleKeyValuePair(TKey: keyType,
                                                                             TValue: valueType,
                                                                             key,
                                                                             value)
-            
+
             XCTFail("ReturnSimpleKeyValuePair should throw an exception because the value passed in does not match the provided generic type")
         } catch {
 			let exceptionMessage = error.localizedDescription
-			
+
 			XCTAssertEqual(exceptionMessage, "Object of type \'System.Object\' cannot be converted to type \'System.Text.StringBuilder\'.")
 		}
 	}
-	
+
 	func testReturnStringOfJoinedArray() throws {
 		let numberOfElements: Int32 = 10
 		let stringPrefix = "Hello_"
-		
+
 		let separator = ";"
 		let separatorDN = separator.dotNETString()
-		
+
 		let stringType = System_String.typeOf
 
 		let arrayOfStrings = try DNArray<System_String>(length: numberOfElements)
 
 		var dnStrings = [System_String]()
 		var strings = [String]()
-		
+
 		for idx in 0..<numberOfElements {
 			let string = "\(stringPrefix)\(idx)"
 			let stringDN = string.dotNETString()
-			
+
 			dnStrings.append(stringDN)
 			strings.append(string)
 
 			try arrayOfStrings.setValue(stringDN, idx)
 		}
-		
+
 		let expectedString = strings.joined(separator: separator)
 
         let stringRet = try Beyond_NET_Sample_GenericTests.returnStringOfJoinedArray(T: stringType,
                                                                                      arrayOfStrings,
                                                                                      separatorDN).string()
-		
+
 		XCTAssertEqual(expectedString, stringRet)
 	}
-	
+
 	func testConstructedGenericListOfStrings() throws {
 		let genericTests = try Beyond_NET_Sample_GenericTests()
-        
+
 		let listOfStrings = try genericTests.listOfStrings
-        
+
 		let listType = System_Collections_Generic_List_A1.typeOf
 		let systemStringType = System_String.typeOf
-		
+
 		let typeArguments = try DNArray<System_Type>(length: 1)
-        
+
         typeArguments[0] = systemStringType
-		
+
         let listOfStringType = try listType.makeGenericType(typeArguments)
 		XCTAssertTrue(listOfStrings.is(listOfStringType))
-		
+
         let arrayOfStrings = try listOfStrings.toArray(T: systemStringType)
-		
+
 		let length = try arrayOfStrings.length
 		XCTAssertEqual(2, length)
-		
+
 		guard let firstObject = try arrayOfStrings.getValue(0 as Int32) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-        
+
         let firstString = try firstObject.castTo(System_String.self).string()
 		XCTAssertEqual("A", firstString)
-		
+
 		guard let secondObject = try arrayOfStrings.getValue(1 as Int32) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
         let secondString = try secondObject.castTo(System_String.self).string()
 		XCTAssertEqual("B", secondString)
 	}

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/IndexerTestsTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/IndexerTestsTests.swift
@@ -5,111 +5,111 @@ final class IndexerTestsTests: XCTestCase {
 	override class func setUp() {
 		Self.sharedSetUp()
 	}
-	
+
 	override class func tearDown() {
 		Self.sharedTearDown()
 	}
-	
+
 	func testGetIndexedPropertyWith3Parameters() throws {
 		let indexerTests = try Beyond_NET_Sample_IndexerTests()
-		
+
 		let aString = "A String"
 		let aStringDN = aString.dotNETString()
-		
+
 		let aNumber: Int32 = 123456
-		
+
 		let aGuid = try System_Guid.newGuid()
-		
+
         let arrayRet = try indexerTests.item(aStringDN,
                                              aNumber,
                                              aGuid)
-		
+
 		let arrayLength = try arrayRet.length
 		XCTAssertEqual(3, arrayLength)
-		
+
 		guard let item1RetAsString = try arrayRet.getValue(0 as Int32)?.castAs(System_String.self)?.string() else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertEqual(aString, item1RetAsString)
-		
+
 		guard let item2RetAsInt32 = try arrayRet.getValue(1 as Int32)?.castToInt32() else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertEqual(aNumber, item2RetAsInt32)
-		
+
 		guard let item3Ret = try arrayRet.getValue(2 as Int32)?.castTo(System_Guid.self) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		let guidEqual = aGuid == item3Ret
-		
+
 		XCTAssertTrue(guidEqual)
 	}
-	
+
 	func testSetIndexedPropertyWith3Parameters() throws {
 		let indexerTests = try Beyond_NET_Sample_IndexerTests()
-		
+
 		let aString = "A String"
 		let aStringDN = aString.dotNETString()
-		
+
 		let aNumber: Int32 = 123456
-		
+
 		let aGuid = try System_Guid.newGuid()
-		
+
         let array = try DNArray<System_Object>(length: 3)
-		
+
 		try array.setValue(aStringDN, 0 as Int32)
 		try array.setValue(DNObject.fromInt32(aNumber), 1 as Int32)
 		try array.setValue(aGuid, 2 as Int32)
-        
+
         try indexerTests.item_set(aStringDN,
                                   aNumber,
                                   aGuid,
                                   array.castTo())
-		
+
 		let arrayRet = try indexerTests.storedValue
 		let arrayLength = try arrayRet.length
 		XCTAssertEqual(3, arrayLength)
-		
+
 		guard let item1RetAsString = try arrayRet.getValue(0 as Int32)?.castTo(System_String.self).string() else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertEqual(aString, item1RetAsString)
-		
+
 		let storedString = try indexerTests.storedString.string()
 		XCTAssertEqual(aString, storedString)
-		
+
 		guard let item2RetAsInt32 = try arrayRet.getValue(1 as Int32)?.castToInt32() else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertEqual(aNumber, item2RetAsInt32)
-		
+
 		let storedNumber = try indexerTests.storedNumber
 		XCTAssertEqual(aNumber, storedNumber)
-		
+
 		guard let item3Ret = try arrayRet.getValue(2 as Int32)?.castTo(System_Guid.self) else {
 			XCTFail("System.Array.GetValue should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		let guidEqual = aGuid == item3Ret
 		XCTAssertTrue(guidEqual)
-		
+
 		let storedGuid = try indexerTests.storedGuid
 		let storedGuidEqual = aGuid == storedGuid
 		XCTAssertTrue(storedGuidEqual)

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/InterfaceTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/InterfaceTests.swift
@@ -5,15 +5,15 @@ final class InterfaceTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testPassingInInterfaces() throws {
         let typeThatImplementsMultipleInterfaces = try Beyond.NET.Sample.TypeThatImplementsMultipleInterfaces()
         let typeThatUsesInterfaces = try Beyond.NET.Sample.TypeThatUsesInterfaces()
-        
+
         let val: Int32 = 5
         try typeThatUsesInterfaces.callMethod1InIInterface1(typeThatImplementsMultipleInterfaces)
         try typeThatUsesInterfaces.setPropertyInIInterface2(typeThatImplementsMultipleInterfaces, val)
@@ -21,34 +21,34 @@ final class InterfaceTests: XCTestCase {
         XCTAssertEqual(val, retVal)
         try typeThatUsesInterfaces.callMethod1InIInterface3(typeThatImplementsMultipleInterfaces)
     }
-    
+
     func testRetrievingInterfaces() throws {
         let typeThatUsesInterfaces = try Beyond.NET.Sample.TypeThatUsesInterfaces()
-        
+
         let interface1 = try typeThatUsesInterfaces.getTypeThatImplementsIInterface1()
         try interface1.methodInIInterface1()
-        
+
         // Use an out parameter placeholder of the correct type here so that we don't have to provide a default value.
         var interface1AsOutParam: Beyond_NET_Sample_IInterface1 = Beyond_NET_Sample_IInterface1_DNInterface.outParameterPlaceholder
         XCTAssertTrue(interface1AsOutParam.isOutParameterPlaceholder)
-        
+
         // This would crash because an out parameter placeholder is NOT a valid object!
 //        try interface1AsOutParam.methodInIInterface1()
-        
+
         try typeThatUsesInterfaces.getTypeThatImplementsIInterface1AsOutParam(&interface1AsOutParam)
         XCTAssertFalse(interface1AsOutParam.isOutParameterPlaceholder)
-        
+
         // This is unnecessary for APIs that return an optional out parameter. In this case we can just use regular Swift syntax.
 //        var interface2AsOutParam: Beyond_NET_Sample_IInterface2? = Beyond_NET_Sample_IInterface2_DNInterface.outParameterPlaceholder
         var interface2AsOutParam: Beyond_NET_Sample_IInterface2?
         try typeThatUsesInterfaces.getTypeThatMaybeImplementsIInterface2AsOutParam(&interface2AsOutParam)
-        
+
         let interface2 = try typeThatUsesInterfaces.getTypeThatImplementsIInterface2()
         try interface2.propertyInIInterface2_set(42)
-        
+
         let interface3 = try typeThatUsesInterfaces.getTypeThatImplementsIInterface3()
         try interface3.methodInIInterface3()
-        
+
         XCTAssertTrue(interface1.is(Beyond.NET.Sample.IInterface1_DNInterface.typeOf))
         XCTAssertTrue(interface1AsOutParam.is(Beyond.NET.Sample.IInterface1_DNInterface.typeOf))
         XCTAssertFalse(interface1 === interface1AsOutParam)
@@ -56,29 +56,29 @@ final class InterfaceTests: XCTestCase {
         XCTAssertTrue(interface3.is(Beyond.NET.Sample.IInterface3_DNInterface.typeOf))
         XCTAssertNil(interface2AsOutParam)
     }
-    
+
     func testInterfaceAdapter() throws {
         let typeThatUsesInterfaces = try Beyond.NET.Sample.TypeThatUsesInterfaces()
-        
+
         let methodInIInterface1CalledExpectation = expectation(description: "IInterface1.MethodInIInterface1 called in Swift")
-        
+
         // Compiler ensures we provide all interface requirements.
         // Ideally, we'd have an auto-generated Swift wrapper type that sets up all the delegate -> closure callbacks and allows us to just override the members required to satisfy the interface/protocol requirements.
         let interface1Adapter = try Beyond.NET.Sample.IInterface1_DelegateAdapter(.init({
             print("IInterface1.MethodInIInterface1 called in Swift")
-            
+
             methodInIInterface1CalledExpectation.fulfill()
         }))
-        
+
         try typeThatUsesInterfaces.callMethod1InIInterface1(interface1Adapter)
-        
+
         wait(for: [ methodInIInterface1CalledExpectation ])
     }
-    
+
     func testDelegateThatReceivesInterface() throws {
         let typeThatUsesInterfaces = try Beyond.NET.Sample.TypeThatUsesInterfaces()
         let typeThatImplementsInterface = try Beyond.NET.Sample.TypeThatImplementsMultipleInterfaces()
-        
+
         try typeThatUsesInterfaces.delegateThatReceivesInterfaceTest(.init({ interface1 in
             do {
                 try interface1.methodInIInterface1()
@@ -87,22 +87,22 @@ final class InterfaceTests: XCTestCase {
             }
         }), typeThatImplementsInterface)
     }
-    
+
     func testDelegateThatReturnsInterface() throws {
         let typeThatUsesInterfaces = try Beyond.NET.Sample.TypeThatUsesInterfaces()
-        
+
         let returnedInterface = try typeThatUsesInterfaces.delegateThatReturnsInterfaceTest(.init({
             do {
                 let typeThatImplementsInterface = try Beyond.NET.Sample.TypeThatImplementsMultipleInterfaces()
-                
+
                 return typeThatImplementsInterface
             } catch {
                 XCTFail("Should not throw")
-                
+
                 return nil
             }
         }))
-        
+
         try returnedInterface.methodInIInterface1()
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/NullabilityTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/NullabilityTests.swift
@@ -5,29 +5,29 @@ final class NullabilityTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testMethodPropertyAndFieldNullability() throws {
         let test = try XCTUnwrap(Beyond.NET.Sample.NullabilityTests())
-        
+
         let helloString = "Hello".dotNETString()
         let nilString: System.String? = nil
-        
+
         XCTAssertEqual(try test.methodWithNonNullableStringParameter(helloString), helloString)
         XCTAssertEqual(try test.methodWithNullableStringParameter(nilString), nilString)
-        
+
         XCTAssertEqual(try test.nonNullableStringProperty, helloString)
         XCTAssertEqual(test.nonNullableStringField, helloString)
         XCTAssertEqual(try test.nullableStringProperty, nilString)
         XCTAssertEqual(test.nullableStringField, nilString)
-        
+
         XCTAssertEqual(try test.methodWithNonNullableStringReturnValue(), helloString)
         XCTAssertEqual(try test.methodWithNullableStringReturnValue(), nilString)
     }
-    
+
     func testConstructor() throws {
         let _ = try Beyond.NET.Sample.NullabilityTests(false) // Should not throw
         XCTAssertThrowsError(try Beyond.NET.Sample.NullabilityTests(true)) // Should throw

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/OutParameterTestTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/OutParameterTestTests.swift
@@ -5,179 +5,179 @@ final class OutParameterTestTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     private func makeInstance() throws -> Beyond.NET.Sample.Source.OutParameterTests {
         try Beyond.NET.Sample.Source.OutParameterTests()
     }
-    
+
     // MARK: - Primitives
     func testNonOptionalPrimitives() throws {
         let inst = try makeInstance()
-        
+
         var returnValue: Int32 = 0
         try inst.return_Int_1_NonOptional(&returnValue)
         XCTAssertEqual(returnValue, 1)
     }
-    
+
     // NOTE: Beyond.NET does not currently support nullable primitives. That's why the other test cases are not implemented.
 //    func testOptionalPrimitives() throws { }
 //    func testOptionalNullPrimitives() throws { }
-    
+
     // MARK: - Enums
     func testNonOptionalEnums() throws {
         let inst = try makeInstance()
-        
+
         var returnValue = System.DateTimeKind.unspecified
         try inst.return_DateTimeKind_Utc_NonOptional(&returnValue)
         XCTAssertEqual(returnValue, System.DateTimeKind.utc)
     }
-    
+
     // NOTE: Beyond.NET does not currently support nullable enums. That's why the other test cases are not implemented.
 //    func testOptionalEnums() throws { }
 //    func testOptionalNullEnums() throws { }
-    
+
     // MARK: - Structs
     func testNonOptionalStructs() throws {
         let inst = try makeInstance()
-        
+
         var returnValue = System.DateTime.minValue
         try inst.return_DateTime_MaxValue_NonOptional(&returnValue)
         XCTAssertEqual(returnValue, System.DateTime.maxValue)
-        
+
         var returnValueWithPlaceholder = System.DateTime.outParameterPlaceholder
         try inst.return_DateTime_MaxValue_NonOptional(&returnValueWithPlaceholder)
         XCTAssertEqual(returnValueWithPlaceholder, System.DateTime.maxValue)
     }
-    
+
     func testOptionalStructs() throws {
         let inst = try makeInstance()
-        
+
         var returnValue: System.DateTime?
         try inst.return_DateTime_MaxValue_Optional(&returnValue)
         XCTAssertEqual(returnValue, System.DateTime.maxValue)
-        
+
         var returnValueWithInValue: System.DateTime? = .minValue
         try inst.return_DateTime_MaxValue_Optional(&returnValueWithInValue)
         XCTAssertEqual(returnValueWithInValue, System.DateTime.maxValue)
-        
+
         var returnValueWithPlaceholder: System.DateTime? = System.DateTime.outParameterPlaceholder
         try inst.return_DateTime_MaxValue_Optional(&returnValueWithPlaceholder)
         XCTAssertEqual(returnValueWithPlaceholder, System.DateTime.maxValue)
     }
-    
+
     func testOptionalNullStructs() throws {
         let inst = try makeInstance()
-        
+
         var returnValue: System.DateTime?
         try inst.return_DateTime_Null(&returnValue)
         XCTAssertNil(returnValue)
-        
+
         var returnValueWithInValue: System.DateTime? = .minValue
         try inst.return_DateTime_Null(&returnValueWithInValue)
         XCTAssertNil(returnValueWithInValue)
-        
+
         var returnValueWithPlaceholder: System.DateTime? = System.DateTime.outParameterPlaceholder
         try inst.return_DateTime_Null(&returnValueWithPlaceholder)
         XCTAssertNil(returnValueWithPlaceholder)
     }
-    
+
     // MARK: - Classes
     func testNonOptionalClasses() throws {
         let inst = try makeInstance()
-        
+
         let abc = "Abc".dotNETString()
-        
+
         var returnValue = System.String.empty
         try inst.return_String_Abc_NonOptional(&returnValue)
         XCTAssertEqual(returnValue, abc)
-        
+
         var returnValueWithPlaceholder = System.String.outParameterPlaceholder
         try inst.return_String_Abc_NonOptional(&returnValueWithPlaceholder)
         XCTAssertEqual(returnValueWithPlaceholder, abc)
     }
-    
+
     func testOptionalClasses() throws {
         let inst = try makeInstance()
-        
+
         let abc = "Abc".dotNETString()
-        
+
         var returnValue: System.String?
         try inst.return_String_Abc_Optional(&returnValue)
         XCTAssertEqual(returnValue, abc)
-        
+
         var returnValueWithInValue: System.String? = .empty
         try inst.return_String_Abc_Optional(&returnValueWithInValue)
         XCTAssertEqual(returnValue, abc)
-        
+
         var returnValueWithPlaceholder: System.String? = System.String.outParameterPlaceholder
         try inst.return_String_Abc_Optional(&returnValueWithPlaceholder)
         XCTAssertEqual(returnValue, abc)
     }
-    
+
     func testOptionalNullClasses() throws {
         let inst = try makeInstance()
-        
+
         var returnValue: System.String?
         try inst.return_String_Null(&returnValue)
         XCTAssertNil(returnValue)
-        
+
         var returnValueWithInValue: System.String? = .empty
         try inst.return_String_Null(&returnValueWithInValue)
         XCTAssertNil(returnValueWithInValue)
-        
+
         var returnValueWithPlaceholder: System.String? = System.String.outParameterPlaceholder
         try inst.return_String_Null(&returnValueWithPlaceholder)
         XCTAssertNil(returnValueWithPlaceholder)
     }
-    
+
     // MARK: - Interfaces
     func testNonOptionalInterfaces() throws {
         let inst = try makeInstance()
-        
+
         let abc = "Abc".dotNETString()
-        
+
         var returnValue: System.Collections.IEnumerable = System.String.empty
         try inst.return_IEnumerable_String_Abc_NonOptional(&returnValue)
         XCTAssertEqual(try returnValue.castTo(System.String.self), abc)
-        
+
         var returnValueWithPlaceholder: System.Collections.IEnumerable = System.Collections.IEnumerable_DNInterface.outParameterPlaceholder
         try inst.return_IEnumerable_String_Abc_NonOptional(&returnValueWithPlaceholder)
         XCTAssertEqual(try returnValueWithPlaceholder.castTo(System.String.self), abc)
     }
-    
+
     func testOptionalInterfaces() throws {
         let inst = try makeInstance()
-        
+
         let abc = "Abc".dotNETString()
-        
+
         var returnValue: System.Collections.IEnumerable?
         try inst.return_IEnumerable_String_Abc_Optional(&returnValue)
         XCTAssertEqual(try returnValue?.castTo(System.String.self), abc)
-        
+
         var returnValueWithInValue: System.Collections.IEnumerable? = System.String.empty
         try inst.return_IEnumerable_String_Abc_Optional(&returnValueWithInValue)
         XCTAssertEqual(try returnValueWithInValue?.castTo(System.String.self), abc)
-        
+
         var returnValueWithPlaceholder: System.Collections.IEnumerable? = System.String.outParameterPlaceholder
         try inst.return_IEnumerable_String_Abc_Optional(&returnValueWithPlaceholder)
         XCTAssertEqual(try returnValueWithPlaceholder?.castTo(System.String.self), abc)
     }
-    
+
     func testOptionalNullInterfaces() throws {
         let inst = try makeInstance()
-        
+
         var returnValue: System.Collections.IEnumerable?
         try inst.return_IEnumerable_Null(&returnValue)
         XCTAssertNil(returnValue)
-        
+
         var returnValueWithInValue: System.Collections.IEnumerable? = System.String.empty
         try inst.return_IEnumerable_Null(&returnValueWithInValue)
         XCTAssertNil(returnValueWithInValue)
-        
+
         var returnValueWithPlaceholder: System.Collections.IEnumerable? = System.Collections.IEnumerable_DNInterface.outParameterPlaceholder
         try inst.return_IEnumerable_Null(&returnValueWithPlaceholder)
         XCTAssertNil(returnValueWithPlaceholder)

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/PersonTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/PersonTests.swift
@@ -5,187 +5,187 @@ final class PersonTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testPerson() throws {
         let firstName = "John"
         let firstNameDN = firstName.dotNETString()
-        
+
         let lastName = "Doe"
         let lastNameDN = lastName.dotNETString()
-        
+
         let age: Int32 = 24
         let expectedNiceLevel: Beyond_NET_Sample_NiceLevels = .veryNice
         let expectedNiceLevelString = "Very nice"
-        
+
         let expectedFullName = "\(firstName) \(lastName)"
         let expectedWelcomeMessage = "Welcome, \(expectedFullName)! You're \(age) years old and \(expectedNiceLevelString)."
-        
+
         let ageWhenBorn = Beyond_NET_Sample_Person.aGE_WHEN_BORN
         XCTAssertEqual(0, ageWhenBorn)
-        
+
         let defaultAge = Beyond_NET_Sample_Person.dEFAULT_AGE
         XCTAssertEqual(ageWhenBorn, defaultAge)
-        
+
         let person = try Beyond_NET_Sample_Person(firstNameDN,
                                                   lastNameDN)
-        
+
         let personAge = try person.age
         XCTAssertEqual(defaultAge, personAge)
-        
+
         try person.niceLevel_set(expectedNiceLevel)
-        
+
         let retrievedNiceLevel = try person.niceLevel
         XCTAssertEqual(expectedNiceLevel, retrievedNiceLevel)
-        
+
         let retrievedFirstName = try person.firstName.string()
         XCTAssertEqual(firstName, retrievedFirstName)
-        
+
         let retrievedLastName = try person.lastName.string()
         XCTAssertEqual(lastName, retrievedLastName)
-        
+
         let retrievedFullName = try person.fullName.string()
         XCTAssertEqual(expectedFullName, retrievedFullName)
-        
+
         let retrievedAge = try person.age
         XCTAssertEqual(defaultAge, retrievedAge)
-        
+
         try person.age_set(age)
-        
+
         let retrievedWelcomeMessage = try person.getWelcomeMessage().string()
         XCTAssertEqual(expectedWelcomeMessage, retrievedWelcomeMessage)
-        
+
         let newFirstName = "Max 😉"
         let newFirstNameDN = newFirstName.dotNETString()
-        
+
         let expectedNewFullName = "\(newFirstName) \(lastName)"
-        
+
         try person.firstName_set(newFirstNameDN)
-        
+
         let newFullName = try person.fullName.string()
         XCTAssertEqual(expectedNewFullName, newFullName)
-        
+
         let numberOfChildren = try person.numberOfChildren
         XCTAssertEqual(0, numberOfChildren)
     }
-    
+
     func testPersonChildren() throws {
         let motherFirstNameDN = "Johanna".dotNETString()
         let sonFirstNameDN = "Max".dotNETString()
         let lastNameDN = "Doe".dotNETString()
-        
+
         let mother = try Beyond_NET_Sample_Person(motherFirstNameDN,
                                                   lastNameDN,
                                                   40)
-        
+
         let son = try Beyond_NET_Sample_Person(sonFirstNameDN,
                                                lastNameDN,
                                                4)
-        
+
         try mother.addChild(son)
-        
+
         let numberOfChildren = try mother.numberOfChildren
-        
+
         XCTAssertEqual(1, numberOfChildren)
-        
+
         guard let firstChild = try? mother.childAt(0) else {
             XCTFail("Person.ChildAt should not throw and return an instance")
-            
+
             return
         }
-        
+
         let firstChildEqualsSon = firstChild === son
         XCTAssertTrue(firstChildEqualsSon)
-        
+
         try mother.removeChild(son)
-        
+
         do {
             try mother.removeChildAt(0)
-            
+
             XCTFail("Person.RemoveChild should throw because the sole child has been removed previously")
         } catch {
             let errorMessage = error.localizedDescription
-            
+
             XCTAssertTrue(errorMessage.contains("Index was out of range"))
         }
     }
-    
+
     func testPersonChildrenArray() throws {
         let motherFirstNameDN = "Johanna".dotNETString()
         let sonFirstNameDN = "Max".dotNETString()
         let lastNameDN = "Doe".dotNETString()
-        
+
         let mother = try Beyond_NET_Sample_Person(motherFirstNameDN,
                                                   lastNameDN,
                                                   40)
-        
+
         let son = try Beyond_NET_Sample_Person(sonFirstNameDN,
                                                lastNameDN,
                                                4)
-        
+
         try mother.addChild(son)
-        
+
         let numberOfChildren = try mother.numberOfChildren
-        
+
         XCTAssertEqual(1, numberOfChildren)
-        
+
         let children = try mother.children
-        
+
         let childrenLength = try children.length
-        
+
         XCTAssertEqual(numberOfChildren, childrenLength)
-        
+
         guard let firstChild = try? children.getValue(0 as Int32) else {
             XCTFail("System.Array.GetValue should not throw and return an instance")
-            
+
             return
         }
-        
+
         let firstChildEqualsSon = firstChild === son
         XCTAssertTrue(firstChildEqualsSon)
     }
-    
+
     func testPersonExtensionMethods() throws {
         let initialAge: Int32 = 0
-        
+
         let firstNameDN = "Johanna".dotNETString()
         let lastNameDN = "Doe".dotNETString()
-        
+
         let baby = try Beyond_NET_Sample_Person(firstNameDN,
                                                 lastNameDN,
                                                 0)
-        
+
         let increaseAgeByYears: Int32 = 4
-        
+
         try baby.increaseAge(increaseAgeByYears)
-        
+
         let expectedAge = initialAge + increaseAgeByYears
-        
+
         let age = try baby.age
-        
+
         XCTAssertEqual(expectedAge, age)
-		
+
 		var nilAddressRet: Beyond_NET_Sample_Address?
 		let nilAddressSuccess = try baby.tryGetAddress(&nilAddressRet)
-		
+
 		XCTAssertFalse(nilAddressSuccess)
 		XCTAssertNil(nilAddressRet)
-		
+
 		let address = try Beyond_NET_Sample_Address("Street Name".dotNETString(),
                                                     "City Name".dotNETString())
-		
+
 		try baby.address_set(address)
-		
+
 		var addressRet: Beyond_NET_Sample_Address?
 		let addressSuccess = try baby.tryGetAddress(&addressRet)
-		
+
 		XCTAssertTrue(addressSuccess)
 		XCTAssertNotNil(addressRet)
     }
-    
+
     func testPersonChangeAge() throws {
         let initialAge: Int32 = 0
 
@@ -208,41 +208,41 @@ final class PersonTests: XCTestCase {
 		let age = try person.age
         XCTAssertEqual(10, age)
     }
-    
+
     func testPersonAddress() throws {
         let firstNameDN = "Johanna".dotNETString()
         let lastNameDN = "Doe".dotNETString()
-        
+
         let person = try Beyond_NET_Sample_Person(firstNameDN,
                                                   lastNameDN,
                                                   15)
-        
+
         let street = "Stephansplatz"
         let streetDN = street.dotNETString()
-        
+
         let city = "Vienna"
         let cityDN = city.dotNETString()
-        
+
         let address = try Beyond_NET_Sample_Address(streetDN,
                                                     cityDN)
-        
+
         try person.address_set(address)
-        
+
         guard let retrievedAddress = try? person.address else {
             XCTFail("Person.Address getter should return an instance and not throw")
-            
+
             return
         }
-        
+
         let retrievedStreet = try retrievedAddress.street.string()
-        
+
         XCTAssertEqual(street, retrievedStreet)
-        
+
         let retrievedCity = try retrievedAddress.city.string()
-        
+
         XCTAssertEqual(city, retrievedCity)
     }
-    
+
     func testPersonEvents() throws {
         var numberOfTimesNumberOfChildrenChangedWasCalled: Int32 = 0
 
@@ -250,7 +250,7 @@ final class PersonTests: XCTestCase {
         let sonFirstNameDN = "Max".dotNETString()
         let daugtherFirstNameDN = "Marie".dotNETString()
         let lastNameDN = "Doe".dotNETString()
-		
+
         let mother = try Beyond_NET_Sample_Person(motherFirstNameDN,
                                                   lastNameDN,
                                                   40)
@@ -258,19 +258,19 @@ final class PersonTests: XCTestCase {
 		let numberOfChildrenChangedDelegate = Beyond_NET_Sample_Person_NumberOfChildrenChangedDelegate({
 			numberOfTimesNumberOfChildrenChangedWasCalled += 1
 		})
-		
+
 		mother.numberOfChildrenChanged_add(numberOfChildrenChangedDelegate)
 
         let son = try Beyond_NET_Sample_Person(sonFirstNameDN,
                                                lastNameDN,
                                                4)
-		
+
 		try mother.addChild(son)
-		
+
         let daugther = try Beyond_NET_Sample_Person(daugtherFirstNameDN,
                                                     lastNameDN,
                                                     10)
-		
+
 		try mother.addChild(daugther)
 
 		let numberOfChildren = try mother.numberOfChildren
@@ -283,9 +283,9 @@ final class PersonTests: XCTestCase {
 		try mother.removeChild(daugther)
 
         XCTAssertEqual(3, numberOfTimesNumberOfChildrenChangedWasCalled)
-		
+
 		mother.numberOfChildrenChanged_remove(numberOfChildrenChangedDelegate)
-		
+
 		try mother.removeChildAt(0)
         XCTAssertEqual(3, numberOfTimesNumberOfChildrenChangedWasCalled)
 
@@ -293,45 +293,45 @@ final class PersonTests: XCTestCase {
         let expectedNumberOfChildrenAfterRemoval: Int32 = 0
         XCTAssertEqual(expectedNumberOfChildrenAfterRemoval, numberOfChildrenAfterRemoval)
     }
-    
+
     func testPersonChildrenArrayChange() throws {
         let motherFirstNameDN = "Johanna".dotNETString()
         let sonFirstNameDN = "Max".dotNETString()
         let daugtherFirstNameDN = "Marie".dotNETString()
         let lastNameDN = "Doe".dotNETString()
-        
+
         let mother = try Beyond_NET_Sample_Person(motherFirstNameDN,
                                                   lastNameDN,
                                                   40)
-        
+
         let son = try Beyond_NET_Sample_Person(sonFirstNameDN,
                                                lastNameDN,
                                                4)
-        
+
         try mother.addChild(son)
-        
+
         let originalChildren = try mother.children
-        
+
         let numberOfChildrenBeforeDaugther = try originalChildren.length
-        
+
         XCTAssertEqual(1, numberOfChildrenBeforeDaugther)
-        
+
         let newChildren = try DNArray<Beyond_NET_Sample_Person>(length: 2)
-        
+
         try System_Array.copy(originalChildren,
                               newChildren,
                               1 as Int32)
-        
+
         let daugther = try Beyond_NET_Sample_Person(daugtherFirstNameDN,
                                                     lastNameDN,
                                                     10)
-        
+
         try newChildren.setValue(daugther, 1 as Int32)
-        
+
         try mother.children_set(newChildren)
-        
+
         let numberOfChildrenAfterDaugther = try mother.numberOfChildren
-        
+
         XCTAssertEqual(2, numberOfChildrenAfterDaugther)
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/SpanTestTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/SpanTestTests.swift
@@ -5,96 +5,96 @@ final class SpanTestTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testReadOnlySpan() throws {
         let helloString = "Hello"
         let goodbyeString = "Goodbye"
         let hugoString = "Hugo"
-        
+
         guard let helloData = helloString.data(using: .utf8) else {
             XCTFail("Failed to get data of string")
-            
+
             return
         }
-        
+
         guard let goodbyeData = goodbyeString.data(using: .utf8) else {
             XCTFail("Failed to get data of string")
-            
+
             return
         }
-        
+
         guard let hugoData = hugoString.data(using: .utf8) else {
             XCTFail("Failed to get data of string")
-            
+
             return
         }
-        
+
         let test = try Beyond.NET.Sample.SpanTest(helloData)
-        
+
         verifySpanTest(test, matchesData: helloData)
-        
+
         XCTAssertNoThrow(try test.setDataAsReadOnlySpan(goodbyeData))
         verifySpanTest(test, matchesData: goodbyeData)
-        
+
         XCTAssertNoThrow(try test.dataAsReadOnlySpan_set(hugoData))
         verifySpanTest(test, matchesData: hugoData)
-        
+
         let hugoByteArray = try test.data
-        
+
         guard let hugoConvertedData = try test.convertByteArrayToSpan(hugoByteArray, .init({ bytes in
             try? bytes.data()
         })) else {
             XCTFail("SpanTest.ConvertByteArrayToSpan should not throw and return an instance")
-            
+
             return
         }
-        
+
         verifySpanTest(test, matchesData: hugoConvertedData)
-        
+
         guard let hugoConvertedByteArray = try? test.convertSpanToByteArray(hugoConvertedData, .init({ span in
             try? span?.dotNETByteArray().nullable()
         })) else {
             XCTFail("SpanTest.ConvertSpanToByteArray should not throw and return an instance")
-            
+
             return
         }
-        
+
         let hugoConvertedByteArrayBackToData = try hugoConvertedByteArray.data()
-        
+
         verifySpanTest(test, matchesData: hugoConvertedByteArrayBackToData)
         XCTAssertTrue(hugoByteArray.elementsEqual(hugoConvertedByteArray))
     }
-    
+
     func verifySpanTest(_ test: Beyond.NET.Sample.SpanTest,
                         matchesData expectedData: Data) {
         guard let dataAsReadOnlySpan = try? test.dataAsReadOnlySpan else {
             XCTFail("SpanTest.DataAsReadOnlySpan should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(dataAsReadOnlySpan, expectedData)
-        
+
         guard let getDataAsReadOnlySpan = try? test.getDataAsReadOnlySpan() else {
             XCTFail("SpanTest.GetDataAsReadOnlySpan should not throw and return an instance")
-            
+
             return
         }
-        
+
         XCTAssertEqual(getDataAsReadOnlySpan, expectedData)
-        
+
         var tryGetDataAsReadOnlySpan: Data?
-        
+
         guard (try? test.tryGetDataAsReadOnlySpan(&tryGetDataAsReadOnlySpan)) ?? false else {
             XCTFail("SpanTest.TryGetDataAsReadOnlySpan should not throw and return an instance as an out parameter")
-            
+
             return
         }
-        
+
         XCTAssertEqual(tryGetDataAsReadOnlySpan, expectedData)
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/StructTestTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/StructTestTests.swift
@@ -5,178 +5,178 @@ final class StructTestTests: XCTestCase {
 	override class func setUp() {
 		Self.sharedSetUp()
 	}
-	
+
 	override class func tearDown() {
 		Self.sharedTearDown()
 	}
-	
+
 	func testStructTest() throws {
 		let nameOrig = "Joe"
 		let nameNew = "John"
-		
+
 		let structTest = try Beyond_NET_Sample_StructTest(nameOrig.dotNETString())
-		
+
 		guard let nameOrigRet = try structTest.name?.string() else {
 			XCTFail("StructTest.Name getter should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertEqual(nameOrig, nameOrigRet)
-		
+
 		try structTest.name_set(nameNew.dotNETString())
-		
+
 		guard let nameNewRet = try structTest.name?.string() else {
 			XCTFail("StructTest.Name getter should not throw and return an instance")
-			
+
 			return
 		}
-		
+
 		XCTAssertEqual(nameNew, nameNewRet)
 	}
-    
+
     func testNullableValueTypes() throws {
         let nullRetVal = try Beyond_NET_Sample_StructTest.nullInstanceProperty
         XCTAssertNil(nullRetVal)
-        
+
         let structRetVal = try Beyond_NET_Sample_StructTest.nonNullInstanceProperty
         XCTAssertEqual(try structRetVal?.name?.string(), "Test")
-        
+
         let newName = "NotTest"
         try structRetVal?.name_set(newName.dotNETString())
         XCTAssertEqual(try structRetVal?.name?.string(), newName)
-        
+
         let nullRetVal2 = try Beyond_NET_Sample_StructTest.getNullableStructReturnValue(true)
         XCTAssertNil(nullRetVal2)
-        
+
         let structRetVal2 = try Beyond_NET_Sample_StructTest.getNullableStructReturnValue(false)
         XCTAssertEqual(try structRetVal2?.name?.string(), "Test")
-        
+
         let newName2 = "NotTest"
         try structRetVal2?.name_set(newName2.dotNETString())
         XCTAssertEqual(try structRetVal2?.name?.string(), newName2)
-        
+
         var nullOutRetVal: Beyond_NET_Sample_StructTest?
-        
+
         try Beyond_NET_Sample_StructTest.getNullableStructReturnValueInOutParameter(true,
                                                                                     &nullOutRetVal)
-        
+
         XCTAssertNil(nullOutRetVal)
-        
-        
-        
+
+
+
         var structRetVal3: Beyond_NET_Sample_StructTest?
-        
+
         try Beyond_NET_Sample_StructTest.getNullableStructReturnValueInOutParameter(false,
                                                                                     &structRetVal3)
-        
+
         guard let structRetVal3 else {
             XCTFail("StructTest.GetNullableStructReturnValueInOutParameter should not be nil")
-            
+
             return
         }
-        
+
         XCTAssertEqual(try structRetVal3.name?.string(), "Test")
-        
+
         let newName3 = "NotTest"
         try structRetVal3.name_set(newName3.dotNETString())
         XCTAssertEqual(try? structRetVal3.name?.string(), newName3)
-        
-        
+
+
         var nullRef: Beyond_NET_Sample_StructTest?
-        
+
         let ret = try Beyond_NET_Sample_StructTest.getNullableStructReturnValueOfRefParameter(&nullRef)
-        
+
         XCTAssertNil(ret)
         XCTAssertTrue(nullRef == ret)
-        
-        
+
+
         let retNonRef = try Beyond_NET_Sample_StructTest.getNullableStructReturnValueOfParameter(nullRef)
-        
+
         XCTAssertNil(retNonRef)
         XCTAssertTrue(nullRef == retNonRef)
-        
-        
+
+
         let origName = "test"
         var structRef: Beyond_NET_Sample_StructTest? = try Beyond_NET_Sample_StructTest(origName.dotNETString())
-        
+
         let ret2 = try Beyond_NET_Sample_StructTest.getNullableStructReturnValueOfRefParameter(&structRef)
-        
+
         guard let ret2 else {
             XCTFail("StructTest.GetNullableStructReturnValueOfRefParameter should not be nil")
-            
+
             return
         }
-        
+
         XCTAssertTrue(structRef == ret2)
         XCTAssertEqual(try ret2.name?.string(), origName)
-        
-        
+
+
         let retNonRef2 = try Beyond_NET_Sample_StructTest.getNullableStructReturnValueOfParameter(structRef)
-        
+
         guard let retNonRef2 else {
             XCTFail("StructTest.GetNullableStructReturnValueOfParameter should not be nil")
-            
+
             return
         }
-        
+
         XCTAssertTrue(structRef == retNonRef2)
         XCTAssertEqual(try ret2.name?.string(), origName)
-        
-        
+
+
         let newName4 = "NotTest"
         try ret2.name_set(newName4.dotNETString())
         XCTAssertEqual(try ret2.name?.string(), newName4)
     }
-    
+
     func testNullableValueTypes_readOnlyNullInstanceField() throws {
         let testClass = try Beyond_NET_Sample_StructTestClass()
         let value = testClass.readOnlyNullInstanceField
-        
+
         XCTAssertNil(value)
     }
-    
+
     func testNullableValueTypes_nonNullInstanceField() throws {
         let origName = "Test"
         let newName = "New Test"
-        
+
         let testClass = try Beyond_NET_Sample_StructTestClass()
         let origValue = testClass.nonNullInstanceField
-        
+
         XCTAssertNotNil(origValue)
         XCTAssertEqual(try origValue?.name?.string(), origName)
-        
+
         let newValue = try Beyond_NET_Sample_StructTest(newName.dotNETString())
         testClass.nonNullInstanceField_set(newValue)
-    
+
         let newValueRet = testClass.nonNullInstanceField
-        
+
         XCTAssertNotNil(newValueRet)
         XCTAssertEqual(try newValueRet?.name?.string(), newName)
-        
+
         testClass.nonNullInstanceField_set(nil)
-        
+
         let nilValueRet = testClass.nonNullInstanceField
-        
+
         XCTAssertNil(nilValueRet)
     }
-    
+
     func testNullableValueTypes_nullableStructPropertyWithGetterAndSetter() throws {
         let testClass = try Beyond_NET_Sample_StructTestClass()
-        
+
         let origValue = try testClass.nullableStructPropertyWithGetterAndSetter
         XCTAssertNil(origValue)
-        
+
         let newName = "Test"
         let newValue = try Beyond_NET_Sample_StructTest(newName.dotNETString())
-        
+
         try testClass.nullableStructPropertyWithGetterAndSetter_set(newValue)
-        
+
         let newValueRet = try testClass.nullableStructPropertyWithGetterAndSetter
         XCTAssertEqual(newValueRet, newValue)
         XCTAssertNotNil(newValueRet)
         XCTAssertEqual(try newValueRet?.name?.string(), newName)
-        
+
         try testClass.nullableStructPropertyWithGetterAndSetter_set(nil)
         let nilValueRet = try testClass.nullableStructPropertyWithGetterAndSetter
         XCTAssertNil(nilValueRet)

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/TestClassesTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/TestClassesTests.swift
@@ -5,116 +5,116 @@ final class TestClassesTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testTestClass() throws {
         let testClass = try Beyond_NET_Sample_TestClass()
         let testClassType = try testClass.getType()
-        
+
         let systemObjectTypeName = "System.Object"
         let systemObjectTypeNameDN = systemObjectTypeName.dotNETString()
-        
+
         guard let systemObjectType = try System_Type.getType(systemObjectTypeNameDN,
                                                               true,
                                                               false) else {
             XCTFail("System.Type.GetType should not throw and return an instance")
-            
+
             return
         }
-        
+
         let retrievedSystemObjectTypeName = try systemObjectType.toString().string()
         XCTAssertEqual(systemObjectTypeName, retrievedSystemObjectTypeName)
-        
+
         let isTestClassAssignableToSystemObject = try testClassType.isAssignableTo(systemObjectType)
         XCTAssertTrue(isTestClassAssignableToSystemObject)
-        
+
         let isSystemObjectAssignableToTestClass = try systemObjectType.isAssignableTo(testClassType)
         XCTAssertFalse(isSystemObjectAssignableToTestClass)
-        
+
         try testClass.sayHello()
-        
+
         let john = "John"
         let johnDN = john.dotNETString()
-        
+
         try testClass.sayHello(johnDN)
-        
+
         let hello = try testClass.getHello().string()
         XCTAssertEqual("Hello", hello)
-        
+
         let number1: Int32 = 85
         let number2: Int32 = 262
-        
+
         let expectedResult = number1 + number2
-        
+
         let result = try testClass.add(number1, number2)
         XCTAssertEqual(expectedResult, result)
     }
-    
+
     func testEnum() throws {
         let enumValue = Beyond_NET_Sample_TestEnum.secondCase
-        
+
         let enumName = try Beyond_NET_Sample_TestClass.getTestEnumName(enumValue).string()
         XCTAssertEqual("SecondCase", enumName)
     }
-    
+
     func testInt32ByRef() throws {
         let testClass = try Beyond_NET_Sample_TestClass()
-        
+
         let originalValue: Int32 = 5
         var valueToModify: Int32 = originalValue
         let targetValue: Int32 = 10
-        
+
         let originalValueRet = try testClass.modifyByRefValueAndReturnOriginalValue(&valueToModify,
                                                                                     targetValue)
-        
+
         XCTAssertEqual(originalValue, originalValueRet)
         XCTAssertEqual(targetValue, valueToModify)
     }
-    
+
     func testEnumByRef() throws {
         let testClass = try Beyond_NET_Sample_TestClass()
-        
+
         let originalValue = Beyond_NET_Sample_TestEnum.firstCase
         var valueToModify = originalValue
         let expectedValue = Beyond_NET_Sample_TestEnum.secondCase
-        
+
         try testClass.modifyByRefEnum(&valueToModify)
         XCTAssertEqual(expectedValue, valueToModify)
     }
-	
+
 	func testDelegateReturningChar() throws {
 		let testClass = try Beyond_NET_Sample_TestClass()
-		
+
 		let value = DNChar(cValue: 5)
-		
+
 		let charReturnerDelegate = Beyond_NET_Sample_CharReturnerDelegate {
 			value
 		}
-		
+
 		let retVal = try testClass.getChar(charReturnerDelegate)
 		XCTAssertEqual(value, retVal)
 	}
-    
+
     func testBookByRef() throws {
         let testClass = try Beyond_NET_Sample_TestClass()
-        
+
         let originalBook = Beyond_NET_Sample_Book.donQuixote
         let targetBook = Beyond_NET_Sample_Book.theLordOfTheRings
-        
+
         var bookToModify = originalBook
         var originalBookRet = Beyond_NET_Sample_Book.outParameterPlaceholder
-        
+
         try testClass.modifyByRefBookAndReturnOriginalBookAsOutParameter(&bookToModify,
                                                                          targetBook,
                                                                          &originalBookRet)
-        
+
         XCTAssertTrue(originalBook == originalBookRet)
         XCTAssertTrue(targetBook == bookToModify)
     }
-    
+
     // TODO: By Ref return values are not supported in Swift yet
 //    func testGetCurrentBookByRef() {
 //        guard let testClass = try? Beyond_NET_Sample_TestClass() else {
@@ -150,7 +150,7 @@ final class TestClassesTests: XCTestCase {
 //        XCTAssertNil(exception)
 //        XCTAssertTrue(currentBookIsEqualToInitialBook)
 //    }
-    
+
     // TODO: By Ref return values are not supported in Swift yet
 //    func testIncreaseAndGetCurrentIntValueByRef() {
 //        var exception: System_Exception_t?

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/TestRecordTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/TestRecordTests.swift
@@ -5,34 +5,34 @@ final class TestRecordTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     func testRecords() throws {
         let expectedString = "Hello 👍"
-        
+
         let aRecord = try Beyond.NET.Sample.TestRecord(expectedString.dotNETString())
-        
+
         let retString = try aRecord.aString.string()
         XCTAssertEqual(expectedString, retString)
-        
+
         var deconstructedStringDN = System.String.outParameterPlaceholder
-        
+
         try aRecord.deconstruct(&deconstructedStringDN)
-        
+
         let deconstructedString = deconstructedStringDN.string()
-        
+
         XCTAssertEqual(expectedString, deconstructedString)
     }
-    
+
     func testReadOnlyRecordStruct() throws {
         let expectedInt: Int32 = .max
-        
+
         let aRecord = try Beyond.NET.Sample.TestReadOnlyRecordStruct(expectedInt)
         let retInt = try aRecord.anInt
-        
+
         XCTAssertEqual(expectedInt, retInt)
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/TransformerTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestClasses/TransformerTests.swift
@@ -5,15 +5,15 @@ final class TransformerTests: XCTestCase {
     override class func setUp() {
         Self.sharedSetUp()
     }
-    
+
     override class func tearDown() {
         Self.sharedTearDown()
     }
-    
+
     /* func testStringTransformerAsInDocs() {
         // Create an input string and convert it to a .NET System.String
         let inputString = "Hello World".dotNETString()
-        
+
         // Call Beyond.NET.Sample.Transformer.transformString by:
         // - Providing the input string as the first argument
         // - Initializing an instance of Beyond_NET_Sample_Transformer_StringTransformerDelegate by passing it a closure that matches the .NET delegate as its sole parameter
@@ -21,83 +21,83 @@ final class TransformerTests: XCTestCase {
             // Take the string that should be transformed, call System.String.ToUpper on it and return it
             return try! stringToTransform!.toUpper()
         }))!.string() // Convert the returned System.String to a Swift String
-        
+
         // Prints "HELLO WORLD!"
         print(outputString)
     } */
-    
+
     func testStringTransformer() throws {
         guard let uppercaser = createUppercaser() else {
             XCTFail("Failed to create uppercaser")
-            
+
             return
         }
-        
+
         let inputString = "Hello"
         let inputStringDN = inputString.dotNETString()
-        
+
         let expectedOutputString = inputString.uppercased()
-        
+
         let outputString = try Beyond_NET_Sample_Transformer.transformString(inputStringDN,
                                                                              uppercaser).string()
-        
+
         XCTAssertEqual(expectedOutputString, outputString)
     }
-    
+
     func testStringGetterAndTransformer() throws {
         guard let fixedStringProvider = createFixedStringProvider() else {
             XCTFail("Failed to create random string provider")
-            
+
             return
         }
-        
+
         guard let uppercaser = createUppercaser() else {
             XCTFail("Failed to create uppercaser")
-            
+
             return
         }
-        
+
         let outputString = try Beyond_NET_Sample_Transformer.getAndTransformString(fixedStringProvider,
                                                                                    uppercaser).string()
-        
+
         XCTAssertEqual("FIXED STRING", outputString)
     }
-    
+
     func testDoublesTransformer() throws {
         let multiplier: Beyond_NET_Sample_Transformer_DoublesTransformerDelegate.ClosureType = { number1, number2 in
             let result = number1 * number2
-            
+
             return result
         }
-        
+
         let doublesTransformerDelegate = Beyond_NET_Sample_Transformer_DoublesTransformerDelegate(multiplier)
-        
+
         let inputNumber1: Double = 2.5
         let inputNumber2: Double = 3.5
-        
+
         let expectedResult = inputNumber1 * inputNumber2
-        
+
         let result = try Beyond_NET_Sample_Transformer.transformDoubles(inputNumber1,
                                                                         inputNumber2,
                                                                         doublesTransformerDelegate)
-        
+
         XCTAssertEqual(expectedResult, result)
     }
-    
+
     func testUppercaserThatActuallyLowercases() throws {
         guard let lowercaser = createLowercaser() else {
             XCTFail("Failed to create lowercaser")
-            
+
             return
         }
-        
+
         try Beyond_NET_Sample_Transformer_BuiltInTransformers.uppercaseStringTransformer_set(lowercaser)
-        
+
         let inputString = "Hello"
         let inputStringDN = inputString.dotNETString()
-        
+
         let expectedOutputString = inputString.lowercased()
-        
+
         let outputString = try Beyond_NET_Sample_Transformer.uppercaseString(inputStringDN).string()
         XCTAssertEqual(expectedOutputString, outputString)
     }
@@ -108,42 +108,42 @@ private extension TransformerTests {
         let fixedStringProvider: Beyond_NET_Sample_Transformer_StringGetterDelegate.ClosureType = {
             let outputString = "Fixed String"
             let outputStringDN = outputString.dotNETString()
-            
+
             return outputStringDN
         }
-        
+
         let stringGetterDelegate = Beyond_NET_Sample_Transformer_StringGetterDelegate(fixedStringProvider)
-        
+
         return stringGetterDelegate
     }
-    
+
     func createUppercaser() -> Beyond_NET_Sample_Transformer_StringTransformerDelegate? {
         let caser: Beyond_NET_Sample_Transformer_StringTransformerDelegate.ClosureType = { inputStringDN in
             let inputString = inputStringDN.string()
-            
+
             let outputString = inputString.uppercased()
             let outputStringDN = outputString.dotNETString()
-            
+
             return outputStringDN
         }
-        
+
         let stringTransformerDelegate = Beyond_NET_Sample_Transformer_StringTransformerDelegate(caser)
-        
+
         return stringTransformerDelegate
     }
-    
+
     func createLowercaser() -> Beyond_NET_Sample_Transformer_StringTransformerDelegate? {
         let caser: Beyond_NET_Sample_Transformer_StringTransformerDelegate.ClosureType = { inputStringDN in
             let inputString = inputStringDN.string()
-            
+
             let outputString = inputString.lowercased()
             let outputStringDN = outputString.dotNETString()
-            
+
             return outputStringDN
         }
-        
+
         let stringTransformerDelegate = Beyond_NET_Sample_Transformer_StringTransformerDelegate(caser)
-        
+
         return stringTransformerDelegate
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestSupport/Data+Extensions.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestSupport/Data+Extensions.swift
@@ -9,16 +9,16 @@ extension Data {
         let status = SecRandomCopyBytes(kSecRandomDefault,
                                         count,
                                         &bytes)
-        
+
         // A status of errSecSuccess indicates success
         guard status == errSecSuccess else {
             return nil
         }
-        
+
         // Convert bytes to Data
-        let data = Data(bytes: bytes, 
+        let data = Data(bytes: bytes,
                         count: count)
-        
+
         return data
     }
 }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/TestSupport/XCTestCase+Extensions.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/TestSupport/XCTestCase+Extensions.swift
@@ -10,10 +10,10 @@ extension XCTestCase {
 		if UnhandledExceptionHandlerStorage.unhandledExceptionHandler == nil {
 			UnhandledExceptionHandlerStorage.unhandledExceptionHandler = addUnhandledExceptionHandler()
 		}
-		
+
 		gcCollect()
 	}
-	
+
 	class func sharedTearDown() {
 		gcCollect()
 	}
@@ -23,44 +23,44 @@ private extension XCTestCase {
 	class func gcCollect() {
         XCTAssertNoThrow(try System.GC.collect())
 	}
-	
+
 	class func addUnhandledExceptionHandler() -> System.UnhandledExceptionEventHandler? {
         guard let appDomain = try? System.AppDomain.currentDomain else {
 			XCTFail("System.AppDomain.CurrentDomain getter should not throw and return an instance")
-			
+
 			return nil
 		}
-        
+
         let handler: System.UnhandledExceptionEventHandler? = .init { sender, e in
             let exceptionAsString: String?
-            
+
             if let exceptionObject = try? e.exceptionObject {
                 exceptionAsString = try? exceptionObject.toString()?.string()
             } else {
                 exceptionAsString = nil
             }
-            
+
             XCTFail("An unhandled exception was thrown:\n\(exceptionAsString ?? "N/A")")
         }
-        
+
         guard let handler else {
             XCTFail("System.UnhandledExceptionEventHandler ctor should not throw and return an instance")
-            
+
             return nil
         }
-        
+
         appDomain.unhandledException_add(handler)
-		
+
 		return handler
 	}
-	
+
 	class func removeUnhandledExceptionHandler(_ handler: System.UnhandledExceptionEventHandler?) {
 		guard let handler else { return }
-        
+
         guard let appDomain = try? System.AppDomain.currentDomain else {
             return
         }
-        
+
         appDomain.unhandledException_remove(handler)
 	}
 }

--- a/Samples/Beyond.NET.Sample_BuildConfig.json
+++ b/Samples/Beyond.NET.Sample_BuildConfig.json
@@ -1,21 +1,21 @@
 {
 	"AssemblyPath": "Beyond.NET.Sample.Managed/bin/Release/publish/Beyond.NET.Sample.Managed.dll",
-	
+
 	"Build": {
 		"Target": "apple-universal",
 		"ProductName": "BeyondDotNETSampleKit",
 		"ProductBundleIdentifier": "com.royalapps.beyonddotnetsamplekit",
 		"ProductOutputPath": "Generated"
 	},
-	
+
 	"CSharpUnmanagedOutputPath": "Generated/Generated_CS.cs",
 	"COutputPath": "Generated/Generated_C.h",
 	"SwiftOutputPath": "Generated/Generated_Swift.swift",
 	"KotlinOutputPath": "Generated/Generated_Kotlin.kt",
-	
+
 	"KotlinPackageName": "com.example.beyondnetsampleandroid.dn",
 	"KotlinNativeLibraryName": "BeyondDotNETSampleNative",
-	
+
 	"EmitUnsupported": true,
 	"GenerateTypeCheckedDestroyMethods": false,
 	"EnableGenericsSupport": true,
@@ -45,7 +45,7 @@
 		"System.Security.SecureString",
 		"System.WeakReference",
 		"System.Buffers.Binary.BinaryPrimitives",
-		
+
 		"System.WeakReference`1",
 		"System.Runtime.CompilerServices.ConditionalWeakTable`2",
 		"System.Threading.Tasks.Task`1",

--- a/Samples/Beyond.NET.Sample_Config.json
+++ b/Samples/Beyond.NET.Sample_Config.json
@@ -1,6 +1,6 @@
 {
 	"AssemblyPath": "Beyond.NET.Sample.Managed/bin/Release/publish/Beyond.NET.Sample.Managed.dll",
-	
+
 	"CSharpUnmanagedOutputPath": "Generated/Generated_CS.cs",
 	"COutputPath": "Generated/Generated_C.h",
 	"SwiftOutputPath": "Generated/Generated_Swift.swift",
@@ -8,7 +8,7 @@
 
 	"KotlinPackageName": "com.example.beyondnetsampleandroid.dn",
 	"KotlinNativeLibraryName": "BeyondDotNETSampleNative",
-	
+
 	"EmitUnsupported": true,
 	"GenerateTypeCheckedDestroyMethods": false,
 	"EnableGenericsSupport": true,


### PR DESCRIPTION
Add `.editorconfig` file for consistent source code formatting. Relevant for .NET IDEs (e.g. Rider or VS), though unsure whether Swift/Kotlin will take this into account.

For C# source code at least, this helps apply consistent formatting:
- UTF-8 encoding for source code, *without* byte-order-marks (BOM)
- strip useless whitespace at the end of the line
- make preferred indent size explicit
- keep a line break before the end of the file

Also strip trailing (invisible and insignificant) whitespace, matching the `.editorconfig` settings. Hopefully future code updates will then avoid generating such large diffs.