### PR TITLE
Improve Kotlin enum case naming

### DIFF
--- a/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinTypeSyntaxWriter.cs
+++ b/Generator/Beyond.NET.CodeGenerator/Syntax/Kotlin/KotlinTypeSyntaxWriter.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
-
+using System.Text;
 using Beyond.NET.CodeGenerator.Extensions;
 using Beyond.NET.CodeGenerator.Generator;
 using Beyond.NET.CodeGenerator.Generator.Kotlin;
@@ -179,8 +179,7 @@ public partial class KotlinTypeSyntaxWriter: IKotlinSyntaxWriter, ITypeSyntaxWri
         List<KotlinEnumClassCase> enumCases = new();
 
         for (int i = 0; i < caseNames.Length; i++) {
-            string caseName = caseNames[i]
-                .ToUpper();
+            string caseName = ToKotlinEnumCaseName(caseNames[i]);
 
             var value = values.GetValue(i) ?? throw new Exception("No enum value for case");
             var valueType = value.GetType();
@@ -261,6 +260,29 @@ public val value: {{underlyingTypeName}}
         var enumClassDefStr = enumClassDef.ToString();
 
         return enumClassDefStr;
+    }
+
+    private static string ToKotlinEnumCaseName(string csharpName) {
+        var sb = new StringBuilder(csharpName.Length + 4);
+
+        sb.Append(char.ToUpper(csharpName[0]));
+        bool lastLower = false;
+
+        for (var i = 1; i < csharpName.Length; i++) {
+            char c = csharpName[i];
+            bool isLower = char.IsLetter(c)
+                ? char.IsLower(c)
+                : true;
+
+            if (!isLower && lastLower) {
+                sb.Append('_');
+            }
+
+            sb.Append(char.ToUpper(c));
+            lastLower = isLower;
+        }
+
+        return sb.ToString();
     }
     #endregion Enum
 

