### PR TITLE
Rename test method `Throw` to `TestThrow`

### DIFF
--- a/Samples/Beyond.NET.Sample.Managed/Source/ExceptionTests.cs
+++ b/Samples/Beyond.NET.Sample.Managed/Source/ExceptionTests.cs
@@ -2,7 +2,7 @@ namespace Beyond.NET.Sample;
 
 public class ExceptionTests
 {
-    public static void Throw(Exception ex)
+    public static void TestThrow(Exception ex)
     {
         throw ex;
     }

--- a/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemExceptionTests.swift
+++ b/Samples/Beyond.NET.Sample.Swift/Tests/System/SystemExceptionTests.swift
@@ -30,7 +30,7 @@ final class SystemExceptionTests: XCTestCase {
         let caughtErr: DNError?
         
         do {
-            try Beyond_NET_Sample_ExceptionTests.throw(ex)
+            try Beyond_NET_Sample_ExceptionTests.testThrow(ex)
             caughtErr = nil
         } catch let error as DNError {
             caughtErr = error


### PR DESCRIPTION
The Kotlin code generated for `Throw` ends up looking like this:

```kotlin
open class Beyond_NET_Sample_ExceptionTests /* Beyond.NET.Sample.ExceptionTests */(handle: Pointer): System_Object(handle) {
	companion object : IDNObjectCompanion<Beyond_NET_Sample_ExceptionTests> {
		public fun throw(ex: System_Exception /* System.Exception */) {
```

This doesn't compile, likely because `throw` happens to be a keyword in Kotlin:

```
[Generated_Kotlin.kt:128159:10] Function declaration must have a name.
[Generated_Kotlin.kt:128159:14] Syntax error: Expecting function name or receiver type.
```

Rename the C# method to avoid this issue.