--- a/Samples/Beyond.NET.Sample.Android/app/src/androidTest/java/com/example/beyondnetsampleandroid/SystemStringTests.kt
+++ b/Samples/Beyond.NET.Sample.Android/app/src/androidTest/java/com/example/beyondnetsampleandroid/SystemStringTests.kt
@@ -43,7 +43,7 @@ class SystemStringTests {
         assertEquals(expectedIndexOfWorld, indexOfWorld)
 
         val splitOptions = System_StringSplitOptions(
-            System_StringSplitOptions.REMOVEEMPTYENTRIES.value or System_StringSplitOptions.TRIMENTRIES.value
+            System_StringSplitOptions.REMOVE_EMPTY_ENTRIES.value or System_StringSplitOptions.TRIM_ENTRIES.value
         )
 
         val blankDN = " ".toDotNETString()

--- a/Samples/Beyond.NET.Sample.Android/app/src/androidTest/java/com/example/beyondnetsampleandroid/TestClassesTests.kt
+++ b/Samples/Beyond.NET.Sample.Android/app/src/androidTest/java/com/example/beyondnetsampleandroid/TestClassesTests.kt
@@ -51,7 +51,7 @@ class TestClassesTests {
     // NOTE: This was transpiled from Swift
     @Test
     fun testEnum() {
-        val enumValue = Beyond_NET_Sample_TestEnum.SECONDCASE
+        val enumValue = Beyond_NET_Sample_TestEnum.SECOND_CASE
         val enumName = Beyond_NET_Sample_TestClass.getTestEnumName(enumValue).toKString()
         assertEquals("SecondCase", enumName)
     }

--- a/Samples/Beyond.NET.Sample.Android/app/src/main/java/com/example/beyondnetsampleandroid/MainActivity.kt
+++ b/Samples/Beyond.NET.Sample.Android/app/src/main/java/com/example/beyondnetsampleandroid/MainActivity.kt
@@ -86,11 +86,11 @@ class MainActivity : ComponentActivity() {
 
         val johnDoeName = johnDoe.fullName.toKString()
         val johnDoeAge = johnDoe.age
-        johnDoe.niceLevel_set(Beyond_NET_Sample_NiceLevels.LITTLEBITNICE)
+        johnDoe.niceLevel_set(Beyond_NET_Sample_NiceLevels.LITTLE_BIT_NICE)
         val johnDoeNiceLevel = johnDoe.niceLevel
         val welcomeMessage = johnDoe.getWelcomeMessage().toKString()
 
-        require(johnDoeNiceLevel == Beyond_NET_Sample_NiceLevels.LITTLEBITNICE)
+        require(johnDoeNiceLevel == Beyond_NET_Sample_NiceLevels.LITTLE_BIT_NICE)
 
         setContent {
             BeyondNETSampleAndroidTheme {


### PR DESCRIPTION
C# enum field names are currently transformed to all-uppercase for Kotlin; this works and is unambiguous but is not particularly readable or user-friendly for the specific case of compound names.

Instead, we could try detecting multi-word enum case names and inserting `_` to separate them. This is a heuristic and won't be perfect for some corner cases, but it does improve readability significantly.

A couple examples from the samples in this repo:

```diff
 public enum class Beyond_NET_Sample_NiceLevels(val rawValue: Int) {
-	NOTNICE(0),
-	LITTLEBITNICE(1),
+	NOT_NICE(0),
+	LITTLE_BIT_NICE(1),
 	NICE(2),
-	VERYNICE(3),
+	VERY_NICE(3),

 public enum class Beyond_NET_Sample_TestEnum(val rawValue: Int) {
-	FIRSTCASE(0),
-	SECONDCASE(1),
+	FIRST_CASE(0),
+	SECOND_CASE(1),
```

And from the C# class libraries:

```diff
 public enum class System_Globalization_DateTimeStyles(val rawValue: Int) {
 	NONE(0),
-	ALLOWLEADINGWHITE(1),
-	ALLOWTRAILINGWHITE(2),
-	ALLOWINNERWHITE(4),
-	ALLOWWHITESPACES(7),
-	NOCURRENTDATEDEFAULT(8),
-	ADJUSTTOUNIVERSAL(16),
-	ASSUMELOCAL(32),
-	ASSUMEUNIVERSAL(64),
-	ROUNDTRIPKIND(128),
+	ALLOW_LEADING_WHITE(1),
+	ALLOW_TRAILING_WHITE(2),
+	ALLOW_INNER_WHITE(4),
+	ALLOW_WHITE_SPACES(7),
+	NO_CURRENT_DATE_DEFAULT(8),
+	ADJUST_TO_UNIVERSAL(16),
+	ASSUME_LOCAL(32),
+	ASSUME_UNIVERSAL(64),
+	ROUNDTRIP_KIND(128),

 public enum class System_Globalization_CultureTypes(val rawValue: Int) {
-	NEUTRALCULTURES(1),
-	SPECIFICCULTURES(2),
-	INSTALLEDWIN32CULTURES(4),
-	ALLCULTURES(7),
-	USERCUSTOMCULTURE(8),
-	REPLACEMENTCULTURES(16),
-	WINDOWSONLYCULTURES(32),
-	FRAMEWORKCULTURES(64),
+	NEUTRAL_CULTURES(1),
+	SPECIFIC_CULTURES(2),
+	INSTALLED_WIN32_CULTURES(4),
+	ALL_CULTURES(7),
+	USER_CUSTOM_CULTURE(8),
+	REPLACEMENT_CULTURES(16),
+	WINDOWS_ONLY_CULTURES(32),
+	FRAMEWORK_CULTURES(64),

 public enum class System_UriComponents(val rawValue: Int) {
 	SCHEME(1),
-	USERINFO(2),
+	USER_INFO(2),
 	HOST(4),
 	PORT(8),
-	SCHEMEANDSERVER(13),
+	SCHEME_AND_SERVER(13),
 	PATH(16),
 	QUERY(32),
-	PATHANDQUERY(48),
-	HTTPREQUESTURL(61),
+	PATH_AND_QUERY(48),
+	HTTP_REQUEST_URL(61),
 	FRAGMENT(64),
-	ABSOLUTEURI(127),
-	STRONGPORT(128),
-	HOSTANDPORT(132),
-	STRONGAUTHORITY(134),
-	NORMALIZEDHOST(256),
-	KEEPDELIMITER(1073741824),
-	SERIALIZATIONINFOSTRING(-2147483648),
+	ABSOLUTE_URI(127),
+	STRONG_PORT(128),
+	HOST_AND_PORT(132),
+	STRONG_AUTHORITY(134),
+	NORMALIZED_HOST(256),
+	KEEP_DELIMITER(1073741824),
+	SERIALIZATION_INFO_STRING(-2147483648),
```

This might be a breaking change for anyone out there using generated Kotlin code, but for our use cases we can easily adapt to this.